### PR TITLE
Feature/device state

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,17 @@ Highlights:
 - use Accessibility Inspector APIs
 
 ```
+ Options:
+  -v --verbose   Enable Debug Logging.
+  -t --trace     Enable Trace Logging (dump every message).
+  --nojson       Disable JSON output (default).
+  -h --help      Show this screen.
+  --udid=<udid>  UDID of the device.
+
 The commands work as following:
-	The default output of all commands is JSON. Should you prefer human readable outout, specify the --nojson option with your command.
-	By default, the first device found will be used for a command unless you specify a --udid=some_udid switch.
-	Specify -v for debug logging and -t for dumping every message.
+        The default output of all commands is JSON. Should you prefer human readable outout, specify the --nojson option with your command. 
+        By default, the first device found will be used for a command unless you specify a --udid=some_udid switch.
+        Specify -v for debug logging and -t for dumping every message.
 
    ios listen [options]                                               Keeps a persistent connection open and notifies about newly connected or disconnected devices.
    ios list [options] [--details]                                     Prints a list of all connected device's udids. If --details is specified, it includes version, name and model of each device.
@@ -31,6 +38,9 @@ The commands work as following:
    ios screenshot [options] [--output=<outfile>]                      Takes a screenshot and writes it to the current dir or to <outfile>
    ios devicename [options]                                           Prints the devicename
    ios date [options]                                                 Prints the device date
+   ios devicestate list [options]                                     Prints a list of all supported device conditions, like slow network, gpu etc.
+   ios devicestate enable <profileTypeId> <profileId> [options]       Enables a profile with ids (use the list command to see options). It will only stay active until the process is terminated.
+   >                                                                  Ex. "ios devicestate enable SlowNetworkCondition SlowNetwork3GGood"
    ios lang [--setlocale=<locale>] [--setlang=<newlang>] [options]    Sets or gets the Device language
    ios diagnostics list [options]                                     List diagnostic infos
    ios pair [options]                                                 Pairs the device without a dialog for supervised devices
@@ -41,16 +51,18 @@ The commands work as following:
    >                                                                  Use "sudo launchctl unload -w /Library/Apple/System/Library/LaunchDaemons/com.apple.usbmuxd.plist"
    >                                                                  to stop usbmuxd and load to start it again should the proxy mess up things.
    >                                                                  The --binary flag will dump everything in raw binary without any decoding. 
-   ios readpair                                                       Dump detailed information about the pairrecord for a device.
+   ios readpair                                                       Dump detailed information about the pairrecord for a device.                                              Starts a pcap dump of network traffic
    ios install --path=<ipaOrAppFolder> [options]                      Specify a .app folder or an installable ipa file that will be installed.  
    ios pcap [options] [--pid=<processID>] [--process=<processName>]   Starts a pcap dump of network traffic, use --pid or --process to filter specific processes.
    ios apps [--system]                                                Retrieves a list of installed applications. --system prints out preinstalled system apps.
    ios launch <bundleID>                                              Launch app with the bundleID on the device. Get your bundle ID from the apps command.
+   ios kill <bundleID> [options]                                      Kill app with the bundleID on the device.
    ios runtest <bundleID>                                             Run a XCUITest. 
-   ios runwda [options]                                               Start WebDriverAgent.
+   ios runwda [options]                                               Start WebDriverAgent
    ios ax [options]                                                   Access accessibility inspector features. 
-   ios debug [--stop-at-entry] <app_path>                             Start debug with lldb.
+   ios debug [--stop-at-entry] <app_path>                             Start debug with lldb
    ios reboot [options]                                               Reboot the given device
    ios -h | --help                                                    Prints this screen.
-   ios --version | version [options]                                  Prints the version.
+   ios --version | version [options]                                  Prints the version
+
 ```

--- a/ios/instruments/devicestate.go
+++ b/ios/instruments/devicestate.go
@@ -3,7 +3,6 @@ package instruments
 import (
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
-	log "github.com/sirupsen/logrus"
 )
 
 const conditionInducerChannelName = "com.apple.instruments.server.services.ConditionInducer"
