### PR TITLE
change TimeZoneOffsetFromUTC field of ios.AllValuesType from int to float64

### DIFF
--- a/ios/lockdown_value.go
+++ b/ios/lockdown_value.go
@@ -94,7 +94,7 @@ type AllValuesType struct {
 	TelephonyCapability                         bool
 	TimeIntervalSince1970                       float64
 	TimeZone                                    string
-	TimeZoneOffsetFromUTC                       int
+	TimeZoneOffsetFromUTC                       float64
 	TrustedHostAttached                         bool
 	UniqueChipID                                uint64
 	UniqueDeviceID                              string


### PR DESCRIPTION
according to the raw plist, the type of TimeZoneOffsetFromUTC is real, and it should be umarshaled to float64, when declared  as int, the retrieved value will always be zero.