### PR TITLE
Adds XCTest integration test& multiple fixes to allow iOS 11 support and resolve bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.mobileprovision
 *.p12
+testdata/wda-signed.ipa
 devimages
 # Binaries for programs and plugins
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-wda.ipa
+*.mobileprovision
+*.p12
 devimages
 # Binaries for programs and plugins
 *.log

--- a/ios/deviceconnection.go
+++ b/ios/deviceconnection.go
@@ -56,14 +56,14 @@ func (conn *DeviceConnection) connectToSocketAddress(socketAddress string) error
 	if err != nil {
 		return err
 	}
-	log.Debug("Opening connection:", &c)
+	log.Tracef("Opening connection: %v", &c)
 	conn.c = c
 	return nil
 }
 
 //Close closes the network connection
 func (conn *DeviceConnection) Close() {
-	log.Debug("Closing connection:", &conn.c)
+	log.Tracef("Closing connection: %v", &conn.c)
 	conn.c.Close()
 }
 
@@ -193,7 +193,7 @@ func (conn *DeviceConnection) createClientTLSConn(pairRecord PairRecord) (*tls.C
 		return nil, err
 	}
 
-	log.Debug("enable session ssl on", &conn.c, " and wrap with tlsConn", &tlsConn)
+	log.Tracef("enable session ssl on %v and wrap with tlsConn: %v",&conn.c, &tlsConn)
 	return tlsConn, nil
 }
 
@@ -219,7 +219,7 @@ func (conn *DeviceConnection) createServerTLSConn(pairRecord PairRecord) (*tls.C
 		log.Info("Handshake error", err)
 		return nil, err
 	}
-	log.Debug("enable session ssl on", &conn.c, " and wrap with tlsConn", &tlsConn)
+	log.Tracef("enable session ssl on %v and wrap with tlsConn: %v",&conn.c, &tlsConn)
 	return tlsConn, nil
 }
 

