### PR TITLE
App Installation using zip_conduit (like Xcode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+wda.ipa
 # Binaries for programs and plugins
 *.log
 *.exe

--- a/ios/zipconduit/plists.go
+++ b/ios/zipconduit/plists.go
@@ -1,0 +1,50 @@
+package zipconduit
+
+import (
+	"fmt"
+	"path"
+)
+
+//metadata is used to write to a plist file that we have to add to what we send
+type metadata struct {
+	StandardDirectoryPerms int
+	StandardFilePerms      int
+	RecordCount            int
+	TotalUncompressedBytes uint64
+	Version                int
+}
+
+//initTransfer is the request you have to send initially to start the transfer
+type initTransfer struct {
+	InstallOptionsDictionary    installoptions
+	InstallTransferredDirectory int
+	MediaSubdir                 string
+	UserInitiatedTransfer       int
+}
+
+//installOptions contains some settings, we just use what XCode uses
+type installoptions struct {
+	DisableDeltaTransfer int
+	InstallDeltaTypeKey  string
+	IsUserInitiated      int
+	PackageType          string
+	PreferWifi           int
+}
+
+// newInitTransfer returns a initTransfer request with
+// the same values XCode uses
+func newInitTransfer(fileName string) initTransfer {
+	base := path.Base(fileName)
+	return initTransfer{
+		InstallTransferredDirectory: 1,
+		UserInitiatedTransfer:       0,
+		MediaSubdir:                 fmt.Sprintf("PublicStaging/%s", base),
+		InstallOptionsDictionary: installoptions{
+			InstallDeltaTypeKey:  "InstallDeltaTypeSparseIPAFiles",
+			DisableDeltaTransfer: 1,
+			IsUserInitiated:      1,
+			PreferWifi:           1,
+			PackageType:          "Customer",
+		},
+	}
+}

--- a/ios/zipconduit/zip_utils.go
+++ b/ios/zipconduit/zip_utils.go
@@ -85,3 +85,6 @@ type zipHeader struct {
 	fileNameLength         uint16
 	extraFieldLength       uint16
 }
+
+//standard header signature for central directory of a zip file
+var centralDirectoryHeader []byte = []byte{0x50, 0x4b, 0x01, 0x02}

--- a/ios/zipconduit/zip_utils.go
+++ b/ios/zipconduit/zip_utils.go
@@ -1,0 +1,87 @@
+package zipconduit
+
+import (
+	"encoding/hex"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+//sadly apple does not use a standard compliant zip implementation for this
+//so I had to hack my own basic pseudo zip format together.
+//this is for a directory.
+func newZipHeaderDir(name string) (zipHeader, []byte, []byte) {
+	return zipHeader{
+		signature:              0x04034b50,
+		version:                20,
+		generalPurposeBitFlags: 0,
+		compressionMethod:      0,
+		lastModifiedTime:       0xBDEF,
+		lastModifiedDate:       0x52EC,
+		crc32:                  0,
+		compressedSize:         0,
+		uncompressedSize:       0,
+		fileNameLength:         uint16(len(name)),
+		extraFieldLength:       32,
+	}, []byte(name), zipExtraBytes
+}
+
+//sadly apple does not use a standard compliant zip implementation for this
+//so I had to hack my own basic pseudo zip format together.
+//this is for a file. It returns the file header, the bytes for the file name and an extra.
+func newZipHeader(size uint32, crc32 uint32, name string) (zipHeader, []byte, []byte) {
+	//the predefined values are just random ones I grabbed from a hexdump
+	//since we only want to get files to a device so it can install an app
+	//timestamps and all that don't really matter anyway
+	return zipHeader{
+		signature:              0x04034b50,
+		version:                20,
+		generalPurposeBitFlags: 0,
+		compressionMethod:      0,
+		lastModifiedTime:       0xBDEF,
+		lastModifiedDate:       0x52EC,
+		crc32:                  crc32,
+		compressedSize:         size,
+		uncompressedSize:       size,
+		fileNameLength:         uint16(len(name)),
+		extraFieldLength:       32,
+	}, []byte(name), zipExtraBytes
+}
+
+
+//will be set by init()
+var zipExtraBytes []byte
+func init(){
+	/**
+	Zip files can carry extra data in their file header fields.
+	Those are usually things like timestamps or some unix permissions we don't really care about.
+	Mostly XCode sends UT extras
+	(https://commons.apache.org/proper/commons-compress/apidocs/org/apache/commons/compress/archivers/zip/X5455_ExtendedTimestamp.html)
+	Since we only push data to the device and don't really care about correct timestamps or anything like that,
+	I just dumped what XCode generates and always send the same extra.
+	In this case I took a 0x5455 "UT" extra. Should it ever break, it'll be easy to fix.
+	 */
+	s := "55540D00 07F3A2EC 60F6A2EC 60F3A2EC 6075780B 000104F5 01000004 14000000"
+	s = strings.ReplaceAll(s, " ", "")
+
+	extra, err := hex.DecodeString(s)
+    zipExtraBytes = extra
+	if err != nil {
+		log.Fatal("this is impossible to break", err)
+	}
+}
+
+//zipHeader is pretty much the structure of a standard zip file header as can be found
+//here f.ex. https://en.wikipedia.org/wiki/ZIP_(file_format)#Local_file_header
+type zipHeader struct {
+	signature              uint32
+	version                uint16
+	generalPurposeBitFlags uint16
+	compressionMethod      uint16
+	lastModifiedTime       uint16
+	lastModifiedDate       uint16
+	crc32                  uint32
+	compressedSize         uint32
+	uncompressedSize       uint32
+	fileNameLength         uint16
+	extraFieldLength       uint16
+}

--- a/ios/zipconduit/zip_utils.go
+++ b/ios/zipconduit/zip_utils.go
@@ -1,8 +1,13 @@
 package zipconduit
 
 import (
+	"archive/zip"
 	"encoding/hex"
+	"fmt"
 	log "github.com/sirupsen/logrus"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -88,3 +93,62 @@ type zipHeader struct {
 
 //standard header signature for central directory of a zip file
 var centralDirectoryHeader []byte = []byte{0x50, 0x4b, 0x01, 0x02}
+
+// unzip is code I copied from https://golangcode.com/unzip-files-in-go/
+// thank you guys for the cool helpful code examples :-D
+func unzip(src string, dest string) ([]string, uint64, error) {
+	var overallSize uint64
+	var filenames []string
+
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return filenames, 0, err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+
+		// Store filename/path for returning and using later on
+		fpath := filepath.Join(dest, f.Name)
+
+		// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
+		if !strings.HasPrefix(fpath, filepath.Clean(dest)+string(os.PathSeparator)) {
+			return filenames, 0, fmt.Errorf("%s: illegal file path", fpath)
+		}
+
+		filenames = append(filenames, fpath)
+
+		if f.FileInfo().IsDir() {
+			// Make Folder
+			os.MkdirAll(fpath, os.ModePerm)
+			continue
+		}
+
+		// Make File
+		if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
+			return filenames, 0, err
+		}
+
+		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			return filenames, 0, err
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			return filenames, 0, err
+		}
+
+		_, err = io.Copy(outFile, rc)
+		//sizeStat, err := outFile.Stat()
+		overallSize += f.UncompressedSize64
+		// Close the file without defer to close before next iteration of loop
+		outFile.Close()
+		rc.Close()
+
+		if err != nil {
+			return filenames, 0, err
+		}
+	}
+	return filenames, overallSize, nil
+}

--- a/ios/zipconduit/zipconduit_installer.go
+++ b/ios/zipconduit/zipconduit_installer.go
@@ -110,12 +110,12 @@ func (conn Connection) SendFile(ipaFile string) error {
 		}
 	}
 
