### PR TITLE
Remove log.Fatal and replace with error propagation

### DIFF
--- a/ios/accessibility/accessibility_control.go
+++ b/ios/accessibility/accessibility_control.go
@@ -1,6 +1,8 @@
 package accessibility
 
 import (
+	"fmt"
+
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
 	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
 	log "github.com/sirupsen/logrus"
@@ -17,7 +19,7 @@ func (a ControlInterface) readhostAppStateChanged() {
 		msg := a.channel.ReceiveMethodCall("hostAppStateChanged:")
 		stateChange, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
 		if err != nil {
-			log.Fatal(err)
+			panic(err)
 		}
 		value := stateChange[0]
 		log.Infof("hostAppStateChanged:%s", value)
@@ -29,7 +31,7 @@ func (a ControlInterface) readhostInspectorNotificationReceived() {
 		msg := a.channel.ReceiveMethodCall("hostInspectorNotificationReceived:")
 		notification, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
 		if err != nil {
-			log.Fatal(err)
+			panic(err)
 		}
 		value := notification[0].(map[string]interface{})["Value"]
 		log.Infof("hostInspectorNotificationReceived:%s", value)
@@ -144,7 +146,7 @@ func (a ControlInterface) awaitHostInspectorCurrentElementChanged() map[string]i
 	log.Info("received hostInspectorCurrentElementChanged")
 	result, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
 	if err != nil {
-		log.Fatalf("Failed unarchiving: %s this is a bug and should not happen", err)
+		panic(fmt.Sprintf("Failed unarchiving: %s this is a bug and should not happen", err))
 	}
 	return result[0].(map[string]interface{})
 }

--- a/ios/accessibility/accessibility_integration_test.go
+++ b/ios/accessibility/accessibility_integration_test.go
@@ -13,17 +13,17 @@ import (
 func TestIT(t *testing.T) {
 	device, err := ios.GetDevice("")
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	conn, err := accessibility.New(device)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	conn.SwitchToDevice()
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	conn.EnableSelectionMode()
 	conn.GetElement()

--- a/ios/connect.go
+++ b/ios/connect.go
@@ -2,8 +2,6 @@ package ios
 
 import (
 	"fmt"
-
-	log "github.com/sirupsen/logrus"
 )
 
 type connectMessage struct {
@@ -122,10 +120,10 @@ func (muxConn *UsbMuxConnection) connectWithStartServiceResponse(deviceID int, s
 	return nil
 }
 
-func ConnectLockdownWithSession(device DeviceEntry) *LockDownConnection {
+func ConnectLockdownWithSession(device DeviceEntry) (*LockDownConnection, error) {
 	muxConnection, err := NewUsbMuxConnectionSimple()
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("USBMuxConnection failed with: %v", err)
 	}
 	defer muxConnection.ReleaseDeviceConnection()
 
@@ -133,8 +131,11 @@ func ConnectLockdownWithSession(device DeviceEntry) *LockDownConnection {
 
 	lockdownConnection, err := muxConnection.ConnectLockdown(device.DeviceID)
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("Lockdown connection failed with: %v", err)
 	}
-	lockdownConnection.StartSession(pairRecord)
-	return lockdownConnection
+	resp, err := lockdownConnection.StartSession(pairRecord)
+	if err != nil {
+		return nil, fmt.Errorf("StartSession failed: %+v error: %v", resp, err)
+	}
+	return lockdownConnection, nil
 }

--- a/ios/connect.go
+++ b/ios/connect.go
@@ -127,7 +127,10 @@ func ConnectLockdownWithSession(device DeviceEntry) (*LockDownConnection, error)
 	}
 	defer muxConnection.ReleaseDeviceConnection()
 
-	pairRecord := muxConnection.ReadPair(device.Properties.SerialNumber)
+	pairRecord, err := muxConnection.ReadPair(device.Properties.SerialNumber)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve PairRecord with error: %v", err)
+	}
 
 	lockdownConnection, err := muxConnection.ConnectLockdown(device.DeviceID)
 	if err != nil {

--- a/ios/debugproxy/binforward.go
+++ b/ios/debugproxy/binforward.go
@@ -64,7 +64,7 @@ func handleConnectToService(connectRequest ios.UsbMuxMessage,
 	serviceInfo PhoneServiceInformation) {
 	err := muxToDevice.SendMuxMessage(connectRequest)
 	if err != nil {
-		p.log.Fatal("Failed sending muxmessage to device")
+		panic("Failed sending muxmessage to device")
 	}
 	connectResponse, err := muxToDevice.ReadMessage()
 	muxOnUnixSocket.SendMuxMessage(connectResponse)

--- a/ios/debugproxy/debugproxy.go
+++ b/ios/debugproxy/debugproxy.go
@@ -100,7 +100,7 @@ func (d *DebugProxy) Launch(device ios.DeviceEntry, binaryMode bool) error {
 	d.setupDirectory()
 	listener, err := net.Listen("unix", ios.DefaultUsbmuxdSocket)
 	if err != nil {
-		log.Fatal("Could not listen on usbmuxd socket, do I have access permissions?", err)
+		log.Error("Could not listen on usbmuxd socket, do I have access permissions?", err)
 		return err
 	}
 
@@ -198,7 +198,7 @@ func writeJSON(filePath string, JSON interface{}) {
 	file, err := os.OpenFile(filePath,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		log.Fatal("Could not write to file, this should not happen", err, filePath)
+		panic(fmt.Sprintf("Could not write to file err: %v filepath:'%s'", err, filePath))
 	}
 	jsonmsg, err := json.Marshal(JSON)
 	if err != nil {

--- a/ios/debugproxy/decoders.go
+++ b/ios/debugproxy/decoders.go
@@ -164,7 +164,7 @@ func writeBytes(filePath string, data []byte) {
 	file, err := os.OpenFile(filePath,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		log.Fatal("Could not write to file, this should not happen", err, filePath)
+		panic(fmt.Sprintf("Could not write to file error: %v path:'%s'", err, filePath))
 	}
 
 	file.Write(data)

--- a/ios/debugproxy/muxhandler.go
+++ b/ios/debugproxy/muxhandler.go
@@ -2,6 +2,7 @@ package debugproxy
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	ios "github.com/danielpaulus/go-ios/ios"
@@ -44,7 +45,7 @@ func proxyUsbMuxConnection(p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnec
 			continue
 		}
 		if err != nil {
-			p.log.Fatal("Failed forwarding message to device", request)
+			panic(fmt.Sprintf("Failed forwarding message to device: %+v", request))
 		}
 		if decodedRequest["MessageType"] == "Listen" {
 			handleListen(p, muxOnUnixSocket, muxToDevice)

--- a/ios/debugproxy/muxhandler.go
+++ b/ios/debugproxy/muxhandler.go
@@ -101,7 +101,7 @@ func handleConnect(connectRequest ios.UsbMuxMessage, decodedConnectRequest map[s
 	} else {
 		info, err := p.debugProxy.retrieveServiceInfoByPort(ios.Ntohs(uint16(port)))
 		if err != nil {
-			p.log.Fatalf("ServiceInfo for port: %d not found, this is a bug :-)reqheader: %+v repayload: %x", port, connectRequest.Header, connectRequest.Payload)
+			panic(fmt.Sprintf("ServiceInfo for port: %d not found, this is a bug :-)reqheader: %+v repayload: %x", port, connectRequest.Header, connectRequest.Payload))
 		}
 		p.log.Infof("Connection to service '%s' detected on port %d", info.ServiceName, info.ServicePort)
 		handleConnectToService(connectRequest, decodedConnectRequest, p, muxOnUnixSocket, muxToDevice, info)
@@ -111,7 +111,7 @@ func handleConnect(connectRequest ios.UsbMuxMessage, decodedConnectRequest map[s
 func handleConnectToLockdown(connectRequest ios.UsbMuxMessage, decodedConnectRequest map[string]interface{}, p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnection, muxToDevice *ios.UsbMuxConnection) {
 	err := muxToDevice.SendMuxMessage(connectRequest)
 	if err != nil {
-		p.log.Fatal("Failed sending muxmessage to device")
+		panic("Failed sending muxmessage to device")
 	}
 	connectResponse, err := muxToDevice.ReadMessage()
 	muxOnUnixSocket.SendMuxMessage(connectResponse)

--- a/ios/deviceconnection.go
+++ b/ios/deviceconnection.go
@@ -62,7 +62,7 @@ func (conn *DeviceConnection) Close() {
 func (conn *DeviceConnection) Send(bytes []byte) error {
 	n, err := conn.c.Write(bytes)
 	if n < len(bytes) {
-		log.Fatalf("DeviceConnection failed writing %d bytes, only %d sent", len(bytes), n)
+		log.Errorf("DeviceConnection failed writing %d bytes, only %d sent", len(bytes), n)
 	}
 	if err != nil {
 		log.Errorf("Failed sending: %s", err)

--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -1,7 +1,9 @@
 package dtx
 
 import (
+	"errors"
 	"io"
+	"net"
 	"sync"
 
 	ios "github.com/danielpaulus/go-ios/ios"
@@ -114,8 +116,8 @@ func reader(dtxConn *Connection) {
 		reader := dtxConn.deviceConnection.Reader()
 		msg, err := ReadMessage(reader)
 		if err != nil {
-			if err == io.EOF || err.Error() == "use of closed network connection" {
-				log.Debug("Closing DTX Connection")
+			if err == io.EOF || err == net.ErrClosed || errors.Unwrap(err) == net.ErrClosed {
+				log.Debug("DTX Connection with EOF")
 				return
 			}
 			log.Errorf("error reading dtx connection %+v", err)

--- a/ios/dtx_codec/decoder_test.go
+++ b/ios/dtx_codec/decoder_test.go
@@ -23,7 +23,7 @@ func TestErrors(t *testing.T) {
 
 	dat, err = ioutil.ReadFile("fixtures/notifyOfPublishedCapabilites")
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	for i := 0; i < len(dat)-4; i++ {
 		_, _, err = dtx.DecodeNonBlocking(dat[0 : 4+i])
@@ -36,12 +36,12 @@ func TestCodec2(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/requestChannelWithCodeIdentifier.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	fixtureMsg, _, err := dtx.DecodeNonBlocking(dat)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	payloadBytes, err := nskeyedarchiver.ArchiveBin(fixtureMsg.Payload[0])
 	assert.NoError(t, err)
@@ -59,7 +59,7 @@ func TestCodec(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/requestChannelWithCodeIdentifier.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	var remainingBytes []byte
 	remainingBytes = dat
@@ -68,7 +68,7 @@ func TestCodec(t *testing.T) {
 		log.Info(msg.StringDebug())
 		remainingBytes = s
 		if !assert.NoError(t, err) {
-			log.Fatal("whet", err)
+			t.Fatal("whet", err)
 		}
 		bytes, err := dtx.Encode(3, 0, 0, true, 2, msg.RawBytes[303:], msg.Auxiliary)
 		if assert.NoError(t, err) {
@@ -86,7 +86,7 @@ func TestAXDump(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/dtactivitytapmessage.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	var remainingBytes []byte
 	remainingBytes = dat
@@ -95,7 +95,7 @@ func TestAXDump(t *testing.T) {
 		log.Info(msg)
 		remainingBytes = s
 		if !assert.NoError(t, err) {
-			log.Fatal("whet", err)
+			t.Fatal("whet", err)
 		}
 	}
 
@@ -109,7 +109,7 @@ func TestType1Message(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/unknown-d-h-h-message.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	var remainingBytes []byte
 	remainingBytes = dat
@@ -118,7 +118,7 @@ func TestType1Message(t *testing.T) {
 		log.Info(msg)
 		remainingBytes = s
 		if !assert.NoError(t, err) {
-			log.Fatal("whet", err)
+			t.Fatal("whet", err)
 		}
 	}
 
@@ -127,7 +127,7 @@ func TestType1Message(t *testing.T) {
 func TestFragmentedMessage(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/fragmentedmessage.bin")
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 
 	//test the non blocking decoder first
@@ -193,7 +193,7 @@ func TestFragmentedMessage(t *testing.T) {
 func TestDecoder(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/notifyOfPublishedCapabilites")
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	msg, remainingBytes, err := dtx.DecodeNonBlocking(dat)
 	if assert.NoError(t, err) {

--- a/ios/dtx_codec/dtxprimitivedictionary.go
+++ b/ios/dtx_codec/dtxprimitivedictionary.go
@@ -46,12 +46,12 @@ func (d PrimitiveDictionary) GetArguments() []interface{} {
 }
 
 //AddNsKeyedArchivedObject wraps the object in a NSKeyedArchiver envelope before saving it to the dictionary as a []byte.
-//This will log.Fatal on error because NSKeyedArchiver has to support everything that is put in here during runtime.
+//This will panic on error because NSKeyedArchiver has to support everything that is put in here during runtime.
 //If not, it is a non-recoverable bug and needs to be fixed anyway.
 func (d *PrimitiveDictionary) AddNsKeyedArchivedObject(object interface{}) {
 	archivedObject, err := nskeyedarchiver.ArchiveBin(object)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 	d.AddBytes(archivedObject)
 }
@@ -189,8 +189,7 @@ func readEntry(auxBytes []byte) (uint32, interface{}, []byte) {
 		data := auxBytes[8 : 8+length]
 		return readType, data, auxBytes[8+length:]
 	}
-	log.Fatalf("Unknown DtxPrimitiveDictionaryType: %d  rawbytes:%x", readType, auxBytes)
-	return 0, nil, nil
+	panic(fmt.Sprintf("Unknown DtxPrimitiveDictionaryType: %d  rawbytes:%x", readType, auxBytes))
 }
 
 const (
@@ -228,7 +227,7 @@ func (a *AuxiliaryEncoder) AddNsKeyedArchivedObject(object interface{}) {
 	a.writeEntry(t_null, nil)
 	bytes, err := archiver.ArchiveBin(object)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 	a.writeEntry(t_bytearray, bytes)
 }
@@ -247,7 +246,7 @@ func (a *AuxiliaryEncoder) writeEntry(entryType uint32, object interface{}) {
 		a.buf.Write(object.([]byte))
 
 	}
-	log.Fatalf("Unknown DtxPrimitiveDictionaryType: %d", entryType)
+	panic(fmt.Sprintf("Unknown DtxPrimitiveDictionaryType: %d", entryType))
 
 }
 

--- a/ios/dtx_codec/fragmentdecoder_test.go
+++ b/ios/dtx_codec/fragmentdecoder_test.go
@@ -2,7 +2,6 @@ package dtx_test
 
 import (
 	"encoding/binary"
-	"log"
 	"testing"
 
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
@@ -30,7 +29,8 @@ func createHeader(fragmentIndex uint16, fragmentLength uint16, identifier uint32
 	}
 	msg, _, err := dtx.DecodeNonBlocking(messageBytes)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
+
 	}
 	return msg
 }

--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -33,7 +33,8 @@ func connectionAccept(l net.Listener, deviceID int, phonePort uint16) {
 	for {
 		clientConn, err := l.Accept()
 		if err != nil {
-			log.Fatal("Error accepting new connection")
+			log.Errorf("Error accepting new connection %v", err)
+			continue
 		}
 		log.WithFields(log.Fields{"conn": fmt.Sprintf("%#v", clientConn)}).Info("new client connected")
 		go startNewProxyConnection(clientConn, deviceID, phonePort)

--- a/ios/house_arrest/house_arrest.go
+++ b/ios/house_arrest/house_arrest.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/danielpaulus/go-ios/ios"
-	log "github.com/sirupsen/logrus"
 
 	"howett.net/plist"
 )
@@ -37,7 +36,7 @@ func vendContainer(deviceConn ios.DeviceConnectionInterface, bundleID string) er
 	vendContainer := map[string]interface{}{"Command": "VendContainer", "Identifier": bundleID}
 	msg, err := plistCodec.Encode(vendContainer)
 	if err != nil {
-		log.Fatal("VendContainer Encoding cannot fail unless the encoder is broken")
+		return fmt.Errorf("VendContainer Encoding cannot fail unless the encoder is broken: %v", err)
 	}
 	err = deviceConn.Send(msg)
 	if err != nil {

--- a/ios/instruments/processcontrol_integration_test.go
+++ b/ios/instruments/processcontrol_integration_test.go
@@ -14,13 +14,13 @@ import (
 func TestLaunchAndKill(t *testing.T) {
 	device, err := ios.GetDevice("")
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	const weatherAppBundleID = "com.apple.weather"
 	pControl, err := instruments.NewProcessControl(device)
 	defer pControl.Close()
 	if !assert.NoError(t, err) {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
 	pid, err := pControl.LaunchApp(weatherAppBundleID)
 	if assert.NoError(t, err) {
@@ -29,5 +29,5 @@ func TestLaunchAndKill(t *testing.T) {
 		assert.NoError(t, err)
 		return
 	}
-	log.Fatal(err)
+	t.Fatal(err)
 }

--- a/ios/lockdown_language_locale.go
+++ b/ios/lockdown_language_locale.go
@@ -20,7 +20,10 @@ func SetLanguage(device DeviceEntry, config LanguageConfiguration) error {
 		log.Debug("SetLanguage called with empty config, no changes made")
 		return nil
 	}
-	lockDownConn := ConnectLockdownWithSession(device)
+	lockDownConn, err := ConnectLockdownWithSession(device)
+	if err != nil {
+		return err
+	}
 	defer lockDownConn.Close()
 	if config.Locale != "" {
 		log.Debugf("Setting locale: %s", config.Locale)
@@ -38,7 +41,10 @@ func SetLanguage(device DeviceEntry, config LanguageConfiguration) error {
 
 //GetLanguage creates a new lockdown session for the device and retrieves language and locale. It returns a LanguageConfiguration or an error.
 func GetLanguage(device DeviceEntry) (LanguageConfiguration, error) {
-	lockDownConn := ConnectLockdownWithSession(device)
+	lockDownConn, err := ConnectLockdownWithSession(device)
+	if err != nil {
+		return LanguageConfiguration{}, err
+	}
 	defer lockDownConn.Close()
 	languageResp, err := lockDownConn.GetValueForDomain("Language", languageDomain)
 	if err != nil {

--- a/ios/lockdown_value.go
+++ b/ios/lockdown_value.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	plist "howett.net/plist"
 )
 
@@ -147,12 +146,16 @@ func (lockDownConn *LockDownConnection) GetValues() (GetAllValuesResponse, error
 }
 
 //GetProductVersion returns the ProductVersion of the device f.ex. "10.3"
-func (lockDownConn *LockDownConnection) GetProductVersion() string {
+func (lockDownConn *LockDownConnection) GetProductVersion() (string, error) {
 	msg, err := lockDownConn.GetValue("ProductVersion")
 	if err != nil {
-		log.Fatal("Failed getting ProductVersion", err)
+		return "", fmt.Errorf("Failed getting ProductVersion: %v", err)
 	}
-	return msg.(string)
+	result, ok := msg.(string)
+	if !ok {
+		return "", fmt.Errorf("could not convert response to string: %+v", msg)
+	}
+	return result, nil
 }
 
 //GetValue gets and returns the string value for the lockdown key

--- a/ios/nskeyedarchiver/archiver.go
+++ b/ios/nskeyedarchiver/archiver.go
@@ -2,7 +2,6 @@ package nskeyedarchiver
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 
 	"howett.net/plist"
@@ -74,8 +73,7 @@ func archive(object interface{}, objects []interface{}) ([]interface{}, plist.UI
 		return encoderFunc(object, objects)
 	}
 
-	log.Fatal(fmt.Errorf("NSKeyedArchiver Unsupported type:%s", object))
-	return nil, 0
+	panic(fmt.Errorf("NSKeyedArchiver Unsupported type:%s", object))
 }
 
 func serializeArray(array []interface{}, objects []interface{}) ([]interface{}, plist.UID) {

--- a/ios/nskeyedarchiver/archiver_test.go
+++ b/ios/nskeyedarchiver/archiver_test.go
@@ -23,7 +23,7 @@ func TestXCTestconfig(t *testing.T) {
 	result, err := nskeyedarchiver.ArchiveXML(config)
 	if err != nil {
 		log.Error(err)
-		t.Fail()
+		t.Fatal()
 	}
 	print(result)
 	log.Info(uuid.String())
@@ -35,7 +35,7 @@ func TestXCTestconfig(t *testing.T) {
 
 	if err != nil {
 		log.Error(err)
-		t.Fail()
+		t.Fatal()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -49,7 +49,7 @@ func TestXCTCaps(t *testing.T) {
 	if err != nil {
 
 		log.Error(err)
-		t.Fail()
+		t.Fatal()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -62,7 +62,7 @@ func TestNSUUID(t *testing.T) {
 
 	if err != nil {
 		log.Error(err)
-		t.Fail()
+		t.Fatal()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -75,7 +75,7 @@ func TestXCActivityRecord(t *testing.T) {
 
 	if err != nil {
 		log.Error(err)
-		t.Fail()
+		t.Fatal()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -88,7 +88,7 @@ func TestDTTapHeartbeatMessage(t *testing.T) {
 
 	if err != nil {
 		log.Error(err)
-		t.Fail()
+		t.Fatal()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -102,8 +102,7 @@ func TestIntKeyDictionary(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/uint64-key-dictionary.bin")
 
 	if err != nil {
-		log.Error(err)
-		t.Fail()
+		t.Fatal(err)
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -137,8 +136,7 @@ func TestNSDate(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/ax_statechange.bin")
 
 	if err != nil {
-		log.Error(err)
-		t.Fail()
+		t.Fatal(err)
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -150,8 +148,7 @@ func TestNSNull(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/ax_focus_on_element.bin")
 
 	if err != nil {
-		log.Error(err)
-		t.Fail()
+		t.Fatal(err)
 	}
 
 	unarchivedObject, _ := archiver.Unarchive(nskeyedBytes)
@@ -168,8 +165,7 @@ func TestArchiver3(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/payload_dump.json")
 
 	if err != nil {
-		log.Error(err)
-		t.Fail()
+		t.Fatal(err)
 	}
 
 	var payloads []string
@@ -196,8 +192,7 @@ func TestArchiver3(t *testing.T) {
 func TestArchiver(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/payload_dump.json")
 	if err != nil {
-		log.Error(err)
-		t.Fail()
+		t.Fatal(err)
 	}
 
 	var payloads []string
@@ -224,8 +219,7 @@ func TestArchiver(t *testing.T) {
 func TestDecoderJson(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/payload_dump.json")
 	if err != nil {
-		log.Error(err)
-		t.Fail()
+		t.Fatal(err)
 	}
 
 	var payloads []string
@@ -254,8 +248,7 @@ func TestDecoder(t *testing.T) {
 	for _, tc := range testCases {
 		dat, err := ioutil.ReadFile("fixtures/" + tc.filename + ".xml")
 		if err != nil {
-			log.Error(err)
-			t.Fail()
+			t.Fatal(err)
 		}
 		objects, err := archiver.Unarchive(dat)
 		assert.NoError(t, err)
@@ -263,8 +256,7 @@ func TestDecoder(t *testing.T) {
 
 		dat, err = ioutil.ReadFile("fixtures/" + tc.filename + ".bin")
 		if err != nil {
-			log.Error(err)
-			t.Fail()
+			t.Fatal(err)
 		}
 		objects, err = archiver.Unarchive(dat)
 		assert.Equal(t, tc.expected, convertToJSON(objects))
@@ -288,8 +280,7 @@ func TestValidation(t *testing.T) {
 	for _, tc := range testCases {
 		dat, err := ioutil.ReadFile("fixtures/" + tc.filename + ".xml")
 		if err != nil {
-			log.Error(err)
-			t.Fail()
+			t.Fatal(err)
 		}
 		_, err = archiver.Unarchive(dat)
 		assert.Error(t, err)

--- a/ios/nskeyedarchiver/archiver_test.go
+++ b/ios/nskeyedarchiver/archiver_test.go
@@ -22,7 +22,8 @@ func TestXCTestconfig(t *testing.T) {
 	config := nskeyedarchiver.NewXCTestConfiguration("productmodulename", uuid, "targetAppBundle", "targetAppPath", "testBundleUrl")
 	result, err := nskeyedarchiver.ArchiveXML(config)
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 	print(result)
 	log.Info(uuid.String())
@@ -33,7 +34,8 @@ func TestXCTestconfig(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/xctestconfiguration.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -45,7 +47,9 @@ func TestXCTCaps(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/XCTCapabilities.bin")
 
 	if err != nil {
-		log.Fatal(err)
+
+		log.Error(err)
+		t.Fail()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -57,7 +61,8 @@ func TestNSUUID(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/nsuuid.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -69,7 +74,8 @@ func TestXCActivityRecord(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/XCActivityRecord.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -81,7 +87,8 @@ func TestDTTapHeartbeatMessage(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/DTTapHeartbeatMessage.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -95,7 +102,8 @@ func TestIntKeyDictionary(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/uint64-key-dictionary.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -129,7 +137,8 @@ func TestNSDate(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/ax_statechange.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 
 	unarchivedObject, err := archiver.Unarchive(nskeyedBytes)
@@ -141,7 +150,8 @@ func TestNSNull(t *testing.T) {
 	nskeyedBytes, err := ioutil.ReadFile("fixtures/ax_focus_on_element.bin")
 
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 
 	unarchivedObject, _ := archiver.Unarchive(nskeyedBytes)
@@ -158,7 +168,8 @@ func TestArchiver3(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/payload_dump.json")
 
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 
 	var payloads []string
@@ -185,7 +196,8 @@ func TestArchiver3(t *testing.T) {
 func TestArchiver(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/payload_dump.json")
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 
 	var payloads []string
@@ -212,7 +224,8 @@ func TestArchiver(t *testing.T) {
 func TestDecoderJson(t *testing.T) {
 	dat, err := ioutil.ReadFile("fixtures/payload_dump.json")
 	if err != nil {
-		log.Fatal(err)
+		log.Error(err)
+		t.Fail()
 	}
 
 	var payloads []string
@@ -241,7 +254,8 @@ func TestDecoder(t *testing.T) {
 	for _, tc := range testCases {
 		dat, err := ioutil.ReadFile("fixtures/" + tc.filename + ".xml")
 		if err != nil {
-			log.Fatal(err)
+			log.Error(err)
+			t.Fail()
 		}
 		objects, err := archiver.Unarchive(dat)
 		assert.NoError(t, err)
@@ -249,7 +263,8 @@ func TestDecoder(t *testing.T) {
 
 		dat, err = ioutil.ReadFile("fixtures/" + tc.filename + ".bin")
 		if err != nil {
-			log.Fatal(err)
+			log.Error(err)
+			t.Fail()
 		}
 		objects, err = archiver.Unarchive(dat)
 		assert.Equal(t, tc.expected, convertToJSON(objects))
@@ -273,7 +288,8 @@ func TestValidation(t *testing.T) {
 	for _, tc := range testCases {
 		dat, err := ioutil.ReadFile("fixtures/" + tc.filename + ".xml")
 		if err != nil {
-			log.Fatal(err)
+			log.Error(err)
+			t.Fail()
 		}
 		_, err = archiver.Unarchive(dat)
 		assert.Error(t, err)

--- a/ios/nskeyedarchiver/archiverutils.go
+++ b/ios/nskeyedarchiver/archiverutils.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 
 	plist "howett.net/plist"
 )
@@ -48,11 +47,11 @@ func toBinaryPlist(data interface{}) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-//Print an object as JSON for debugging purposes, careful log.Fatals on error
+//Print an object as JSON for debugging purposes, careful panics on error
 func printAsJSON(obj interface{}) {
 	b, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
-		log.Fatalf("Error while marshalling Json:%s", err)
+		panic(fmt.Sprintf("Error while marshalling Json:%s", err))
 	}
 	fmt.Print(string(b))
 }

--- a/ios/nskeyedarchiver/objectivec_classes.go
+++ b/ios/nskeyedarchiver/objectivec_classes.go
@@ -177,7 +177,7 @@ func NewNSUUIDFromBytes(object map[string]interface{}, objects []interface{}) in
 func NewNSUUID(id uuid.UUID) NSUUID {
 	bytes, err := id.MarshalBinary()
 	if err != nil {
-		log.Fatal("Unexpected Error", err)
+		panic(fmt.Sprintf("Unexpected Error: %v", err))
 	}
 	return NSUUID{bytes}
 }

--- a/ios/pcap/pcap.go
+++ b/ios/pcap/pcap.go
@@ -2,27 +2,32 @@ package pcap
 
 import (
 	"encoding/hex"
-	"log"
 
 	"github.com/danielpaulus/go-ios/ios"
 	"howett.net/plist"
 )
 
-func Start(device ios.DeviceEntry) {
+func Start(device ios.DeviceEntry) error {
 	intf, err := ios.ConnectToService(device, "com.apple.pcapd")
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	plistCodec := ios.NewPlistCodec()
 	for {
-		b, _ := plistCodec.Decode(intf.Reader())
-
-		println(hex.Dump(fromBytes(b)))
+		b, err := plistCodec.Decode(intf.Reader())
+		if err != nil {
+			return err
+		}
+		decodedBytes, err := fromBytes(b)
+		if err != nil {
+			return err
+		}
+		println(hex.Dump(decodedBytes))
 	}
 }
 
-func fromBytes(data []byte) []byte {
+func fromBytes(data []byte) ([]byte, error) {
 	var result []byte
-	plist.Unmarshal(data, &result)
-	return result
+	_, err := plist.Unmarshal(data, &result)
+	return result, err
 }

--- a/ios/plistcodec_test.go
+++ b/ios/plistcodec_test.go
@@ -29,7 +29,8 @@ func TestPlistCodec(t *testing.T) {
 			if *update {
 				err := ioutil.WriteFile(golden, []byte(actual), 0644)
 				if err != nil {
-					log.Fatal(err)
+					log.Error(err)
+					t.Fail()
 				}
 			}
 			expected, _ := ioutil.ReadFile(golden)

--- a/ios/readpairrecord.go
+++ b/ios/readpairrecord.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	plist "howett.net/plist"
 )
 
@@ -74,7 +73,8 @@ func PairRecordfromBytes(plistBytes []byte) PairRecord {
 	var data PairRecord
 	err := decoder.Decode(&data)
 	if err != nil {
-		log.Fatalf("Failed decoding pair record plist %x", plistBytes)
+		//this is unrecoverable and should not happen
+		panic(fmt.Sprintf("Failed decoding pair record plist %x", plistBytes))
 	}
 	return data
 }

--- a/ios/startservice.go
+++ b/ios/startservice.go
@@ -51,7 +51,10 @@ func (lockDownConn *LockDownConnection) StartService(serviceName string) (StartS
 //StartService conveniently starts a service on a device and cleans up the used UsbMuxconnection.
 //It returns the service port as a uint16 in BigEndian byte order.
 func StartService(device DeviceEntry, serviceName string) (StartServiceResponse, error) {
-	lockdown := ConnectLockdownWithSession(device)
+	lockdown, err := ConnectLockdownWithSession(device)
+	if err != nil {
+		return StartServiceResponse{}, err
+	}
 	defer lockdown.Close()
 	response, err := lockdown.StartService(serviceName)
 	if err != nil {

--- a/ios/syslog/syslog.go
+++ b/ios/syslog/syslog.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"io"
-	"log"
 
 	"github.com/danielpaulus/go-ios/ios"
 )
@@ -29,14 +28,13 @@ func New(device ios.DeviceEntry) (*Connection, error) {
 
 //ReadLogMessage this is a blocking function that will return individual log messages received from syslog.
 //Call it in an endless for loop in a separate go routine.
-func (sysLogConn *Connection) ReadLogMessage() string {
+func (sysLogConn *Connection) ReadLogMessage() (string, error) {
 	reader := sysLogConn.deviceConn.Reader()
 	logmsg, err := sysLogConn.Decode(reader)
 	if err != nil {
-		log.Fatal(err)
-		return ""
+		return "", err
 	}
-	return logmsg
+	return logmsg, nil
 }
 
 //Encode returns only and error because syslog is read only.

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -445,7 +445,11 @@ func startTestRunner12(pControl *instruments.ProcessControl, xctestConfigPath st
 }
 
 func setupXcuiTest(device ios.DeviceEntry, bundleID string, testRunnerBundleID string, xctestConfigFileName string) (uuid.UUID, semver.Version, string, nskeyedarchiver.XCTestConfiguration, testInfo, error) {
-	version := ios.GetValues(device).Value.ProductVersion
+	versionResp, err := ios.GetValues(device)
+	if err != nil {
+		return uuid.UUID{}, semver.Version{}, "", nskeyedarchiver.XCTestConfiguration{}, testInfo{}, err
+	}
+	version := versionResp.Value.ProductVersion
 	testSessionID := uuid.New()
 
 	v, err := semver.NewVersion(version)

--- a/ios/utils.go
+++ b/ios/utils.go
@@ -30,7 +30,8 @@ func ParsePlist(data []byte) (map[string]interface{}, error) {
 func ToPlistBytes(data interface{}) []byte {
 	bytes, err := plist.Marshal(data, plist.XMLFormat)
 	if err != nil {
-		log.Fatal("Failed converting to plist", data, err)
+		//this should not happen
+		panic(fmt.Sprintf("Failed converting to plist %v error:%v", data, err))
 	}
 	return bytes
 }

--- a/ios/utils_test.go
+++ b/ios/utils_test.go
@@ -43,7 +43,8 @@ func TestPlistConversion(t *testing.T) {
 		if *update {
 			err := ioutil.WriteFile(golden, []byte(actual), 0644)
 			if err != nil {
-				log.Fatal(err)
+				log.Error(err)
+				t.FailNow()
 			}
 		}
 		expected, _ := ioutil.ReadFile(golden)

--- a/main.go
+++ b/main.go
@@ -108,9 +108,7 @@ The commands work as following:
 
   `, version)
 	arguments, err := docopt.ParseDoc(usage)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitIfError("failed parsing args", err)
 	disableJSON, _ := arguments.Bool("--nojson")
 	if disableJSON {
 		JSONdisabled = true
@@ -157,15 +155,13 @@ The commands work as following:
 
 	udid, _ := arguments.String("--udid")
 	device, err := ios.GetDevice(udid)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitIfError("error getting devicelist", err)
 
 	b, _ = arguments.Bool("pcap")
 	if b {
 		err := pcap.Start(device)
 		if err != nil {
-			failWithError("pcap failed", err)
+			exitIfError("pcap failed", err)
 		}
 		return
 	}
@@ -264,13 +260,11 @@ The commands work as following:
 			log.Fatal("please provide a bundleID")
 		}
 		pControl, err := instruments.NewProcessControl(device)
-		if err != nil {
-			log.Fatal(err)
-		}
+		exitIfError("processcontrol failed", err)
+
 		pid, err := pControl.LaunchApp(bundleID)
-		if err != nil {
-			log.Fatal(err)
-		}
+		exitIfError("launch app command failed", err)
+
 		log.WithFields(log.Fields{"pid": pid}).Info("Process launched")
 	}
 
@@ -342,21 +336,16 @@ The commands work as following:
 
 func language(device ios.DeviceEntry, locale string, language string) {
 	lang, err := ios.GetLanguage(device)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitIfError("failed getting language", err)
+
 	err = ios.SetLanguage(device, ios.LanguageConfiguration{Language: language, Locale: locale})
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitIfError("failed setting language", err)
 	if lang.Language != language && language != "" {
 		log.Debugf("Language should be changed from %s to %s waiting for Springboard to reboot", lang.Language, language)
 		notificationproxy.WaitUntilSpringboardStarted(device)
 	}
 	lang, err = ios.GetLanguage(device)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitIfError("failed getting language", err)
 
 	fmt.Println(convertToJSONString(lang))
 }
@@ -364,16 +353,12 @@ func language(device ios.DeviceEntry, locale string, language string) {
 func startAx(device ios.DeviceEntry) {
 	go func() {
 		deviceList, err := ios.ListDevices()
-		if err != nil {
-			failWithError("failed converting to json", err)
-		}
+		exitIfError("failed converting to json", err)
 
 		device := deviceList.DeviceList[0]
 
 		conn, err := accessibility.New(device)
-		if err != nil {
-			log.Fatal(err)
-		}
+		exitIfError("failed starting ax", err)
 
 		conn.SwitchToDevice()
 
@@ -389,9 +374,7 @@ func startAx(device ios.DeviceEntry) {
 		//conn.GetElement()
 		//conn.GetElement()
 
-		if err != nil {
-			log.Fatal(err)
-		}
+		exitIfError("ax failed", err)
 	}()
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
@@ -444,19 +427,17 @@ func startForwarding(device ios.DeviceEntry, hostPort int, targetPort int) {
 func printDiagnostics(device ios.DeviceEntry) {
 	log.Debug("print diagnostics")
 	diagnosticsService, err := diagnostics.New(device)
-	if err != nil {
-		log.Fatalf("Starting diagnostics service failed with: %s", err)
-	}
+	exitIfError("Starting diagnostics service failed with", err)
+
 	values, err := diagnosticsService.AllValues()
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitIfError("getting valued failed", err)
+
 	fmt.Println(convertToJSONString(values))
 }
 
 func printDeviceDate(device ios.DeviceEntry) {
 	allValues, err := ios.GetValues(device)
-	failWithError("failed getting values", err)
+	exitIfError("failed getting values", err)
 
 	formatedDate := time.Unix(int64(allValues.Value.TimeIntervalSince1970), 0).Format(time.RFC850)
 	if JSONdisabled {
@@ -470,22 +451,20 @@ func printInstalledApps(device ios.DeviceEntry, system bool) {
 	svc, _ := installationproxy.New(device)
 	if !system {
 		response, err := svc.BrowseUserApps()
-		if err != nil {
-			log.Fatal(err)
-		}
+		exitIfError("browsing user apps failed", err)
+
 		log.Info(response)
 		return
 	}
 	response, err := svc.BrowseSystemApps()
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitIfError("browsing system apps failed", err)
+
 	log.Info(response)
 }
 
 func printDeviceName(device ios.DeviceEntry) {
 	allValues, err := ios.GetValues(device)
-	failWithError("failed getting values", err)
+	exitIfError("failed getting values", err)
 	if JSONdisabled {
 		println(allValues.Value.DeviceName)
 	} else {
@@ -498,22 +477,19 @@ func printDeviceName(device ios.DeviceEntry) {
 func saveScreenshot(device ios.DeviceEntry, outputPath string) {
 	log.Debug("take screenshot")
 	screenshotrService, err := screenshotr.New(device)
-	if err != nil {
-		log.Fatalf("Starting Screenshotr failed with: %s", err)
-	}
+	exitIfError("Starting Screenshotr failed with", err)
+
 	imageBytes, err := screenshotrService.TakeScreenshot()
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitIfError("screenshotr failed", err)
+
 	if outputPath == "" {
 		time := time.Now().Format("20060102150405")
 		path, _ := filepath.Abs("./screenshot" + time + ".png")
 		outputPath = path
 	}
 	err = ioutil.WriteFile(outputPath, imageBytes, 0777)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitIfError("write file failed", err)
+
 	if JSONdisabled {
 		println(outputPath)
 	} else {
@@ -525,7 +501,7 @@ func processList(device ios.DeviceEntry) {
 	service, err := instruments.NewDeviceInfoService(device)
 	defer service.Close()
 	if err != nil {
-		failWithError("failed opening deviceInfoService for getting process list", err)
+		exitIfError("failed opening deviceInfoService for getting process list", err)
 	}
 	processList, err := service.ProcessList()
 	println(convertToJSONString(processList))
@@ -534,7 +510,7 @@ func processList(device ios.DeviceEntry) {
 func printDeviceList(details bool) {
 	deviceList, err := ios.ListDevices()
 	if err != nil {
-		failWithError("failed getting device list", err)
+		exitIfError("failed getting device list", err)
 	}
 
 	if details {
@@ -564,7 +540,7 @@ func outputDetailedList(deviceList ios.DeviceList) {
 	for i, device := range deviceList.DeviceList {
 		udid := device.Properties.SerialNumber
 		allValues, err := ios.GetValues(device)
-		failWithError("failed getting values", err)
+		exitIfError("failed getting values", err)
 		result[i] = detailsEntry{udid, allValues.Value.ProductName, allValues.Value.ProductType, allValues.Value.ProductVersion}
 	}
 	fmt.Println(convertToJSONString(map[string][]detailsEntry{
@@ -576,7 +552,7 @@ func outputDetailedListNoJSON(deviceList ios.DeviceList) {
 	for _, device := range deviceList.DeviceList {
 		udid := device.Properties.SerialNumber
 		allValues, err := ios.GetValues(device)
-		failWithError("failed getting values", err)
+		exitIfError("failed getting values", err)
 		fmt.Printf("%s  %s  %s %s\n", udid, allValues.Value.ProductName, allValues.Value.ProductType, allValues.Value.ProductVersion)
 	}
 }
@@ -618,7 +594,7 @@ func startListening() {
 func printDeviceInfo(device ios.DeviceEntry) {
 	allValues, err := ios.GetValuesPlist(device)
 	if err != nil {
-		failWithError("failed getting info", err)
+		exitIfError("failed getting info", err)
 	}
 	fmt.Println(convertToJSONString(allValues))
 }
@@ -627,9 +603,8 @@ func runSyslog(device ios.DeviceEntry) {
 	log.Debug("Run Syslog.")
 
 	syslogConnection, err := syslog.New(device)
-	if err != nil {
-		log.Fatalf("Syslog connection failed, %s", err)
-	}
+	exitIfError("Syslog connection failed", err)
+
 	defer syslogConnection.Close()
 
 	go func() {
@@ -637,7 +612,7 @@ func runSyslog(device ios.DeviceEntry) {
 		for {
 			logMessage, err := syslogConnection.ReadLogMessage()
 			if err != nil {
-				failWithError("failed reading syslog", err)
+				exitIfError("failed reading syslog", err)
 			}
 			if JSONdisabled {
 				print(logMessage)
@@ -655,7 +630,7 @@ func runSyslog(device ios.DeviceEntry) {
 func pairDevice(device ios.DeviceEntry) {
 	err := ios.Pair(device)
 	if err != nil {
-		failWithError("Pairing failed", err)
+		exitIfError("Pairing failed", err)
 	} else {
 		log.Infof("Successfully paired %s", device.Properties.SerialNumber)
 	}
@@ -664,11 +639,11 @@ func pairDevice(device ios.DeviceEntry) {
 func readPair(device ios.DeviceEntry) {
 	record, err := ios.ReadPairRecord(device.Properties.SerialNumber)
 	if err != nil {
-		failWithError("failed reading pairrecord", err)
+		exitIfError("failed reading pairrecord", err)
 	}
 	json, err := json.Marshal(record)
 	if err != nil {
-		failWithError("failed converting to json", err)
+		exitIfError("failed converting to json", err)
 	}
 	fmt.Printf("%s", json)
 }
@@ -682,7 +657,7 @@ func convertToJSONString(data interface{}) string {
 	return string(b)
 }
 
-func failWithError(msg string, err error) {
+func exitIfError(msg string, err error) {
 	if err != nil {
 		log.WithFields(log.Fields{"err": err}).Fatalf(msg)
 	}

--- a/main.go
+++ b/main.go
@@ -163,7 +163,10 @@ The commands work as following:
 
 	b, _ = arguments.Bool("pcap")
 	if b {
-		pcap.Start(device)
+		err := pcap.Start(device)
+		if err != nil {
+			failWithError("pcap failed", err)
+		}
 		return
 	}
 
@@ -632,7 +635,10 @@ func runSyslog(device ios.DeviceEntry) {
 	go func() {
 		messageContainer := map[string]string{}
 		for {
-			logMessage := syslogConnection.ReadLogMessage()
+			logMessage, err := syslogConnection.ReadLogMessage()
+			if err != nil {
+				failWithError("failed reading syslog", err)
+			}
 			if JSONdisabled {
 				print(logMessage)
 			} else {

--- a/main.go
+++ b/main.go
@@ -452,7 +452,8 @@ func printDiagnostics(device ios.DeviceEntry) {
 }
 
 func printDeviceDate(device ios.DeviceEntry) {
-	allValues := ios.GetValues(device)
+	allValues, err := ios.GetValues(device)
+	failWithError("failed getting values", err)
 
 	formatedDate := time.Unix(int64(allValues.Value.TimeIntervalSince1970), 0).Format(time.RFC850)
 	if JSONdisabled {
@@ -480,7 +481,8 @@ func printInstalledApps(device ios.DeviceEntry, system bool) {
 }
 
 func printDeviceName(device ios.DeviceEntry) {
-	allValues := ios.GetValues(device)
+	allValues, err := ios.GetValues(device)
+	failWithError("failed getting values", err)
 	if JSONdisabled {
 		println(allValues.Value.DeviceName)
 	} else {
@@ -558,7 +560,8 @@ func outputDetailedList(deviceList ios.DeviceList) {
 	result := make([]detailsEntry, len(deviceList.DeviceList))
 	for i, device := range deviceList.DeviceList {
 		udid := device.Properties.SerialNumber
-		allValues := ios.GetValues(device)
+		allValues, err := ios.GetValues(device)
+		failWithError("failed getting values", err)
 		result[i] = detailsEntry{udid, allValues.Value.ProductName, allValues.Value.ProductType, allValues.Value.ProductVersion}
 	}
 	fmt.Println(convertToJSONString(map[string][]detailsEntry{
@@ -569,7 +572,8 @@ func outputDetailedList(deviceList ios.DeviceList) {
 func outputDetailedListNoJSON(deviceList ios.DeviceList) {
 	for _, device := range deviceList.DeviceList {
 		udid := device.Properties.SerialNumber
-		allValues := ios.GetValues(device)
+		allValues, err := ios.GetValues(device)
+		failWithError("failed getting values", err)
 		fmt.Printf("%s  %s  %s %s\n", udid, allValues.Value.ProductName, allValues.Value.ProductType, allValues.Value.ProductVersion)
 	}
 }
@@ -673,5 +677,7 @@ func convertToJSONString(data interface{}) string {
 }
 
 func failWithError(msg string, err error) {
-	log.WithFields(log.Fields{"err": err}).Fatalf(msg)
+	if err != nil {
+		log.WithFields(log.Fields{"err": err}).Fatalf(msg)
+	}
 }


### PR DESCRIPTION
In my first days of learning golang, I used log.Fatal everywhere. 
Now I have realized this makes go-ios really hard to use as a library as it will unexpectedly crash all the time instead of
returning proper errors. 