@@ -14,13 +13,9 @@ type DeviceStateControl struct {
 }
 
 func NewDeviceStateControl(device ios.DeviceEntry) (*DeviceStateControl, error) {
-	dtxConn, err := dtx.NewConnection(device, serviceName)
+	dtxConn, err := connectInstruments(device)
 	if err != nil {
-		log.Debugf("Failed connecting to %s, trying %s", serviceName, serviceNameiOS14)
-		dtxConn, err = dtx.NewConnection(device, serviceNameiOS14)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	conditionInducerChannel := dtxConn.RequestChannelIdentifier(conditionInducerChannelName, loggingDispatcher{dtxConn})
 	return &DeviceStateControl{controlChannel: conditionInducerChannel, conn: dtxConn}, nil

--- a/ios/instruments/devicestate.go
+++ b/ios/instruments/devicestate.go
@@ -1,0 +1,27 @@
+package instruments
+
+import (
+	"github.com/danielpaulus/go-ios/ios"
+	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
+	log "github.com/sirupsen/logrus"
+)
+
+const conditionInducerChannelName = "com.apple.instruments.server.services.ConditionInducer"
+
+type DeviceStateControl struct {
+	controlChannel *dtx.Channel
+	conn           *dtx.Connection
+}
+
+func NewDeviceStateControl(device ios.DeviceEntry) (*DeviceStateControl, error) {
+	dtxConn, err := dtx.NewConnection(device, serviceName)
+	if err != nil {
+		log.Debugf("Failed connecting to %s, trying %s", serviceName, serviceNameiOS14)
+		dtxConn, err = dtx.NewConnection(device, serviceNameiOS14)
+		if err != nil {
+			return nil, err
+		}
+	}
+	conditionInducerChannel := dtxConn.RequestChannelIdentifier(conditionInducerChannelName, loggingDispatcher{dtxConn})
+	return &DeviceStateControl{controlChannel: conditionInducerChannel, conn: dtxConn}, nil
+}

--- a/ios/instruments/devicestate.go
+++ b/ios/instruments/devicestate.go
@@ -1,6 +1,7 @@
 package instruments
 
 import (
+	"fmt"
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
 )
@@ -19,4 +20,86 @@ func NewDeviceStateControl(device ios.DeviceEntry) (*DeviceStateControl, error) 
 	}
 	conditionInducerChannel := dtxConn.RequestChannelIdentifier(conditionInducerChannelName, loggingDispatcher{dtxConn})
 	return &DeviceStateControl{controlChannel: conditionInducerChannel, conn: dtxConn}, nil
+}
+
+type ProfileType struct {
+	ActiveProfile  string
+	Identifier     string
+	ProfilesSorted bool
+	IsActive       bool
+	Name           string
+	IsDestructive  bool
+	IsInternal     bool
+	Profiles       []Profile
+}
+
+type Profile struct {
+	Description string
+	Identifier  string
+	Name        string
+}
+
+func (d DeviceStateControl) List() ([]ProfileType, error) {
+	const methodName = "availableConditionInducers"
+	response, err := d.controlChannel.MethodCall(methodName)
+	if err != nil {
+		return []ProfileType{}, err
+	}
+	profiles, err := decodeProfileTypes(response.Payload[0])
+	if err != nil {
+		return []ProfileType{}, err
+	}
+	return profiles, nil
+}
+
+func decodeProfileTypes(response interface{}) ([]ProfileType, error) {
+	profileTypeList, ok := response.([]interface{})
+	if !ok {
+		return []ProfileType{}, fmt.Errorf("invalid response: %+v", response)
+	}
+	result := make([]ProfileType, len(profileTypeList))
+	for i, rawProfile := range profileTypeList {
+		profileMap := rawProfile.(map[string]interface{})
+		profiles, err := decodeProfiles(profileMap)
+		if err != nil {
+			return []ProfileType{}, err
+		}
+		p := ProfileType{
+			ActiveProfile:  profileMap["activeProfile"].(string),
+			Identifier:     profileMap["identifier"].(string),
+			IsActive:       profileMap["isActive"].(bool),
+			IsDestructive:  profileMap["isDestructive"].(bool),
+			IsInternal:     profileMap["isInternal"].(bool),
+			Name:           profileMap["name"].(string),
+			ProfilesSorted: profileMap["profilesSorted"].(bool),
+			Profiles:       profiles,
+		}
+		result[i] = p
+	}
+	return result, nil
+}
+
+func decodeProfiles(profileMap map[string]interface{}) ([]Profile, error) {
+	profilesListRaw, ok := profileMap["profiles"]
+	if !ok {
+		return []Profile{}, fmt.Errorf("failed finding 'profiles' key in map: %+v", profileMap)
+	}
+	profilesList, ok := profilesListRaw.([]interface{})
+	if !ok {
+		return []Profile{}, fmt.Errorf("failed converting 'profiles' to list in map: %+v", profileMap)
+	}
+	result := make([]Profile, len(profilesList))
+	for i, profileRaw := range profilesList {
+		profile, ok := profileRaw.(map[string]interface{})
+		if !ok {
+			return []Profile{}, fmt.Errorf("invalid map: %+v", profileMap)
+		}
+		p := Profile{
+			Description: profile["description"].(string),
+			Identifier:  profile["identifier"].(string),
+			Name:        profile["name"].(string),
+		}
+		result[i] = p
+	}
+	return result, nil
 }