-	_, err = conn.deviceConn.Writer().Write([]byte{0x50, 0x4b, 0x01, 0x02})
-	//_, err = conn.deviceConn.Writer().Write([]byte{0x02, 0x01, 0x4b, 0x50})
+	_, err = conn.deviceConn.Writer().Write(centralDirectoryHeader)
+
 	if err != nil {
 		return err
 	}
-	//deviceStream.Close()
+
 
 	for {
 		msg, _ := conn.plistCodec.Decode(conn.deviceConn.Reader())

--- a/ios/zipconduit/zipconduit_installer.go
+++ b/ios/zipconduit/zipconduit_installer.go
@@ -1,10 +1,8 @@
 package zipconduit
 
 import (
-	"archive/zip"
 	"encoding/binary"
 	"encoding/hex"
-	"fmt"
 	"github.com/danielpaulus/go-ios/ios"
 	log "github.com/sirupsen/logrus"
 	"hash/crc32"
@@ -12,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 )
 
@@ -77,7 +74,7 @@ func (conn Connection) SendFile(ipaFile string) error {
 		log.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	unzippedFiles, totalBytes, err := Unzip(ipaFile, tmpDir)
+	unzippedFiles, totalBytes, err := unzip(ipaFile, tmpDir)
 	if err != nil {
 		return err
 	}
@@ -174,61 +171,3 @@ func AddFileToZip(writer io.Writer, filename string, tmpdir string) error {
 	return err
 }
 
-
-
-func Unzip(src string, dest string) ([]string, uint64, error) {
-	var overallSize uint64
-	var filenames []string
-
-	r, err := zip.OpenReader(src)
-	if err != nil {
-		return filenames, 0, err
-	}
-	defer r.Close()
-
-	for _, f := range r.File {
-
-		// Store filename/path for returning and using later on
-		fpath := filepath.Join(dest, f.Name)
-
-		// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
-		if !strings.HasPrefix(fpath, filepath.Clean(dest)+string(os.PathSeparator)) {
-			return filenames, 0, fmt.Errorf("%s: illegal file path", fpath)
-		}
-
-		filenames = append(filenames, fpath)
-
-		if f.FileInfo().IsDir() {
-			// Make Folder
-			os.MkdirAll(fpath, os.ModePerm)
-			continue
-		}
-
-		// Make File
-		if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
-			return filenames, 0, err
-		}
-
-		outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return filenames, 0, err
-		}
-
-		rc, err := f.Open()
-		if err != nil {
-			return filenames, 0, err
-		}
-
-		_, err = io.Copy(outFile, rc)
-		//sizeStat, err := outFile.Stat()
-		overallSize += f.UncompressedSize64
-		// Close the file without defer to close before next iteration of loop
-		outFile.Close()
-		rc.Close()
-
-		if err != nil {
-			return filenames, 0, err
-		}
-	}
-	return filenames, overallSize, nil
-}