--- a/ios/deviceconnection.go
+++ b/ios/deviceconnection.go
@@ -13,7 +13,7 @@ import (
 
 // DeviceConnectionInterface contains a physical network connection to a usbmuxd socket.
 type DeviceConnectionInterface interface {
-	Close()
+	Close() error
 	Send(message []byte) error
 	Reader() io.Reader
 	Writer() io.Writer
@@ -62,9 +62,9 @@ func (conn *DeviceConnection) connectToSocketAddress(socketAddress string) error
 }
 
 //Close closes the network connection
-func (conn *DeviceConnection) Close() {
+func (conn *DeviceConnection) Close() error{
 	log.Tracef("Closing connection: %v", &conn.c)
-	conn.c.Close()
+	return conn.c.Close()
 }
 
 //Send sends a message

--- a/ios/dtx_codec/channel.go
+++ b/ios/dtx_codec/channel.go
@@ -128,7 +128,7 @@ func (d *Channel) Dispatch(msg Message) {
 		d.messageIdentifier = msg.Identifier + 1
 	}
 	if msg.PayloadHeader.MessageType == Methodinvocation {
-		log.Debug("Dispatching:", msg.Payload[0].(string))
+		log.Trace("Dispatching:", msg.Payload[0].(string))
 		if v, ok := d.registeredMethods[msg.Payload[0].(string)]; ok {
 			d.mutex.Unlock()
 			v <- msg

--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -74,7 +74,7 @@ func (g GlobalDispatcher) Dispatch(msg Message) {
 			return
 		}
 	}
-	log.Debugf("Global Dispatcher Received: %s %s", msg.Payload, msg.Auxiliary)
+	log.Tracef("Global Dispatcher Received: %s %s", msg.Payload, msg.Auxiliary)
 	if msg.HasError() {
 		log.Error(msg.Payload[0])
 	}
@@ -139,7 +139,6 @@ func reader(dtxConn *Connection) {
 
 func SendAckIfNeeded(dtxConn *Connection, msg Message) {
 	if msg.ExpectsReply {
-		log.Debug("sending ack")
 		ack := BuildAckMessage(msg)
 		err := dtxConn.Send(ack)
 		if err != nil {

--- a/ios/imagemounter/imagedownloader.go
+++ b/ios/imagemounter/imagedownloader.go
@@ -22,7 +22,7 @@ var availableVersions = []string{"10.0", "10.1", "10.2", "10.3", "11.0", "11.1",
 
 const v12_2 = "12.2 (16E226)"
 
-func matchAvailable(version string) string {
+func MatchAvailable(version string) string {
 	log.Debugf("device version: %s ", version)
 	ver := semver.MustParse(version)
 	var bestMatch string
@@ -63,7 +63,8 @@ func DownloadImageFor(device ios.DeviceEntry, baseDir string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	version := matchAvailable(allValues.Value.ProductVersion)
+	version := MatchAvailable(allValues.Value.ProductVersion)
+	log.Infof("getting developer image for iOS %s", version)
 	imageDownloaded, err := validateBaseDirAndLookForImage(baseDir, version)
 	if err != nil {
 		return "", err
@@ -72,8 +73,6 @@ func DownloadImageFor(device ios.DeviceEntry, baseDir string) (string, error) {
 		log.Infof("%s already downloaded from https://github.com/haikieu/", imageDownloaded)
 		return imageDownloaded, nil
 	}
-
-	log.Infof("getting developer image for iOS %s", version)
 	downloadUrl := fmt.Sprintf(repo, version)
 	log.Infof("downloading from: %s", downloadUrl)
 	log.Info("thank you haikieu for making these images available :-)")

--- a/ios/imagemounter/imagedownloader.go
+++ b/ios/imagemounter/imagedownloader.go
@@ -51,7 +51,7 @@ func matchAvailable(version string) string {
 
 
 	}
-	log.Debugf("device version: %s bestMarch: %s", version, bestMatch)
+	log.Debugf("device version: %s bestMatch: %s", version, bestMatch)
 	if bestMatch == "12.2" {
 		return v12_2
 	}

--- a/ios/imagemounter/imagedownloader_test.go
+++ b/ios/imagemounter/imagedownloader_test.go
@@ -1,0 +1,13 @@
+package imagemounter_test
+
+import (
+	"github.com/danielpaulus/go-ios/ios/imagemounter"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestVersionMatching(t *testing.T) {
+	assert.Equal(t, "11.2", imagemounter.MatchAvailable("11.2.5"))
+	assert.Equal(t, "13.6", imagemounter.MatchAvailable("13.6.1"))
+	assert.Equal(t, "14.7", imagemounter.MatchAvailable("14.7.1"))
+}

--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -84,6 +84,7 @@ func (conn *Connection) ListImages() ([][]byte, error) {
 	return result, nil
 }
 
+//MountImage installs a .dmg image from imagePath after checking that it is present and valid.
 func (conn *Connection) MountImage(imagePath string) error {
 	signatureBytes, imageSize, err := validatePathAndLoadSignature(imagePath)
 	if err != nil {

--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -66,7 +66,7 @@ func (conn *Connection) ListImages() ([][]byte, error) {
 
 	signatures, ok := resp["ImageSignature"]
 	if !ok {
-		if conn.version.LessThan(semver.MustParse("14.0")) {
+		if conn.version.LessThan(ios.IOS14()) {
 			return [][]byte{}, nil
 		}
 		return nil, fmt.Errorf("invalid response: %+v", resp)

--- a/ios/listdevices_integration_test.go
+++ b/ios/listdevices_integration_test.go
@@ -1,12 +1,11 @@
+//go:build !fast
 // +build !fast
 
 package ios_test
 
 import (
 	"github.com/danielpaulus/go-ios/ios"
-	"github.com/stretchr/testify/assert"
-	"os/exec"
-	"strings"
+	"os"
 	"testing"
 )
 
@@ -16,13 +15,15 @@ func TestListDevices(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	outBytes, err := exec.Command("ioreg", "-p", "IOUSB", "-l", "-b").CombinedOutput()
-	usbDeviceDetails := string(outBytes)
-	assert.Greater(t, len(devices.DeviceList), 0, "at least one device should be connected")
-	for _, dev := range devices.DeviceList {
-		sn := dev.Properties.SerialNumber
-		sn = strings.Replace(sn, "-", "", 1)
-
-		assert.Contains(t, usbDeviceDetails, sn, "check that sn %s is connected")
+	udid := os.Getenv("udid")
+	if udid == "" {
+		t.Skip("warn no udid specified")
+		return
 	}
+	for _, device := range devices.DeviceList {
+		if device.Properties.SerialNumber == udid {
+			return
+		}
+	}
+	t.Errorf("device %s not found in list %+v", udid, devices.DeviceList)
 }

--- a/ios/plistcodec.go
+++ b/ios/plistcodec.go
@@ -25,7 +25,7 @@ func NewPlistCodec() PlistCodec {
 //followed by the plist as a string
 func (plistCodec PlistCodec) Encode(message interface{}) ([]byte, error) {
 	stringContent := ToPlist(message)
-	log.Debug("Lockdown send", reflect.TypeOf(message))
+	log.Tracef("Lockdown send %v", reflect.TypeOf(message))
 	buf := new(bytes.Buffer)
 	length := len(stringContent)
 	messageLength := uint32(length)

--- a/ios/screenshotr/screenshot_integration_test.go
+++ b/ios/screenshotr/screenshot_integration_test.go
@@ -7,14 +7,13 @@ import (
 	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/screenshotr"
 	"github.com/stretchr/testify/assert"
-	"os"
 	"testing"
 )
 
 const png uint32 = 0x89504E47
 
 func TestScreenshot(t *testing.T) {
-	device, err := ios.GetDevice(os.Getenv("udid"))
+	device, err := ios.GetDevice("")
 	if err != nil {
 		t.Error(err)
 		return

--- a/ios/syslog/syslog_integration_test.go
+++ b/ios/syslog/syslog_integration_test.go
@@ -8,12 +8,11 @@ import (
 	"github.com/danielpaulus/go-ios/ios/syslog"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"os"
 	"testing"
 )
 
 func TestSyslog(t *testing.T) {
-	device, err := ios.GetDevice(os.Getenv("udid"))
+	device, err := ios.GetDevice("")
 	if err != nil {
 		t.Error(err)
 		return

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -193,7 +193,7 @@ func (p ProxyDispatcher) Dispatch(m dtx.Message) {
 	if shouldAck {
 		dtx.SendAckIfNeeded(p.dtxConnection, m)
 	}
-	log.Debugf("dispatcher received: %s", m.String())
+	log.Tracef("dispatcher received: %s", m.String())
 }
 
 func newDtxProxy(dtxConnection *dtx.Connection) dtxproxy {
@@ -471,23 +471,28 @@ func startTestRunner12(pControl *instruments.ProcessControl, xctestConfigPath st
 func setupXcuiTest(device ios.DeviceEntry, bundleID string, testRunnerBundleID string, xctestConfigFileName string) (uuid.UUID, string, nskeyedarchiver.XCTestConfiguration, testInfo, error) {
 	testSessionID := uuid.New()
 	installationProxy, err := installationproxy.New(device)
-	defer installationProxy.Close()
 	if err != nil {
 		return uuid.UUID{}, "", nskeyedarchiver.XCTestConfiguration{}, testInfo{}, err
 	}
+	defer installationProxy.Close()
+
 	apps, err := installationProxy.BrowseUserApps()
 	if err != nil {
 		return uuid.UUID{}, "", nskeyedarchiver.XCTestConfiguration{}, testInfo{}, err
 	}
+
 	info, err := getAppInfos(bundleID, testRunnerBundleID, apps)
 	if err != nil {
 		return uuid.UUID{}, "", nskeyedarchiver.XCTestConfiguration{}, testInfo{}, err
 	}
+	log.Debugf("app info found: %+v", info)
+
 	houseArrestService, err := house_arrest.New(device, testRunnerBundleID)
 	defer houseArrestService.Close()
 	if err != nil {
 		return uuid.UUID{}, "", nskeyedarchiver.XCTestConfiguration{}, testInfo{}, err
 	}
+	log.Debugf("creating test config")
 	testConfigPath, testConfig, err := createTestConfigOnDevice(testSessionID, info, houseArrestService, xctestConfigFileName)
 	if err != nil {
 		return uuid.UUID{}, "", nskeyedarchiver.XCTestConfiguration{}, testInfo{}, err

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -319,17 +319,21 @@ func RunXCUIWithBundleIds(
 	if err != nil {
 		return err
 	}
-	log.Debugf("%v",version)
-	/*if version.LessThan(ios.IOS12()) {
+	log.Debugf("%v", version)
+	if version.LessThan(ios.IOS12()) {
+		log.Infof("iOS version: %s detected, running with ios11 support", version)
 		return RunXCUIWithBundleIds11(bundleID, testRunnerBundleID, xctestConfigFileName, device, wdaargs, wdaenv)
-	}*/
-	conn, err := dtx.NewConnection(device, testmanagerdiOS14)
-	if err == nil {
+	}
+
+	if version.Major() == 14 {
+		conn, err := dtx.NewConnection(device, testmanagerdiOS14)
+		if err != nil {
+			return err
+		}
 		return runXUITestWithBundleIdsXcode12(bundleID, testRunnerBundleID, xctestConfigFileName, device, conn, wdaargs, wdaenv)
 	}
-	log.Debugf("Failed connecting to %s with %v, trying %s", testmanagerdiOS14, err, testmanagerd)
 
-	conn, err = dtx.NewConnection(device, testmanagerd)
+	conn, err := dtx.NewConnection(device, testmanagerd)
 	if err != nil {
 		return err
 	}
@@ -363,8 +367,6 @@ func RunXCUIWithBundleIds(
 	ideDaemonProxy2.ideInterface.testConfig = testConfig
 
 	//log.Debug(caps)
-
-
 
 	pControl, err := instruments.NewProcessControl(device)
 	if err != nil {

--- a/ios/testmanagerd/xcuitestrunner_11.go
+++ b/ios/testmanagerd/xcuitestrunner_11.go
@@ -19,6 +19,7 @@ func RunXCUIWithBundleIds11(
 	if err != nil {
 		return err
 	}
+	log.Debugf("test session setup ok")
 	conn, err := dtx.NewConnection(device, testmanagerd)
 	defer conn.Close()
 	ideDaemonProxy := newDtxProxyWithConfig(conn, testConfig)

--- a/ios/testmanagerd/xcuitestrunner_11.go
+++ b/ios/testmanagerd/xcuitestrunner_11.go
@@ -1,0 +1,111 @@
+package testmanagerd
+
+import (
+	"github.com/danielpaulus/go-ios/ios"
+	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
+	"github.com/danielpaulus/go-ios/ios/instruments"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+func RunXCUIWithBundleIds11(
+	bundleID string,
+	testRunnerBundleID string,
+	xctestConfigFileName string,
+	device ios.DeviceEntry,
+	args []string,
+	env []string) error {
+	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName)
+	if err != nil {
+		return err
+	}
+	conn, err := dtx.NewConnection(device, testmanagerd)
+	defer conn.Close()
+	ideDaemonProxy := newDtxProxyWithConfig(conn, testConfig)
+
+	conn2, err := dtx.NewConnection(device, testmanagerd)
+	if err != nil {
+		return err
+	}
+	defer conn2.Close()
+	log.Debug("connections ready")
+	ideDaemonProxy2 := newDtxProxyWithConfig(conn2, testConfig)
+	ideDaemonProxy2.ideInterface.testConfig = testConfig
+	//TODO: fixme
+	protocolVersion := uint64(25)
+	_, err = ideDaemonProxy.daemonConnection.initiateSessionWithIdentifier(testSessionId, protocolVersion)
+	if err != nil {
+		return err
+	}
+
+	pControl, err := instruments.NewProcessControl(device)
+	if err != nil {
+		return err
+	}
+	defer pControl.Close()
+
+	pid, err := startTestRunner11(pControl, xctestConfigPath, testRunnerBundleID, testSessionId.String(), testInfo.testrunnerAppPath+"/PlugIns/"+xctestConfigFileName, args, env)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Runner started with pid:%d, waiting for testBundleReady", pid)
+
+	//protVersion, minimalVersion := ideDaemonProxy.ideInterface.
+	//log.Debugf("prot:%d min:%d", protVersion, minimalVersion)
+	err = ideDaemonProxy2.daemonConnection.initiateControlSession(pid, protocolVersion)
+	if err != nil {
+		return err
+	}
+
+	ideInterfaceChannel := ideDaemonProxy2.dtxConnection.ForChannelRequest(ProxyDispatcher{id: "emty"})
+
+
+
+	err = ideDaemonProxy2.daemonConnection.startExecutingTestPlanWithProtocolVersion(ideInterfaceChannel, 25)
+	if err != nil {
+		log.Error(err)
+	}
+	<-closeChan
+	log.Infof("Killing WebDriverAgent with pid %d ...", pid)
+	err = pControl.KillProcess(pid)
+	if err != nil {
+		return err
+	}
+	log.Info("WDA killed with success")
+	var signal interface{}
+	closedChan <- signal
+	return nil
+}
+
+
+func startTestRunner11(pControl *instruments.ProcessControl, xctestConfigPath string, bundleID string,
+	sessionIdentifier string, testBundlePath string, wdaargs []string, wdaenv []string) (uint64, error) {
+	args := []interface{}{
+
+	}
+	for _, arg := range wdaargs {
+		args = append(args, arg)
+	}
+	env := map[string]interface{}{
+
+		"XCTestBundlePath":                testBundlePath,
+		"XCTestConfigurationFilePath":     xctestConfigPath,
+		"XCTestSessionIdentifier":         sessionIdentifier,
+	}
+
+	for _, entrystring := range wdaenv {
+		entry := strings.Split(entrystring, "=")
+		key := entry[0]
+		value := entry[1]
+		env[key] = value
+		log.Debugf("adding extra env %s=%s", key, value)
+	}
+
+	opts := map[string]interface{}{
+		"StartSuspendedKey": uint64(0),
+		"ActivateSuspended": uint64(1),
+	}
+
+	return pControl.StartProcess(bundleID, env, args, opts)
+
+}

--- a/ios/testmanagerd/xcuitestrunner_test.go
+++ b/ios/testmanagerd/xcuitestrunner_test.go
@@ -63,7 +63,7 @@ func TestXcuiTest(t *testing.T) {
 	pollLogs(hook, wdaStarted)
 
 	select {
-	case <-time.After(time.Second * 5):
+	case <-time.After(time.Second * 50):
 		t.Error("timeout")
 		return
 	case <-wdaStarted:

--- a/ios/testmanagerd/xcuitestrunner_test.go
+++ b/ios/testmanagerd/xcuitestrunner_test.go
@@ -28,6 +28,7 @@ const bundleId = "com.facebook.WebDriverAgentRunner.xctrunner"
 
 func TestXcuiTest(t *testing.T) {
 	hook := test.NewGlobal()
+	log.SetLevel(log.DebugLevel)
 
 	device, err := ios.GetDevice("")
 	if err != nil {

--- a/ios/testmanagerd/xcuitestrunner_test.go
+++ b/ios/testmanagerd/xcuitestrunner_test.go
@@ -1,7 +1,124 @@
+//go:build !fast
+// +build !fast
+
 package testmanagerd_test
 
-import "testing"
+import (
+	"fmt"
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/imagemounter"
+	"github.com/danielpaulus/go-ios/ios/installationproxy"
+	"github.com/danielpaulus/go-ios/ios/testmanagerd"
+	"github.com/danielpaulus/go-ios/ios/zipconduit"
+	log "github.com/sirupsen/logrus"
+	stdlog "log"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+const wdapath = "../../testdata/wda.ipa"
+const wdaSignedPath = "../../testdata/wda-signed.ipa"
+
+const signerPath = "../../testdata/app-signer-mac"
+
+const wdaSuccessLogMessage = "ServerURLHere->"
 
 func TestXcuiTest(t *testing.T) {
+	patchLogger()
+	device, err := ios.GetDevice("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = imagemounter.FixDevImage(device, ".")
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
+	err = signAndInstall(device)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	bundleID, testbundleID, xctestconfig := "com.facebook.WebDriverAgentRunner.xctrunner", "com.facebook.WebDriverAgentRunner.xctrunner", "WebDriverAgentRunner.xctest"
+	var wdaargs []string
+	var wdaenv []string
+	go func() {
+		err := testmanagerd.RunXCUIWithBundleIds(bundleID, testbundleID, xctestconfig, device, wdaargs, wdaenv)
+
+		if err != nil {
+			log.WithFields(log.Fields{"error": err}).Fatal("Failed running WDA")
+		}
+	}()
+	select {
+	case <-time.After(time.Second * 5):
+		t.Error("timeout")
+		return
+	case <-successChannel:
+		log.Info("wda started successfully")
+	}
+
+	log.Infof("done")
+
+	err = testmanagerd.CloseXCUITestRunner()
+	if err != nil {
+		log.Error("Failed closing wda-testrunner")
+		t.Fail()
+	}
+}
+
+func signAndInstall(device ios.DeviceEntry) error {
+	svc, _ := installationproxy.New(device)
+	response, err := svc.BrowseUserApps()
+	for _, info := range response {
+		if "com.facebook.WebDriverAgentRunner.xctrunner" == info.CFBundleIdentifier {
+			log.Info("wda installed, skipping installation")
+			return nil
+		}
+	}
+
+	err = SignWda(device)
+	if err != nil {
+		return err
+	}
+	conn, err := zipconduit.New(device)
+	if err != nil {
+		return err
+	}
+	return conn.SendFile(wdaSignedPath)
+}
+
+func SignWda(device ios.DeviceEntry) error {
+	cmd := exec.Command(signerPath,
+		fmt.Sprintf("--udid=%s", device.Properties.SerialNumber),
+		"--p12password=a",
+		"--profilespath=../../testdata",
+		fmt.Sprintf("--ipa=%s", wdapath),
+		fmt.Sprintf("--output=%s", wdaSignedPath),
+	)
+	_, err := cmd.CombinedOutput()
+	return err
+}
+
+func patchLogger() {
+	successChannel = make(chan bool, 2)
+	//log.SetLevel(log.DebugLevel)
+	stdlog.SetOutput(new(LogrusWriter))
+}
+
+type LogrusWriter int
+
+var successChannel chan bool
+
+func (LogrusWriter) Write(data []byte) (int, error) {
+	logmessage := string(data)
+	if strings.Contains(logmessage, wdaSuccessLogMessage) {
+		successChannel <- true
+		return len(data), nil
+	}
+	log.Infof("gousb_logs:%s", logmessage)
+	return len(data), nil
 }

--- a/ios/testmanagerd/xcuitestrunner_test.go
+++ b/ios/testmanagerd/xcuitestrunner_test.go
@@ -1,0 +1,7 @@
+package testmanagerd_test
+
+import "testing"
+
+func TestXcuiTest(t *testing.T) {
+
+}

--- a/ios/usbmuxconnection.go
+++ b/ios/usbmuxconnection.go
@@ -3,10 +3,9 @@ package ios
 import (
 	"encoding/binary"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"io"
 	"reflect"
-
-	log "github.com/sirupsen/logrus"
 )
 
 //DefaultUsbmuxdSocket this is the unix domain socket address to connect to.
@@ -107,7 +106,7 @@ func (muxConn *UsbMuxConnection) ReadMessage() (UsbMuxMessage, error) {
 
 //encode serializes a MuxMessage struct to a Plist and writes it to the io.Writer.
 func (muxConn *UsbMuxConnection) encode(message interface{}, writer io.Writer) error {
-	log.Debug("UsbMux send", reflect.TypeOf(message), " on ", &muxConn.deviceConn)
+	log.Tracef("UsbMux send %v  on  %v", reflect.TypeOf(message), &muxConn.deviceConn)
 	mbytes := ToPlistBytes(message)
 	err := writeHeader(len(mbytes), muxConn.tag, writer)
 	if err != nil {
@@ -137,7 +136,7 @@ func (muxConn UsbMuxConnection) decode(r io.Reader) (UsbMuxMessage, error) {
 	if err != nil {
 		return UsbMuxMessage{}, fmt.Errorf("Error '%s' while reading usbmux package. Only %d bytes received instead of %d", err.Error(), n, muxHeader.Length-16)
 	}
-	log.Debug("UsbMux Receive on ", &muxConn.deviceConn)
+	log.Tracef("UsbMux Receive on %v", &muxConn.deviceConn)
 
 	return UsbMuxMessage{muxHeader, payloadBytes}, nil
 }

--- a/ios/usbmuxconnection_test.go
+++ b/ios/usbmuxconnection_test.go
@@ -96,8 +96,9 @@ type DeviceConnectionMock struct {
 	mock.Mock
 }
 
-func (mock *DeviceConnectionMock) Close() {
+func (mock *DeviceConnectionMock) Close() error{
 	mock.Called()
+	return nil
 }
 func (mock *DeviceConnectionMock) Send(message []byte) error {
 	args := mock.Called(message)

--- a/ios/utils.go
+++ b/ios/utils.go
@@ -80,7 +80,7 @@ func GetDevice(udid string) (DeviceEntry, error) {
 	return DeviceEntry{}, fmt.Errorf("Device '%s' not found. Is it attached to the machine?", udid)
 }
 
-//It is used to determine whether the path folder exists
+//PathExists is used to determine whether the path folder exists
 //True if it exists, false otherwise
 func PathExists(path string) (bool, error) {
 	_, err := os.Stat(path)

--- a/ios/utils.go
+++ b/ios/utils.go
@@ -48,8 +48,17 @@ func Ntohs(port uint16) uint16 {
 	return binary.LittleEndian.Uint16(buf)
 }
 
-//GetDevice returns the device for udid. If udid equals emptystring, it returns the first device in the list.
+//GetDevice returns:
+// the device for the udid if a valid udid is provided.
+// if the env variable 'udid' is specified, the device with that udid
+// otherwise it returns the first device in the list.
 func GetDevice(udid string) (DeviceEntry, error) {
+	if udid == "" {
+		udid = os.Getenv("udid")
+		if udid != "" {
+			log.Info("using udid from env.udid variable")
+		}
+	}
 	log.Debugf("Looking for device '%s'", udid)
 	deviceList, err := ListDevices()
 	if err != nil {
@@ -59,7 +68,8 @@ func GetDevice(udid string) (DeviceEntry, error) {
 		if len(deviceList.DeviceList) == 0 {
 			return DeviceEntry{}, errors.New("no iOS devices are attached to this host")
 		}
-		log.WithFields(log.Fields{"udid": deviceList.DeviceList[0].Properties.SerialNumber}).Debug("no udid specified using default")
+		log.WithFields(log.Fields{"udid": deviceList.DeviceList[0].Properties.SerialNumber}).
+			Info("no udid specified using first device in list")
 		return deviceList.DeviceList[0], nil
 	}
 	for _, device := range deviceList.DeviceList {

--- a/ios/utils.go
+++ b/ios/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/Masterminds/semver"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -80,4 +81,14 @@ func PathExists(path string) (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+//IOS14 semver.MustParse("14.0")
+func IOS14() *semver.Version {
+	return semver.MustParse("14.0")
+}
+
+//IOS12 semver.MustParse("12.0")
+func IOS12() *semver.Version {
+	return semver.MustParse("12.0")
 }

--- a/ios/zipconduit/zipconduit_installer.go
+++ b/ios/zipconduit/zipconduit_installer.go
@@ -78,8 +78,7 @@ func (conn Connection) SendFile(appFilePath string) error {
 }
 
 func (conn Connection) Close() error {
-	conn.deviceConn.Close()
-	return nil
+	return conn.deviceConn.Close()
 }
 
 func (conn Connection) sendDirectory(dir string) error {

--- a/ios/zipconduit/zipconduit_installer.go
+++ b/ios/zipconduit/zipconduit_installer.go
@@ -76,6 +76,12 @@ func (conn Connection) SendFile(appFilePath string) error {
 	}
 	return conn.sendIpaFile(appFilePath)
 }
+
+func (conn Connection) Close() error {
+	conn.deviceConn.Close()
+	return nil
+}
+
 func (conn Connection) sendDirectory(dir string) error {
 	tmpDir, err := ioutil.TempDir("", "prefix")
 	if err != nil {


### PR DESCRIPTION
- Hopefully fixes #85  #78  and #68 
- Adds support for iOS 11
- Some refactoring
- Adds an integration test for running webdriveragent
- move super verbose logs to trace level
- go-ios supports specifying a device udid with an env variable "udid" now
- tested everything on iOS 11.2.5, 13.6.1, 14.7.1 and 15.1.1
- DeviceConnection interface now returns an error as it should
- zipconduit installer can close the connection now
- added nice little unit test for auto dev image downloader