--- a/ios/instruments/devicestate.go
+++ b/ios/instruments/devicestate.go
@@ -23,7 +23,12 @@ func NewDeviceStateControl(device ios.DeviceEntry) (*DeviceStateControl, error) 
 	if err != nil {
 		return nil, err
 	}
-	conditionInducerChannel := dtxConn.RequestChannelIdentifier(conditionInducerChannelName, loggingDispatcher{dtxConn})
+	conditionInducerChannel := dtxConn.RequestChannelIdentifier(
+		conditionInducerChannelName,
+		loggingDispatcher{dtxConn},
+		//ThermalConditions tend to take a lot of time to enable, so we have to increase the timeout here.
+		dtx.WithTimeout(120),
+	)
 	return &DeviceStateControl{controlChannel: conditionInducerChannel, conn: dtxConn}, nil
 }
 

--- a/ios/instruments/devicestate.go
+++ b/ios/instruments/devicestate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
-	log "github.com/sirupsen/logrus"
 )
 
 const conditionInducerChannelName = "com.apple.instruments.server.services.ConditionInducer"
@@ -95,18 +94,26 @@ func (d DeviceStateControl) List() ([]ProfileType, error) {
 }
 
 func (d DeviceStateControl) Enable(pType ProfileType, profile Profile) error {
-	const selector = "enableConditionWithIdentifier:profileIdentifier:"
-	log.Infof("enabling profile: %s - %s", pType.Identifier, profile.Identifier)
-	response, err := d.controlChannel.MethodCall(selector, pType.Identifier, profile.Identifier)
-	log.Info(response)
+	response, err := d.controlChannel.MethodCall("enableConditionWithIdentifier:profileIdentifier:", pType.Identifier, profile.Identifier)
+	if err != nil {
+		return err
+	}
+	success, ok := response.Payload[0].(bool)
+	if !ok || !success {
+		return fmt.Errorf("failed enabling profile %+v", response)
+	}
 	return err
 }
 
 func (d DeviceStateControl) Disable(pType ProfileType) error {
-	const selector = "disableConditionWithIdentifier:"
-	log.Infof("disabling profiletype: %s", pType.Identifier)
-	response, err := d.controlChannel.MethodCall(selector, pType.Identifier)
-	log.Info(response)
+	response, err := d.controlChannel.MethodCall("disableConditionWithIdentifier:", pType.Identifier)
+	if err != nil {
+		return err
+	}
+	success, ok := response.Payload[0].(bool)
+	if !ok || !success {
+		return fmt.Errorf("failed enabling profile %+v", response)
+	}
 	return err
 }
 

