### PR TITLE
Add listen command

### DIFF
--- a/go-ios.go
+++ b/go-ios.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"usbmuxd/usbmux"
 
-	docopt "github.com/docopt/docopt-go"
+	"github.com/docopt/docopt-go"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -13,6 +13,7 @@ func main() {
 	usage := `iOS client v 0.01
 
 Usage:
+  ios listen 
   ios list [--details]
   ios info [options]
   ios syslog [options]
@@ -33,23 +34,30 @@ Options:
   `
 	arguments, _ := docopt.ParseDoc(usage)
 
-	fmt.Println(arguments)
+	b, _ := arguments.Bool("listen")
+	if b {
+		startListening()
+		return
+	}
+
 	udid, _ := arguments.String("--udid")
 	device, err := getDeviceOrQuit(udid)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	b, _ := arguments.Bool("info")
+	b, _ = arguments.Bool("info")
 	if b {
 		printDeviceInfo(device)
 		return
 	}
+
 	b, _ = arguments.Bool("syslog")
 	if b {
 		runSyslog(device)
 		return
 	}
+
 	b, _ = arguments.Bool("screenshot")
 	if b {
 		path, _ := arguments.String("--output")
@@ -165,6 +173,24 @@ func getDeviceOrQuit(udid string) (usbmux.DeviceEntry, error) {
 		}
 	}
 	return usbmux.DeviceEntry{}, fmt.Errorf("Device '%s' not found. Is it attached to the machine?", udid)
+}
+
+func startListening() {
+	muxConnection := usbmux.NewUsbMuxConnection()
+	defer muxConnection.Close()
+	attachedReceiver, err := muxConnection.Listen()
+	if err != nil {
+		log.Fatal("Failed issuing Listen command", err)
+	}
+	for {
+		msg, err := attachedReceiver()
+		if err != nil {
+			log.Error("Stopped listening because of error")
+			return
+		}
+		log.Info(usbmux.ToPlist(msg))
+	}
+
 }
 
 func printDeviceInfo(device usbmux.DeviceEntry) {

--- a/usbmux/deviceconnection.go
+++ b/usbmux/deviceconnection.go
@@ -3,6 +3,7 @@ package usbmux
 import (
 	"io"
 	"net"
+	"os"
 	"reflect"
 
 	log "github.com/sirupsen/logrus"
@@ -81,13 +82,12 @@ func reader(conn *DeviceConnection) {
 			return
 		default:
 			if err != nil {
-				log.Errorf("Failed decoding/reading %s", err)
-				conn.Close()
-				return
+				log.Errorf("Failed decoding/reading %s, sending zero length data to codec", err)
+				//TODO: find more elegant way
+				os.Exit(1)
 			}
 		}
 	}
-
 }
 
 //SendForProtocolUpgrade takes care of the complicated protocol upgrade process of iOS/Usbmux.

--- a/usbmux/listen.go
+++ b/usbmux/listen.go
@@ -1,0 +1,68 @@
+package usbmux
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"howett.net/plist"
+)
+
+type ListenType struct {
+	MessageType         string
+	ProgName            string
+	ClientVersionString string
+	ConnType            int
+	kLibUSBMuxVersion   int
+}
+
+//Contains some info about when iOS devices are connected or disconnected from the host
+type AttachedMessage struct {
+	MessageType string
+	DeviceID    int
+	Properties  DeviceProperties
+}
+
+func attachedFromBytes(plistBytes []byte) (AttachedMessage, error) {
+	decoder := plist.NewDecoder(bytes.NewReader(plistBytes))
+	var obj AttachedMessage
+	err := decoder.Decode(&obj)
+	if err != nil {
+		return obj, err
+	}
+	return obj, nil
+}
+
+func (msg AttachedMessage) DeviceAttached() bool {
+	return "Attached" == msg.MessageType
+}
+
+func (msg AttachedMessage) DeviceDetached() bool {
+	return "Detached" == msg.MessageType
+}
+
+func NewListen() *ListenType {
+	data := &ListenType{
+		MessageType:         "Listen",
+		ProgName:            "go-usbmux",
+		ClientVersionString: "usbmuxd-471.8.1",
+		//dunno if conntype is needed
+		ConnType:          1,
+		kLibUSBMuxVersion: 3,
+	}
+	return data
+}
+
+//Listen will send a listen command to usbmuxd which will cause this connection to stay open indefinitely and receive
+// messages whenever devices are connected or disconnected
+func (muxConn *MuxConnection) Listen() (func() (AttachedMessage, error), error) {
+	msg := NewListen()
+	muxConn.Send(msg)
+	response := <-muxConn.ResponseChannel
+	if !MuxResponsefromBytes(response).IsSuccessFull() {
+		return nil, errors.New("Listen command to usbmuxd failed:" + hex.Dump(response))
+	}
+
+	return func() (AttachedMessage, error) {
+		return attachedFromBytes(<-muxConn.ResponseChannel)
+	}, nil
+}


### PR DESCRIPTION
Add Quick and Dirty support for the USBMux Listen command. 
When you use this command you will get a persistent connection that can be used to get notified about unplug or plug-in events for iOS devices. No need to use libusb or anything to discover new devices, usbmuxd does it for you :-D