### PR TITLE
fix: META-INF file exists bug

### DIFF
--- a/ios/utils.go
+++ b/ios/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	plist "howett.net/plist"
@@ -66,4 +67,17 @@ func GetDevice(udid string) (DeviceEntry, error) {
 		}
 	}
 	return DeviceEntry{}, fmt.Errorf("Device '%s' not found. Is it attached to the machine?", udid)
+}
+
+//It is used to determine whether the path folder exists
+//True if it exists, false otherwise
+func PathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }

--- a/ios/zipconduit/zipconduit_installer.go
+++ b/ios/zipconduit/zipconduit_installer.go
@@ -236,15 +236,18 @@ const metainfFileName = "com.apple.ZipMetadata.plist"
 
 func addMetaInf(metainfPath string, files []string, totalBytes uint64) (string, string, error) {
 	folderPath := path.Join(metainfPath, "META-INF")
-	err := os.Mkdir(folderPath, 0777)
-	if err != nil {
-		return "", "", err
+	ret, _ := ios.PathExists(folderPath)
+	if !ret {
+		err := os.Mkdir(folderPath, 0777)
+		if err != nil {
+			return "", "", err
+		}
 	}
 	//recordcount == files + meta-inf + metainffile
 	meta := metadata{RecordCount: 2 + len(files), StandardDirectoryPerms: 16877, StandardFilePerms: -32348, TotalUncompressedBytes: totalBytes, Version: 2}
 	metaBytes := ios.ToPlistBytes(meta)
 	filePath := path.Join(metainfPath, "META-INF", metainfFileName)
-	err = ioutil.WriteFile(filePath, metaBytes, 0777)
+	err := ioutil.WriteFile(filePath, metaBytes, 0777)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
**Bug Description:**
When i try to install a ipa file, i find if META-INF folder is included in the unzip IPA package. The following error messages will be generated.

"**{"err":"mkdir /var/folders/3_/fjr0f3dn58j22061qts7sssh0000gp/T/prefix693025361/META-INF: file exists","level":"fatal","msg":"failed writing","time":"2021-07-25T20:16:11+08:00"}**“

Therefore, i added code determine whether the folder exists before creating it.