--- a/ios/instruments/helper.go
+++ b/ios/instruments/helper.go
@@ -1,0 +1,31 @@
+package instruments
+
+import (
+	"github.com/danielpaulus/go-ios/ios"
+	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
+	log "github.com/sirupsen/logrus"
+)
+
+const serviceName string = "com.apple.instruments.remoteserver"
+const serviceNameiOS14 string = "com.apple.instruments.remoteserver.DVTSecureSocketProxy"
+
+type loggingDispatcher struct {
+	conn *dtx.Connection
+}
+
+func (p loggingDispatcher) Dispatch(m dtx.Message) {
+	dtx.SendAckIfNeeded(p.conn, m)
+	log.Debug(m)
+}
+
+func connectInstruments(device ios.DeviceEntry) (*dtx.Connection, error) {
+	dtxConn, err := dtx.NewConnection(device, serviceName)
+	if err != nil {
+		log.Debugf("Failed connecting to %s, trying %s", serviceName, serviceNameiOS14)
+		dtxConn, err = dtx.NewConnection(device, serviceNameiOS14)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dtxConn, nil
+}

--- a/ios/instruments/processcontrol.go
+++ b/ios/instruments/processcontrol.go
@@ -17,7 +17,7 @@ type ProcessControl struct {
 	conn                  *dtx.Connection
 }
 
-type processControlDispatcher struct {
+type loggingDispatcher struct {
 	conn *dtx.Connection
 }
 
@@ -33,7 +33,7 @@ func (p *ProcessControl) Close() {
 	p.conn.Close()
 }
 
-func (p processControlDispatcher) Dispatch(m dtx.Message) {
+func (p loggingDispatcher) Dispatch(m dtx.Message) {
 	dtx.SendAckIfNeeded(p.conn, m)
 	log.Debug(m)
 }
@@ -47,7 +47,7 @@ func NewProcessControl(device ios.DeviceEntry) (*ProcessControl, error) {
 			return nil, err
 		}
 	}
-	processControlChannel := dtxConn.RequestChannelIdentifier(processControlChannelName, processControlDispatcher{dtxConn})
+	processControlChannel := dtxConn.RequestChannelIdentifier(processControlChannelName, loggingDispatcher{dtxConn})
 	return &ProcessControl{processControlChannel: processControlChannel, conn: dtxConn}, nil
 }
 

--- a/ios/instruments/processlist.go
+++ b/ios/instruments/processlist.go
@@ -77,7 +77,7 @@ func NewDeviceInfoService(device ios.DeviceEntry) (*DeviceInfoService, error) {
 			return nil, err
 		}
 	}
-	processControlChannel := dtxConn.RequestChannelIdentifier(deviceInfoServiceName, processControlDispatcher{dtxConn})
+	processControlChannel := dtxConn.RequestChannelIdentifier(deviceInfoServiceName, loggingDispatcher{dtxConn})
 	return &DeviceInfoService{channel: processControlChannel, conn: dtxConn}, nil
 }
 

--- a/ios/instruments/processlist.go
+++ b/ios/instruments/processlist.go
@@ -6,7 +6,6 @@ import (
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
 	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
-	log "github.com/sirupsen/logrus"
 )
 
 const deviceInfoServiceName = "com.apple.instruments.server.services.deviceinfo"
@@ -22,15 +21,15 @@ type ProcessInfo struct {
 }
 
 //ProcessList returns a []ProcessInfo, one for each process running on the iOS device
