### PR TITLE
Change forward to listen on all interfaces

### DIFF
--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -18,7 +18,7 @@ type iosproxy struct {
 func Forward(device ios.DeviceEntry, hostPort uint16, phonePort uint16) error {
 
 	log.Infof("Start listening on port %d forwarding to port %d on device", hostPort, phonePort)
-	l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", hostPort))
+	l, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", hostPort))
 
 	go connectionAccept(l, device.DeviceID, phonePort)
 


### PR DESCRIPTION
Current forward configuration listens only to request from localhost.
This change allows us to access to the forwarded port from other origins.