### PR TITLE
ios runwda: die on error

### DIFF
--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -309,8 +309,10 @@ func runXUITestWithBundleIdsXcode12(bundleID string, testRunnerBundleID string, 
 		return err
 	}
 	log.Info("WDA killed with success")
+	/*
 	var signal interface{}
 	closedChan <- signal
+	*/
 	return nil
 
 }

--- a/ios/testmanagerd/xcuitestrunner_11.go
+++ b/ios/testmanagerd/xcuitestrunner_11.go
@@ -74,8 +74,8 @@ func RunXCUIWithBundleIds11(
 	if err != nil {
 		return err
 	}
-	/*
 	log.Info("WDA killed with success")
+	/*
 	var signal interface{}
 	closedChan <- signal
 	*/


### PR DESCRIPTION
runwda can fail due to wda not starting up properly. I am not 100% sure why wda fails to launch, but if it does not launch then runwda should exit instead of just sitting there.

Before:
```
$ go-ios runwda ...

"bundleID":"com.apple.test.WebDriverAgentRunner-Runner","channel_id":"com.apple.instruments.server.services.processcontrol","level":"info","msg":"Launching process","time":"2022-01-12T10:40:51-08:00"}
{"channel_id":"com.apple.instruments.server.services.processcontrol","level":"info","msg":"Process started successfully","pid":81353,"time":"2022-01-12T10:40:51-08:00"}
{"level":"info","msg":"2022-01-12 10:40:51.505522-0800 WebDriverAgentRunner-Runner[81353:41648797] Running tests...\n","time":"2022-01-12T10:40:51-08:00"}
{"level":"info","msg":"device called local method","sel":"_XCT_didFailToBootstrapWithError:","time":"2022-01-12T10:40:51-08:00"}
{"level":"info","msg":"2022-01-12 10:40:51.518200-0800 WebDriverAgentRunner-Runner[81353:41648797] Failed to create a bundle instance representing '/private/var/containers/Bundle/Application/80887842-4ED9-4483-A9BA-47B7D3878177/x.app/PlugIns/WebDriverAgentRunner'. Check that the bundle exists on disk.\n","time":"2022-01-12T10:40:51-08:00"}
{"level":"error","msg":"DeviceConnection failed writing 402 bytes, only 0 sent","time":"2022-01-12T10:40:52-08:00"}
{"level":"error","msg":"Failed sending: write unix -\u003e/var/run/usbmuxd: write: broken pipe","time":"2022-01-12T10:40:52-08:00"}
{"channel_id":"dtxproxy:XCTestDriverInterface:XCTestManager_IDEInterface","error":"write unix -\u003e/var/run/usbmuxd: write: broken pipe","level":"info","methodselector":"_IDE_startExecutingTestPlanWithProtocolVersion:","msg":"failed starting invoking method","time":"2022-01-12T10:40:52-08:00"}
^C{"level":"info","msg":"os signal:2 received, closing..","time":"2022-01-12T10:41:06-08:00"}
{"level":"info","msg":"Killing WebDriverAgent with pid 81353 ...","time":"2022-01-12T10:41:06-08:00"}
{"level":"info","msg":"WDA killed with success","time":"2022-01-12T10:41:06-08:00"}
{"level":"info","msg":"Done Closing","time":"2022-01-12T10:41:06-08:00"}
```
Note that wda failed to launch and called the local method `_XCT_didFailToBootstrapWithError`. If this function is called then I believe go-ios should abort runwda and just exit. In the above output I pressed ctrl-c, you can see the ^C there.

After:
```
{"bundleid":"com.apple.test.WebDriverAgentRunner-Runner","level":"info","msg":"Running wda","testbundleid":"com.apple.test.WebDriverAgentRunner-Runner","time":"2022-01-12T12:02:47-08:00","xctestconfig":"WebDriverAgentRunner"}
{"bundleID":"com.apple.test.WebDriverAgentRunner-Runner","channel_id":"com.apple.instruments.server.services.processcontrol","level":"info","msg":"Launching process","time":"2022-01-12T12:02:48-08:00"}
{"channel_id":"com.apple.instruments.server.services.processcontrol","level":"info","msg":"Process started successfully","pid":81458,"time":"2022-01-12T12:02:49-08:00"}
{"level":"info","msg":"2022-01-12 12:02:49.102937-0800 WebDriverAgentRunner-Runner[81458:41670445] Running tests...\n","time":"2022-01-12T12:02:49-08:00"}
{"level":"info","msg":"2022-01-12 12:02:49.115029-0800 WebDriverAgentRunner-Runner[81458:41670445] Failed to create a bundle instance representing '/private/var/containers/Bundle/Application/80887842-4ED9-4483-A9BA-47B7D3878177/x.app/PlugIns/WebDriverAgentRunner'. Check that the bundle exists on disk.\n","time":"2022-01-12T12:02:49-08:00"}
{"level":"error","msg":"DeviceConnection failed writing 402 bytes, only 0 sent","time":"2022-01-12T12:02:50-08:00"}
{"level":"error","msg":"Failed sending: write unix -\u003e/var/run/usbmuxd: write: broken pipe","time":"2022-01-12T12:02:50-08:00"}
{"channel_id":"dtxproxy:XCTestDriverInterface:XCTestManager_IDEInterface","error":"write unix -\u003e/var/run/usbmuxd: write: broken pipe","level":"info","methodselector":"_IDE_startExecutingTestPlanWithProtocolVersion:","msg":"failed starting invoking method","time":"2022-01-12T12:02:50-08:00"}
{"level":"info","msg":"Killing WebDriverAgent with pid 81458 ...","time":"2022-01-12T12:02:50-08:00"}
{"level":"info","msg":"WDA killed with success","time":"2022-01-12T12:02:50-08:00"}
```

This PR adds a handler for that XCT message and tries to abort `runwda`. This is accomplished using the go context library, which is slightly different from how termination works in go-ios now. Instead of a channel dedicated to listening for signals, the various runXUITest* functions wait for a context to be closed. This can be accomplished through either the XCT failed message being received, or if the user sends a signal via ctrl-c or what have you.

Let me know if using contexts is acceptable here, or if you have some other ideas for abnormal termination. Also I still have to test this code for an ios device that would use the RunXCUIWithBundleIds11, as my existing test case used ios 14.