### PR TITLE
Change the listen command to run indefinitely and retry should usbmuxd be killed

### DIFF
--- a/ios/connect.go
+++ b/ios/connect.go
@@ -82,9 +82,15 @@ func ConnectToService(device DeviceEntry, serviceName string) (DeviceConnectionI
 	if err != nil {
 		return nil, err
 	}
-	pairRecord := ReadPairRecord(device.Properties.SerialNumber)
+	pairRecord, err := ReadPairRecord(device.Properties.SerialNumber)
+	if err != nil {
+		return nil, err
+	}
 
-	muxConn := NewUsbMuxConnection(NewDeviceConnection(DefaultUsbmuxdSocket))
+	muxConn, err := NewUsbMuxConnectionSimple()
+	if err != nil {
+		return nil, fmt.Errorf("Could not connect to usbmuxd socket, is it running? %w", err)
+	}
 	err = muxConn.connectWithStartServiceResponse(device.DeviceID, startServiceResponse, pairRecord)
 	if err != nil {
 		return nil, err
@@ -117,7 +123,10 @@ func (muxConn *UsbMuxConnection) connectWithStartServiceResponse(deviceID int, s
 }
 
 func ConnectLockdownWithSession(device DeviceEntry) *LockDownConnection {
-	muxConnection := NewUsbMuxConnection(NewDeviceConnection(DefaultUsbmuxdSocket))
+	muxConnection, err := NewUsbMuxConnectionSimple()
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer muxConnection.ReleaseDeviceConnection()
 
 	pairRecord := muxConnection.ReadPair(device.Properties.SerialNumber)

--- a/ios/deviceconnection.go
+++ b/ios/deviceconnection.go
@@ -31,10 +31,9 @@ type DeviceConnection struct {
 }
 
 //NewDeviceConnection creates a new DeviceConnection pointing to the given socket waiting for a call to Connect()
-func NewDeviceConnection(socketToConnectTo string) *DeviceConnection {
+func NewDeviceConnection(socketToConnectTo string) (*DeviceConnection, error) {
 	conn := &DeviceConnection{}
-	conn.connectToSocketAddress(socketToConnectTo)
-	return conn
+	return conn, conn.connectToSocketAddress(socketToConnectTo)
 }
 
 //NewDeviceConnectionWithConn create a DeviceConnection with a already connected network conn.
@@ -43,14 +42,14 @@ func NewDeviceConnectionWithConn(conn net.Conn) *DeviceConnection {
 }
 
 //ConnectToSocketAddress connects to the USB multiplexer with a specified socket addres
-func (conn *DeviceConnection) connectToSocketAddress(socketAddress string) {
+func (conn *DeviceConnection) connectToSocketAddress(socketAddress string) error {
 	c, err := net.Dial("unix", socketAddress)
 	if err != nil {
-		log.Fatal("Could not connect to usbmuxd socket, is it running?", err)
+		return err
 	}
 	log.Debug("Opening connection:", &c)
 	conn.c = c
-
+	return nil
 }
 
 //Close closes the network connection

--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -41,7 +41,12 @@ func connectionAccept(l net.Listener, deviceID int, phonePort uint16) {
 }
 
 func startNewProxyConnection(clientConn net.Conn, deviceID int, phonePort uint16) {
-	usbmuxConn := ios.NewUsbMuxConnection(ios.NewDeviceConnection(ios.DefaultUsbmuxdSocket))
+	usbmuxConn, err := ios.NewUsbMuxConnectionSimple()
+	if err != nil {
+		log.Errorf("could not connect to usbmuxd: %+v", err)
+		clientConn.Close()
+		return
+	}
 	muxError := usbmuxConn.Connect(deviceID, phonePort)
 	if muxError != nil {
 		log.WithFields(log.Fields{"conn": fmt.Sprintf("%#v", clientConn), "err": muxError, "phonePort": phonePort}).Infof("could not connect to phone")

--- a/ios/listdevices.go
+++ b/ios/listdevices.go
@@ -94,8 +94,8 @@ func (muxConn *UsbMuxConnection) ListDevices() DeviceList {
 
 //ListDevices returns a DeviceList containing data about all
 //currently connected iOS devices using a new UsbMuxConnection
-func ListDevices() DeviceList {
-	muxConnection := NewUsbMuxConnection(NewDeviceConnection(DefaultUsbmuxdSocket))
+func ListDevices() (DeviceList, error) {
+	muxConnection, err := NewUsbMuxConnectionSimple()
 	defer muxConnection.ReleaseDeviceConnection()
-	return muxConnection.ListDevices()
+	return muxConnection.ListDevices(), err
 }

--- a/ios/readpairrecord.go
+++ b/ios/readpairrecord.go
@@ -91,8 +91,8 @@ func (muxConn *UsbMuxConnection) ReadPair(udid string) PairRecord {
 }
 
 //ReadPairRecord creates a new USBMuxConnection just to read the pair record and closes it right after than.
-func ReadPairRecord(udid string) PairRecord {
-	muxConnection := NewUsbMuxConnection(NewDeviceConnection(DefaultUsbmuxdSocket))
+func ReadPairRecord(udid string) (PairRecord, error) {
+	muxConnection, err := NewUsbMuxConnectionSimple()
 	defer muxConnection.ReleaseDeviceConnection()
-	return muxConnection.ReadPair(udid)
+	return muxConnection.ReadPair(udid), err
 }

--- a/ios/usbmuxconnection.go
+++ b/ios/usbmuxconnection.go
@@ -21,11 +21,17 @@ type UsbMuxConnection struct {
 	deviceConn DeviceConnectionInterface
 }
 
-// NewUsbMuxConnection creates a new UsbMuxConnection with from an already initialized DeviceConnectionInterface
-// and
+// NewUsbMuxConnection creates a new UsbMuxConnection from an already initialized DeviceConnectionInterface
 func NewUsbMuxConnection(deviceConn DeviceConnectionInterface) *UsbMuxConnection {
 	muxConn := &UsbMuxConnection{tag: 0, deviceConn: deviceConn}
 	return muxConn
+}
+
+// NewUsbMuxConnectionSimple creates a new UsbMuxConnection with a connection to /var/run/usbmuxd
+func NewUsbMuxConnectionSimple() (*UsbMuxConnection, error) {
+	deviceConn, err := NewDeviceConnection(DefaultUsbmuxdSocket)
+	muxConn := &UsbMuxConnection{tag: 0, deviceConn: deviceConn}
+	return muxConn, err
 }
 
 //ReleaseDeviceConnection dereferences this UsbMuxConnection from the underlying DeviceConnection and it returns the DeviceConnection for later use.

--- a/ios/utils.go
+++ b/ios/utils.go
@@ -48,7 +48,10 @@ func Ntohs(port uint16) uint16 {
 //GetDevice returns the device for udid. If udid equals emptystring, it returns the first device in the list.
 func GetDevice(udid string) (DeviceEntry, error) {
 	log.Debugf("Looking for device '%s'", udid)
-	deviceList := ListDevices()
+	deviceList, err := ListDevices()
+	if err != nil {
+		return DeviceEntry{}, err
+	}
 	if udid == "" {
 		if len(deviceList.DeviceList) == 0 {
 			return DeviceEntry{}, errors.New("no iOS devices are attached to this host")

--- a/main.go
+++ b/main.go
@@ -557,25 +557,37 @@ func outputDetailedListNoJSON(deviceList ios.DeviceList) {
 }
 
 func startListening() {
-	deviceConn, err := ios.NewDeviceConnection(ios.DefaultUsbmuxdSocket)
-	if err != nil {
-		log.Fatalf("did not work")
-	}
-	muxConnection := ios.NewUsbMuxConnection(deviceConn)
-	defer muxConnection.ReleaseDeviceConnection()
-	attachedReceiver, err := muxConnection.Listen()
-	if err != nil {
-		log.Fatal("Failed issuing Listen command", err)
-	}
-	for {
-		msg, err := attachedReceiver()
-		if err != nil {
-			log.Error("Stopped listening because of error")
-			return
-		}
-		println(convertToJSONString((msg)))
-	}
+	go func() {
+		for {
+			deviceConn, err := ios.NewDeviceConnection(ios.DefaultUsbmuxdSocket)
+			defer deviceConn.Close()
+			if err != nil {
+				log.Errorf("could not connect to %s with err %+v, will retry in 3 seconds...", ios.DefaultUsbmuxdSocket, err)
+				time.Sleep(time.Second * 3)
+				continue
+			}
+			muxConnection := ios.NewUsbMuxConnection(deviceConn)
 
+			attachedReceiver, err := muxConnection.Listen()
+			if err != nil {
+				log.Error("Failed issuing Listen command, will retry in 3 seconds", err)
+				deviceConn.Close()
+				time.Sleep(time.Second * 3)
+				continue
+			}
+			for {
+				msg, err := attachedReceiver()
+				if err != nil {
+					log.Error("Stopped listening because of error")
+					break
+				}
+				println(convertToJSONString((msg)))
+			}
+		}
+	}()
+	c := make(chan os.Signal, syscall.SIGTERM)
+	signal.Notify(c, os.Interrupt)
+	<-c
 }
 
 func printDeviceInfo(device ios.DeviceEntry) {

--- a/main.go
+++ b/main.go
@@ -353,7 +353,12 @@ func language(device ios.DeviceEntry, locale string, language string) {
 
 func startAx(device ios.DeviceEntry) {
 	go func() {
-		device := ios.ListDevices().DeviceList[0]
+		deviceList, err := ios.ListDevices()
+		if err != nil {
+			failWithError("failed converting to json", err)
+		}
+
+		device := deviceList.DeviceList[0]
 
 		conn, err := accessibility.New(device)
 		if err != nil {
@@ -504,7 +509,10 @@ func processList(device ios.DeviceEntry) {
 }
 
 func printDeviceList(details bool) {
-	deviceList := ios.ListDevices()
+	deviceList, err := ios.ListDevices()
+	if err != nil {
+		failWithError("failed getting device list", err)
+	}
 
 	if details {
 		if JSONdisabled {
@@ -549,7 +557,11 @@ func outputDetailedListNoJSON(deviceList ios.DeviceList) {
 }
 
 func startListening() {
-	muxConnection := ios.NewUsbMuxConnection(ios.NewDeviceConnection(ios.DefaultUsbmuxdSocket))
+	deviceConn, err := ios.NewDeviceConnection(ios.DefaultUsbmuxdSocket)
+	if err != nil {
+		log.Fatalf("did not work")
+	}
+	muxConnection := ios.NewUsbMuxConnection(deviceConn)
 	defer muxConnection.ReleaseDeviceConnection()
 	attachedReceiver, err := muxConnection.Listen()
 	if err != nil {
@@ -612,7 +624,10 @@ func pairDevice(device ios.DeviceEntry) {
 }
 
 func readPair(device ios.DeviceEntry) {
-	record := ios.ReadPairRecord(device.Properties.SerialNumber)
+	record, err := ios.ReadPairRecord(device.Properties.SerialNumber)
+	if err != nil {
+		failWithError("failed reading pairrecord", err)
+	}
 	json, err := json.Marshal(record)
 	if err != nil {
 		failWithError("failed converting to json", err)


### PR DESCRIPTION
Some parts of the code still execute a `log.Fatal` rather than returning an error. This is a leftover form my initial days of golang learning and now I think it is not a good idea for several reasons. 
This PR removes log.Fatal for deviceconnection.go and usbmuxconnection.go and replaces it with returning an error. 

I need those to return an actual error so I can try to reconnect in an endless loop for the `LISTEN` command rather than exitting and failing the command. 