--- a/ios/zipconduit/zipconduit_installer.go
+++ b/ios/zipconduit/zipconduit_installer.go
@@ -133,66 +133,10 @@ type Metadata struct {
 	Version                int
 }
 
-type ZipHeader struct {
-	signature             uint32
-	version               uint16
-	generalPurpseBitFlags uint16
-	compressionMethod     uint16
-	lastModifiedTime      uint16
-	lastModifiedDate      uint16
-	crc32                 uint32
-	compressedSize        uint32
-	uncompressedSize      uint32
-	fileNameLength        uint16
-	extrafieldLength      uint16
-}
 
-func newZipHeader(size uint32, crc32 uint32, name string) (ZipHeader, []byte, []byte) {
-	s:= "55540D00 07F3A2EC 60F6A2EC 60F3A2EC 6075780B 000104F5 01000004 14000000"
-	s = strings.ReplaceAll(s, " ", "")
 
-	extra, err := hex.DecodeString(s)
-	if err != nil {
-		log.Fatal("wtf", err)
-	}
-	return ZipHeader{
-		signature:             0x04034b50,
-		version:               20,
-		generalPurpseBitFlags: 0,
-		compressionMethod:     0,
-		lastModifiedTime:      0xBDEF,
-		lastModifiedDate:      0x52EC,
-		crc32:                 crc32,
-		compressedSize:        size,
-		uncompressedSize:      size,
-		fileNameLength:        uint16(len(name)),
-		extrafieldLength:      32,
-	}, []byte(name), extra
-}
 
