### PR TITLE
pass the xctest config path for ios 14+

### DIFF
--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -378,7 +378,7 @@ func startTestRunner12(pControl *instruments.ProcessControl, xctestConfigPath st
 		"OS_ACTIVITY_DT_MODE":             "YES",
 		"SQLITE_ENABLE_THREAD_ASSERTIONS": "1",
 		"XCTestBundlePath":                testBundlePath,
-		"XCTestConfigurationFilePath":     "",
+		"XCTestConfigurationFilePath":     xctestConfigPath,
 		"XCTestSessionIdentifier":         sessionIdentifier,
 	}
 


### PR DESCRIPTION
startTestRunner12 does not set the XCTestConfigurationFilePath to a valid value when `--xctestconfig` is used with the `runwda` command. This leads to the following error
```
{"level":"info","msg":"2022-01-11 16:05:58.758140-0800 WebDriverAgentRunner-Runner[80932:41383367] Unable to load configuration data from specified path /; error: The file “System” couldn’t be opened because you don’t have permission to view it.\n","time":"2022-01-11T16:05:58-08:00"}
```

I was launching wda like so
```
$ ./go-ios runwda --udid=$udid --bundleid=com.apple.test.WebDriverAgentRunner-Runner --testrunnerbundleid=com.apple.test.WebDriverAgentRunner-Runner --xctestconfig=WebDriverAgentRunner.xctest
```
rather than using the default com.facebook.WebDriverAgentRunner bundle id.

This PR passes in the xctest config file as an environment variable to wda. I think I saw the default com.facebook.WebDriverAgentRunner app start up correctly on the same device even without this PR, so I'm not sure whats going on there. Maybe if the XCTestConfigurationFilePath variable is the empty string that ios defaults it to something that happens to work for the com.facebook bundle id?