-func (p DeviceInfoService) ProcessList() ([]ProcessInfo, error) {
-	resp, err := p.channel.MethodCall("runningProcesses")
+func (d DeviceInfoService) ProcessList() ([]ProcessInfo, error) {
+	resp, err := d.channel.MethodCall("runningProcesses")
 	result := mapToProcInfo(resp.Payload[0].([]interface{}))
 	return result, err
 }
 
 //NameForPid resolves a process name for a given pid
-func (p DeviceInfoService) NameForPid(pid uint64) error {
-	_, err := p.channel.MethodCall("execnameForPid:", pid)
+func (d DeviceInfoService) NameForPid(pid uint64) error {
+	_, err := d.channel.MethodCall("execnameForPid:", pid)
 	return err
 }
 
@@ -52,15 +51,6 @@ func mapToProcInfo(procList []interface{}) []ProcessInfo {
 	return result
 }
 
-type deviceInfoDispatcher struct {
-	conn *dtx.Connection
-}
-
-func (p deviceInfoDispatcher) Dispatch(m dtx.Message) {
-	dtx.SendAckIfNeeded(p.conn, m)
-	log.Debug(m)
-}
-
 //DeviceInfoService gives us access to retrieving process lists and resolving names for PIDs
 type DeviceInfoService struct {
 	channel *dtx.Channel
@@ -69,13 +59,9 @@ type DeviceInfoService struct {
 
 //NewDeviceInfoService creates a new DeviceInfoService for a given device
 func NewDeviceInfoService(device ios.DeviceEntry) (*DeviceInfoService, error) {
-	dtxConn, err := dtx.NewConnection(device, serviceName)
+	dtxConn, err := connectInstruments(device)
 	if err != nil {
-		log.Debugf("Failed connecting to %s, trying %s", serviceName, serviceNameiOS14)
-		dtxConn, err = dtx.NewConnection(device, serviceNameiOS14)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	processControlChannel := dtxConn.RequestChannelIdentifier(deviceInfoServiceName, loggingDispatcher{dtxConn})
 	return &DeviceInfoService{channel: processControlChannel, conn: dtxConn}, nil

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -483,16 +484,22 @@ func deviceState(device ios.DeviceEntry, list bool, enable bool, profileTypeId s
 }
 
 func outputPrettyStateList(types []instruments.ProfileType) {
-	s := ""
+	var buffer bytes.Buffer
 	for i, ptype := range types {
-		s += fmt.Sprintf("ProfileType %d\nName:%s\nisActive:%v\nIdentifier:%s\n\n", i, ptype.Name, ptype.IsActive, ptype.Identifier)
+		buffer.WriteString(
+			fmt.Sprintf("ProfileType %d\nName:%s\nisActive:%v\nIdentifier:%s\n\n",
+				i, ptype.Name, ptype.IsActive, ptype.Identifier,
+			),
+		)
 		for i, profile := range ptype.Profiles {
-			s += fmt.Sprintf("\tProfile %d:%s\n\tIdentifier:%s\n\t%s", i, profile.Name, profile.Identifier, profile.Description)
-			s += "\n\t------\n"
+			buffer.WriteString(fmt.Sprintf("\tProfile %d:%s\n\tIdentifier:%s\n\t%s",
+				i, profile.Name, profile.Identifier, profile.Description),
+			)
+			buffer.WriteString("\n\t------\n")
 		}
-		s += "\n\n"
+		buffer.WriteString("\n\n")
 	}
-	println(s)
+	println(buffer.String())
 }
 
 func fixDevImage(device ios.DeviceEntry, baseDir string) {

--- a/main.go
+++ b/main.go
@@ -100,6 +100,7 @@ The commands work as following:
    ios screenshot [options] [--output=<outfile>]                      Takes a screenshot and writes it to the current dir or to <outfile>
    ios devicename [options]                                           Prints the devicename
    ios date [options]                                                 Prints the device date
+   ios devicestate list [options]                                     Prints a list of all supported device conditions, like slow network, gpu etc. 
    ios lang [--setlocale=<locale>] [--setlang=<newlang>] [options]    Sets or gets the Device language
    ios diagnostics list [options]                                     List diagnostic infos
    ios pair [options]                                                 Pairs the device without a dialog for supervised devices

--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ The commands work as following:
    ios date [options]                                                 Prints the device date
    ios devicestate list [options]                                     Prints a list of all supported device conditions, like slow network, gpu etc.
    ios devicestate enable <profileTypeId> <profileId> [options]       Enables a profile with ids (use the list command to see options). It will only stay active until the process is terminated.
+   >                                                                  Ex. "ios devicestate enable SlowNetworkCondition SlowNetwork3GGood"
    ios lang [--setlocale=<locale>] [--setlang=<newlang>] [options]    Sets or gets the Device language
    ios diagnostics list [options]                                     List diagnostic infos
    ios pair [options]                                                 Pairs the device without a dialog for supervised devices

--- a/main.go
+++ b/main.go
@@ -471,7 +471,7 @@ func deviceState(device ios.DeviceEntry, list bool, enable bool, profileTypeId s
 		log.Info("Enabling profile.. (this can take a while for ThermalConditions)")
 		err = control.Enable(pType, profile)
 		exitIfError("could not enable profile", err)
-		log.Infof("Profile %s - %s is active! waiting for SIGTERM..", profileId, profileId)
+		log.Infof("Profile %s - %s is active! waiting for SIGTERM..", profileTypeId, profileId)
 		c := make(chan os.Signal, syscall.SIGTERM)
 		signal.Notify(c, os.Interrupt)
 		<-c


### PR DESCRIPTION
Add support for enabling device conditions like slow network, bad gpu performance, high thermal state.

You can list available profiles and profileTypes for a device using the following command:
`ios devicestate list --nojson` 
The --nojson flag includes pretty printing so it is human readable. 
Here is a shortened example output:
```
ProfileType 1
Name:Thermal State
isActive:false
Identifier:ThermalCondition

        Profile 0:Fair
        Identifier:ThermalFair
        The system behaves as though under slightly elevated thermal state
```

If you want to enable a profile use the type identifier and the profile identifier with the enable command like so:
`ios devicestate enable ThermalCondition ThermalSerious` 

It seems like only one profile can be active at once and will be automatically turned off when the connection ends. This is why the enable command is blocking and waits for a SIGTERM before it disables the profile again. 