### PR TITLE
change TimeZoneOffsetFromUTC field of ios.AllValuesType from int to float64

### DIFF
--- a/ios/lockdown_value.go
+++ b/ios/lockdown_value.go
@@ -94,7 +94,7 @@ type AllValuesType struct {
 	TelephonyCapability                         bool
 	TimeIntervalSince1970                       float64
 	TimeZone                                    string
-	TimeZoneOffsetFromUTC                       int
+	TimeZoneOffsetFromUTC                       float64
 	TrustedHostAttached                         bool
 	UniqueChipID                                uint64
 	UniqueDeviceID                              string


### PR DESCRIPTION
the type of TimeZoneOffsetFromUTC in ios.AllValuesType is real, when it is declared as int, you get 0 every time, and when you use plist.Umarshal to deserialize it, it returns an error, so it should be changed to float64