### PR TITLE
remove exit on error if no images on device

### DIFF
--- a/main.go
+++ b/main.go
@@ -532,7 +532,6 @@ func mountImage(device ios.DeviceEntry, path string) {
 	conn, err := imagemounter.New(device)
 	exitIfError("failed connecting to image mounter", err)
 	signatures, err := conn.ListImages()
-	exitIfError("failed getting image list", err)
 	if len(signatures) != 0 {
 		log.Fatal("there is already a developer image mounted, reboot the device if you want to remove it. aborting.")
 	}


### PR DESCRIPTION
Honestly, this is my first line of Go ever and it's not even a line but a removal (:D) but this is a possible fix for this issue - https://github.com/danielpaulus/go-ios/issues/58. To me this specific 'exitIfError' is obsolete when trying to mount an image, you shouldn't exit if there are no images on the device, the purpose of the mount is to provide them :P With this line removed I was able to successfully mount an image on device that had no images and it also provides the log error on line 536 if there is an image on the device so I suppose it works as expected 