-func newZipHeaderDir(name string) (ZipHeader, []byte, []byte) {
-	s:= "55540D00 07F3A2EC 60F6A2EC 60F3A2EC 6075780B 000104F5 01000004 14000000"
-	s = strings.ReplaceAll(s, " ", "")
 
-	extra, err := hex.DecodeString(s)
-
-	if err != nil {
-		log.Fatal("wtf", err)
-	}
-	return ZipHeader{
-		signature:             0x04034b50,
-		version:               20,
-		generalPurpseBitFlags: 0,
-		compressionMethod:     0,
-		lastModifiedTime:      0xBDEF,
-		lastModifiedDate:      0x52EC,
-		crc32:                 0,
-		compressedSize:        0,
-		uncompressedSize:      0,
-		fileNameLength:        uint16(len(name)),
-		extrafieldLength:      32,
-	}, []byte(name), extra
-}
 
 func AddFileToZip(writer io.Writer, filename string, tmpdir string) error {
 	fileToZip, err := os.Open(filename)

--- a/ios/zipconduit/zipconduit_installer.go
+++ b/ios/zipconduit/zipconduit_installer.go
@@ -147,9 +147,17 @@ func (conn Connection) waitForInstallation() error {
 	for {
 		msg, _ := conn.plistCodec.Decode(conn.deviceConn.Reader())
 		plist, _ := ios.ParsePlist(msg)
-		log.Infof("%+v", plist)
+		log.Debugf("%+v", plist)
+		done, percent, status, err := evaluateProgress(plist)
+		if err != nil {
+			return err
+		}
+		if done {
+			log.Info("installation successful")
+			return nil
+		}
+		log.WithFields(log.Fields{"status": status, "percentComplete": percent}).Info("installing")
 	}
-	return nil
 }
 
 const metainfFileName = "com.apple.ZipMetadata.plist"

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/danielpaulus/go-ios/ios/zipconduit"
 	"io/ioutil"
 	"path/filepath"
 	"runtime/debug"
@@ -182,7 +183,7 @@ The commands work as following:
 	b, _ = arguments.Bool("install")
 	if b {
 		path, _ := arguments.String("--path")
-		installApp(path)
+		installApp(device, path)
 		return
 	}
 
@@ -348,8 +349,12 @@ The commands work as following:
 
 }
 
-func installApp(path string) {
+func installApp(device ios.DeviceEntry, path string) {
 	log.Info("installing " + path)
+	conn, err := zipconduit.New(device)
+	exitIfError("failed connecting to zipconduit, dev image installed?", err)
+	err = conn.SendFile(path)
+	exitIfError("failed writing", err)
 }
 
 func language(device ios.DeviceEntry, locale string, language string) {

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ Usage:
   ios dproxy
   ios readpair [options]
   ios pcap [options]
+  ios install --path=<ipaOrAppFolder> [options]
   ios apps [--system] [options]
   ios launch <bundleID> [options]
   ios runtest <bundleID> [options]
@@ -92,6 +93,7 @@ The commands work as following:
    ios dproxy                                                         Starts the reverse engineering proxy server. It dumps every communication in plain text so it can be implemented easily. Use "sudo launchctl unload -w /Library/Apple/System/Library/LaunchDaemons/com.apple.usbmuxd.plist" to stop usbmuxd and load to start it again should the proxy mess up things.
    ios readpair                                                       Dump detailed information about the pairrecord for a device.
    ios pcap [options]                                                 Starts a pcap dump of network traffic
+   ios install --path=<ipaOrAppFolder> [options]                      Specify a .app folder or an installable ipa file that will be installed.  
    ios apps [--system]                                                Retrieves a list of installed applications. --system prints out preinstalled system apps.
    ios launch <bundleID>                                              Launch app with the bundleID on the device. Get your bundle ID from the apps command.
    ios runtest <bundleID>                                             Run a XCUITest. 
@@ -165,6 +167,13 @@ The commands work as following:
 	b, _ = arguments.Bool("ps")
 	if b {
 		processList(device)
+		return
+	}
+
+	b, _ = arguments.Bool("install")
+	if b {
+		path, _ := arguments.String("--path")
+		installApp(path)
 		return
 	}
 
@@ -328,6 +337,10 @@ The commands work as following:
 		return
 	}
 
+}
+
+func installApp(path string) {
+	log.Info("installing " + path)
 }
 
 func language(device ios.DeviceEntry, locale string, language string) {

--- a/main.go
+++ b/main.go
@@ -350,7 +350,8 @@ The commands work as following:
 }
 
 func installApp(device ios.DeviceEntry, path string) {
-	log.Info("installing " + path)
+	log.WithFields(
+		log.Fields{"appPath": path, "device": device.Properties.SerialNumber}).Info("installing")
 	conn, err := zipconduit.New(device)
 	exitIfError("failed connecting to zipconduit, dev image installed?", err)
 	err = conn.SendFile(path)


### PR DESCRIPTION
Adding app installation with streaming zip conduit. 
The cool thing is that this installation method can install uncompressed apps without compressing them to a zip first. 
Files will be sent to the device directly with no compression. 
You can install apps like so:
- for zipped ipa files: `ios install --path=/Users/user/wda.ipa --nojson`
- for uncompressed .app folders: `install --path=/Users/user/WebDriverAgentRunner-Runner.app --nojson`