### PR TITLE
Add ability to make IORegEntry request

### DIFF
--- a/ios/diagnostics/diagnostics.go
+++ b/ios/diagnostics/diagnostics.go
@@ -2,6 +2,7 @@ package diagnostics
 
 import (
 	"fmt"
+
 	ios "github.com/danielpaulus/go-ios/ios"
 )
 
@@ -53,31 +54,14 @@ func (diagnosticsConn *Connection) Reboot() error {
 	}
 	if val, ok := plist["Status"]; ok {
 		if statusString, yes := val.(string); yes {
-			if "Success" == statusString {
+			if statusString == "Success" {
 				return nil
 			}
 
 		}
 
 	}
-	return fmt.Errorf("Could not reboot, response: %+v", plist)
-}
-
-func (diagnosticsConn *Connection) MobileGestaltQuery(keys []string) (interface{}, error) {
-	err := diagnosticsConn.deviceConn.Send(gestaltRequest(keys))
-	if err != nil {
-		return "", err
-	}
-	respBytes, err := diagnosticsConn.plistCodec.Decode(diagnosticsConn.deviceConn.Reader())
-	if err != nil {
-		return "", err
-	}
-	err = diagnosticsConn.deviceConn.Send(goodBye())
-	if err != nil {
-		return "", err
-	}
-	plist, err := ios.ParsePlist(respBytes)
-	return plist, err
+	return fmt.Errorf("could not reboot, response: %+v", plist)
 }
 
 func (diagnosticsConn *Connection) AllValues() (allDiagnosticsResponse, error) {

--- a/ios/diagnostics/ioregistry.go
+++ b/ios/diagnostics/ioregistry.go
@@ -1,0 +1,28 @@
+package diagnostics
+
+import ios "github.com/danielpaulus/go-ios/ios"
+
+func ioregentryRequest(key string) []byte {
+	requestMap := map[string]interface{}{
+		"Request":   "IORegistry",
+		"EntryName": key,
+	}
+	bt, err := ios.PlistCodec{}.Encode(requestMap)
+	if err != nil {
+		panic("query request encoding should never fail")
+	}
+	return bt
+}
+
+func (diagnosticsConn *Connection) IORegEntryQuery(key string) (interface{}, error) {
+	err := diagnosticsConn.deviceConn.Send(ioregentryRequest(key))
+	if err != nil {
+		return "", err
+	}
+	respBytes, err := diagnosticsConn.plistCodec.Decode(diagnosticsConn.deviceConn.Reader())
+	if err != nil {
+		return "", err
+	}
+	plist, err := ios.ParsePlist(respBytes)
+	return plist, err
+}

--- a/ios/diagnostics/mobilegestalt.go
+++ b/ios/diagnostics/mobilegestalt.go
@@ -1,0 +1,28 @@
+package diagnostics
+
+import ios "github.com/danielpaulus/go-ios/ios"
+
+func gestaltRequest(keys []string) []byte {
+	goodbyeMap := map[string]interface{}{
+		"Request":           "MobileGestalt",
+		"MobileGestaltKeys": keys,
+	}
+	bt, err := ios.PlistCodec{}.Encode(goodbyeMap)
+	if err != nil {
+		panic("gestalt request encoding should never fail")
+	}
+	return bt
+}
+
+func (diagnosticsConn *Connection) MobileGestaltQuery(keys []string) (interface{}, error) {
+	err := diagnosticsConn.deviceConn.Send(gestaltRequest(keys))
+	if err != nil {
+		return "", err
+	}
+	respBytes, err := diagnosticsConn.plistCodec.Decode(diagnosticsConn.deviceConn.Reader())
+	if err != nil {
+		return "", err
+	}
+	plist, err := ios.ParsePlist(respBytes)
+	return plist, err
+}

--- a/ios/diagnostics/request.go
+++ b/ios/diagnostics/request.go
@@ -2,36 +2,12 @@ package diagnostics
 
 import (
 	"bytes"
-	"github.com/danielpaulus/go-ios/ios"
 
 	plist "howett.net/plist"
 )
 
 type diagnosticsRequest struct {
 	Request string
-}
-
-func gestaltRequest(keys []string) []byte {
-	goodbyeMap := map[string]interface{}{
-		"Request":           "MobileGestalt",
-		"MobileGestaltKeys": keys,
-	}
-	bt, err := ios.PlistCodec{}.Encode(goodbyeMap)
-	if err != nil {
-		panic("gestalt request encoding should never fail")
-	}
-	return bt
-}
-
-func goodBye() []byte {
-	goodbyeMap := map[string]interface{}{
-		"Request": "Goodbye",
-	}
-	bt, err := ios.PlistCodec{}.Encode(goodbyeMap)
-	if err != nil {
-		panic("goodbye request encoding should never fail")
-	}
-	return bt
 }
 
 func diagnosticsfromBytes(plistBytes []byte) allDiagnosticsResponse {
@@ -52,23 +28,28 @@ type allDiagnosticsResponse struct {
 	Diagnostics Diagnostics
 	Status      string
 }
+
 type Diagnostics struct {
 	GasGauge GasGauge
 	HDMI     HDMI
 	NAND     NAND
 	WiFi     WiFi
 }
+
 type WiFi struct {
 	Active string
 	Status string
 }
+
 type NAND struct {
 	Status string
 }
+
 type HDMI struct {
 	Connection string
 	Status     string
 }
+
 type GasGauge struct {
 	CycleCount         uint64
 	DesignCapacity     uint64


### PR DESCRIPTION
Signed-off-by: Ali Yousuf <aly.yousuf7@gmail.com>

This does 3 things:
- Move `MobileGestalt` to its own file to separate the concern, including its request payload.
- It removes sending `goodBye()` message request, otherwise you cannot reuse the Diagnostics connection to make another request. User can use `defer diagnosticsConn.Close()` to close the connection it manually.
- Adds query function for `IORegEntry` request from diagnostics, which returns very useful data, such as Battery information with `AppleSmartBattery` as `key`.