### PR TITLE
Add support for profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,25 @@ If you miss something your Mac can do but go-iOS can't, just request a feature i
 All features:
 
 ```
+ The commands work as following:
+        The default output of all commands is JSON. Should you prefer human readable outout, specify the --nojson option with your command. 
+        By default, the first device found will be used for a command unless you specify a --udid=some_udid switch.
+        Specify -v for debug logging and -t for dumping every message.
+
    ios listen [options]                                               Keeps a persistent connection open and notifies about newly connected or disconnected devices.
    ios list [options] [--details]                                     Prints a list of all connected device's udids. If --details is specified, it includes version, name and model of each device.
    ios info [options]                                                 Prints a dump of Lockdown getValues.
    ios image list [options]                                           List currently mounted developers images' signatures
    ios image mount [--path=<imagepath>] [options]                     Mount a image from <imagepath>
-   ios image auto [--basedir=<where_dev_images_are_stored>] [options] Automatically download correct dev image from the internets and mount it. You can specify a dir where images should be cached. The default is the current dir. 
+   ios image auto [--basedir=<where_dev_images_are_stored>] [options] Automatically download correct dev image from the internets and mount it.
+   >                                                                  You can specify a dir where images should be cached.
+   >                                                                  The default is the current dir. 
    ios syslog [options]                                               Prints a device's log output
    ios screenshot [options] [--output=<outfile>]                      Takes a screenshot and writes it to the current dir or to <outfile>
+   ios crash ls [<pattern>] [options]                                 run "ios crash ls" to get all crashreports in a list, 
+   >                                                                  or use a pattern like 'ios crash ls "*ips*"' to filter
+   ios crash cp <srcpattern> <target> [options]                       copy "file pattern" to the target dir. Ex.: 'ios crash cp "*" "./crashes"'
+   ios crash rm <cwd> <pattern> [options]                             remove file pattern from dir. Ex.: 'ios crash rm "." "*"' to delete everything
    ios devicename [options]                                           Prints the devicename
    ios date [options]                                                 Prints the device date
    ios devicestate list [options]                                     Prints a list of all supported device conditions, like slow network, gpu etc.
@@ -53,14 +64,23 @@ All features:
    ios pair [--p12file=<orgid>] [--password=<p12password>] [options]  Pairs the device. If the device is supervised, specify the path to the p12 file 
    >                                                                  to pair without a trust dialog. Specify the password either with the argument or
    >                                                                  by setting the environment variable 'P12_PASSWORD'
+   ios profiles list                                                  List the profiles on the device
+   ios profiles remove <profileName>                                  Remove the profileName from the device
+   ios profiles add <profileName> [--p12file=<orgid>] [--password=<p12password>] Install profile file on the device. 
+   >                                                                  Use p12 file and password for silent installation on supervised devices.
    ios ps [options]                                                   Dumps a list of running processes on the device
+   ios ip [options]                                                   Uses the live pcap iOS packet capture to wait until it finds one that contains the IP address of the device.
+   >                                                                  It relies on the MAC address of the WiFi adapter to know which is the right IP. 
+   >                                                                  You have to disable the "automatic wifi address"-privacy feature of the device for this to work.
+   >                                                                  If you wanna speed it up, open apple maps or similar to force network traffic.
+   >                                                                  f.ex. "ios launch com.apple.Maps"
    ios forward [options] <hostPort> <targetPort>                      Similar to iproxy, forward a TCP connection to the device.
    ios dproxy [--binary]                                              Starts the reverse engineering proxy server. 
    >                                                                  It dumps every communication in plain text so it can be implemented easily. 
    >                                                                  Use "sudo launchctl unload -w /Library/Apple/System/Library/LaunchDaemons/com.apple.usbmuxd.plist"
    >                                                                  to stop usbmuxd and load to start it again should the proxy mess up things.
    >                                                                  The --binary flag will dump everything in raw binary without any decoding. 
-   ios readpair                                                       Dump detailed information about the pairrecord for a device.                                              Starts a pcap dump of network traffic
+   ios readpair                                                       Dump detailed information about the pairrecord for a device.
    ios install --path=<ipaOrAppFolder> [options]                      Specify a .app folder or an installable ipa file that will be installed.  
    ios pcap [options] [--pid=<processID>] [--process=<processName>]   Starts a pcap dump of network traffic, use --pid or --process to filter specific processes.
    ios apps [--system]                                                Retrieves a list of installed applications. --system prints out preinstalled system apps.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ All features:
    ios pair [--p12file=<orgid>] [--password=<p12password>] [options]  Pairs the device. If the device is supervised, specify the path to the p12 file 
    >                                                                  to pair without a trust dialog. Specify the password either with the argument or
    >                                                                  by setting the environment variable 'P12_PASSWORD'
-   ios profiles list                                                  List the profiles on the device
-   ios profiles remove <profileName>                                  Remove the profileName from the device
-   ios profiles add <profileName> [--p12file=<orgid>] [--password=<p12password>] Install profile file on the device. 
+   ios profile list                                                   List the profiles on the device
+   ios profile remove <profileName>                                   Remove the profileName from the device
+   ios profile add <profileFile> [--p12file=<orgid>] [--password=<p12password>] Install profile file on the device.
+   ios httpproxy <host> <port> [<user>] [<pass>] --p12file=<orgid> --password=<p12password> set global http proxy on supervised device
    >                                                                  Use p12 file and password for silent installation on supervised devices.
    ios ps [options]                                                   Dumps a list of running processes on the device
    ios ip [options]                                                   Uses the live pcap iOS packet capture to wait until it finds one that contains the IP address of the device.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ If you miss something your Mac can do but go-iOS can't, just request a feature i
 All features:
 
 ```
- The commands work as following:
+Options:
+  -v --verbose   Enable Debug Logging.
+  -t --trace     Enable Trace Logging (dump every message).
+  --nojson       Disable JSON output (default).
+  -h --help      Show this screen.
+  --udid=<udid>  UDID of the device.
+
+The commands work as following:
         The default output of all commands is JSON. Should you prefer human readable outout, specify the --nojson option with your command. 
         By default, the first device found will be used for a command unless you specify a --udid=some_udid switch.
         Specify -v for debug logging and -t for dumping every message.
@@ -66,8 +73,8 @@ All features:
    >                                                                  by setting the environment variable 'P12_PASSWORD'
    ios profile list                                                   List the profiles on the device
    ios profile remove <profileName>                                   Remove the profileName from the device
-   ios profile add <profileFile> [--p12file=<orgid>] [--password=<p12password>] Install profile file on the device.
-   ios httpproxy <host> <port> [<user>] [<pass>] --p12file=<orgid> --password=<p12password> set global http proxy on supervised device
+   ios profile add <profileFile> [--p12file=<orgid>] [--password=<p12password>] Install profile file on the device. If supervised set p12file and password or the environment variable 'P12_PASSWORD'
+   ios httpproxy <host> <port> [<user>] [<pass>] --p12file=<orgid> [--password=<p12password>] set global http proxy on supervised device. Use the password argument or set the environment variable 'P12_PASSWORD'
    >                                                                  Use p12 file and password for silent installation on supervised devices.
    ios ps [options]                                                   Dumps a list of running processes on the device
    ios ip [options]                                                   Uses the live pcap iOS packet capture to wait until it finds one that contains the IP address of the device.

--- a/ios/crypto_utils.go
+++ b/ios/crypto_utils.go
@@ -1,6 +1,7 @@
 package ios
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -9,6 +10,7 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"errors"
+	"github.com/fullsailor/pkcs7"
 	"math/big"
 	"time"
 )
@@ -189,4 +191,18 @@ func savePEMKey(key *rsa.PrivateKey) []byte {
 		},
 	)
 	return privateKeyPem
+}
+
+func Sign(challengeBytes []byte, cert *x509.Certificate, supervisedPrivateKey interface{}) ([]byte, error) {
+	sd, err := pkcs7.NewSignedData(challengeBytes)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	err = sd.AddSigner(cert, supervisedPrivateKey.(crypto.Signer), pkcs7.SignerInfoConfig{})
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return sd.Finish()
 }

--- a/ios/mcinstall/mcinstall.go
+++ b/ios/mcinstall/mcinstall.go
@@ -2,6 +2,7 @@ package mcinstall
 
 import (
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"io"
 
 	ios "github.com/danielpaulus/go-ios/ios"
@@ -172,4 +173,40 @@ func (mcInstallConn *Connection) HandleList() ([]ProfileInfo, error) {
 //Close closes the underlying DeviceConnection
 func (mcInstallConn *Connection) Close() error {
 	return mcInstallConn.deviceConn.Close()
+}
+
+func (mcInstallConn *Connection) AddProfile(profilePlist []byte) error {
+request := map[string]interface{}{"RequestType":"InstallProfile", "Payload": profilePlist}
+	requestBytes, err := mcInstallConn.plistCodec.Encode(request)
+	if err != nil {
+		return err
+	}
+	err = mcInstallConn.deviceConn.Send(requestBytes)
+	if err != nil {
+		return err
+	}
+	respBytes, err := mcInstallConn.plistCodec.Decode(mcInstallConn.deviceConn.Reader())
+	if err!=nil{
+		return err
+	}
+	log.Infof("received install response %x", respBytes)
+	return nil
+}
+
+func (mcInstallConn *Connection) RemoveProfile(identifier string) error {
+	request := map[string]interface{}{"RequestType":"RemoveProfile", "ProfileIdentifier": identifier}
+	requestBytes, err := mcInstallConn.plistCodec.Encode(request)
+	if err != nil {
+		return err
+	}
+	err = mcInstallConn.deviceConn.Send(requestBytes)
+	if err != nil {
+		return err
+	}
+	respBytes, err := mcInstallConn.plistCodec.Decode(mcInstallConn.deviceConn.Reader())
+	if err!=nil{
+		return err
+	}
+	log.Infof("received install response %x", respBytes)
+	return nil
 }

--- a/ios/mcinstall/mcinstall.go
+++ b/ios/mcinstall/mcinstall.go
@@ -267,8 +267,12 @@ func (mcInstallConn *Connection) addProfile(profilePlist []byte, installcmd stri
 	if err != nil {
 		return err
 	}
-	log.Infof("received install response %x", respBytes)
-	return nil
+	plist, err := ios.ParsePlist(respBytes)
+	if checkStatus(plist) {
+		return nil
+	}
+	log.Errorf("received remove response %+v", plist)
+	return fmt.Errorf("remove failed")
 }
 
 func (mcInstallConn *Connection) RemoveProfile(identifier string) error {
@@ -285,8 +289,12 @@ func (mcInstallConn *Connection) RemoveProfile(identifier string) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("received install response %x", respBytes)
-	return nil
+	plist, err := ios.ParsePlist(respBytes)
+	if checkStatus(plist) {
+		return nil
+	}
+	log.Errorf("received remove response %+v", plist)
+	return fmt.Errorf("remove failed")
 }
 
 func (mcInstallConn *Connection) AddProfileSupervised(filebytes []byte, bytes []byte, password string) error {

--- a/ios/pair.go
+++ b/ios/pair.go
@@ -2,10 +2,8 @@ package ios
 
 import (
 	"bytes"
-	"crypto"
 	"errors"
 	"fmt"
-	"github.com/fullsailor/pkcs7"
 	"github.com/google/uuid"
 	"golang.org/x/crypto/pkcs12"
 	plist "howett.net/plist"
@@ -73,16 +71,7 @@ func PairSupervised(device DeviceEntry, p12bytes []byte, p12Password string) err
 	if err != nil {
 		return err
 	}
-	sd, err := pkcs7.NewSignedData(challengeBytes)
-
-	if err != nil {
-		return err
-	}
-	err = sd.AddSigner(cert, supervisedPrivateKey.(crypto.Signer), pkcs7.SignerInfoConfig{})
-	if err != nil {
-		return err
-	}
-	der, err := sd.Finish()
+	der, err := Sign(challengeBytes, cert, supervisedPrivateKey)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -27,10 +27,10 @@ import (
 	"github.com/danielpaulus/go-ios/ios/forward"
 	"github.com/danielpaulus/go-ios/ios/installationproxy"
 	"github.com/danielpaulus/go-ios/ios/instruments"
+	"github.com/danielpaulus/go-ios/ios/mcinstall"
 	"github.com/danielpaulus/go-ios/ios/notificationproxy"
 	"github.com/danielpaulus/go-ios/ios/pcap"
 	"github.com/danielpaulus/go-ios/ios/screenshotr"
-	"github.com/danielpaulus/go-ios/ios/mcinstall"
 	syslog "github.com/danielpaulus/go-ios/ios/syslog"
 	"github.com/docopt/docopt-go"
 	log "github.com/sirupsen/logrus"
@@ -755,7 +755,9 @@ func startDebugProxy(device ios.DeviceEntry, binaryMode bool) {
 func handleProfileList(device ios.DeviceEntry) {
 	profileService, err := mcinstall.New(device)
 	exitIfError("Starting mcInstall failed with", err)
-	profileService.HandleList()
+	list, err := profileService.HandleList()
+	exitIfError("failed getting profile list", err)
+	fmt.Println(convertToJSONString(list))
 }
 
 func startForwarding(device ios.DeviceEntry, hostPort int, targetPort int) {

--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ The commands work as following:
 	diagnosticsCommand, _ := arguments.Bool("diagnostics")
 	imageCommand, _ := arguments.Bool("image")
 	deviceStateCommand, _ := arguments.Bool("devicestate")
-	profileCommand, _ := arguments.Bool("profiles")
+	profileCommand, _ := arguments.Bool("profile")
 
 	if listCommand && !diagnosticsCommand && !imageCommand && !deviceStateCommand && !profileCommand {
 		b, _ = arguments.Bool("--details")
@@ -795,6 +795,7 @@ func handleProfileRemove(device ios.DeviceEntry, identifier string) {
 	exitIfError("Starting mcInstall failed with", err)
 	err = profileService.RemoveProfile(identifier)
 	exitIfError("failed adding profile", err)
+	log.Infof("profile '%s' removed",identifier)
 }
 
 func handleProfileAdd(device ios.DeviceEntry, file string) {
@@ -804,6 +805,7 @@ func handleProfileAdd(device ios.DeviceEntry, file string) {
 	exitIfError("could not read profile-file", err)
 	err = profileService.AddProfile(filebytes)
 	exitIfError("failed adding profile", err)
+	log.Info("profile installed, you have to accept it in the device settings")
 }
 
 func handleProfileAddSupervised(device ios.DeviceEntry, file string, p12file string, p12password string) {
@@ -815,6 +817,7 @@ func handleProfileAddSupervised(device ios.DeviceEntry, file string, p12file str
 	exitIfError("could not read p12-file", err)
 	err = profileService.AddProfileSupervised(filebytes,p12bytes, p12password)
 	exitIfError("failed adding profile", err)
+	log.Info("profile installed")
 }
 
 func handleProfileList(device ios.DeviceEntry) {

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ Usage:
   ios profile list [options]
   ios profile remove <profileName> [options]
   ios profile add <profileFile> [--p12file=<orgid>] [--password=<p12password>] [options]
+  ios httpproxy <host> <port> [<user>] [<pass>] --p12file=<orgid> --password=<p12password>
   ios pair [--p12file=<orgid>] [--password=<p12password>] [options]
   ios ps [options]
   ios ip [options]
@@ -130,9 +131,10 @@ The commands work as following:
    ios pair [--p12file=<orgid>] [--password=<p12password>] [options]  Pairs the device. If the device is supervised, specify the path to the p12 file 
    >                                                                  to pair without a trust dialog. Specify the password either with the argument or
    >                                                                  by setting the environment variable 'P12_PASSWORD'
-   ios profiles list                                                  List the profiles on the device
-   ios profiles remove <profileName>                                  Remove the profileName from the device
-   ios profiles add <profileName> [--p12file=<orgid>] [--password=<p12password>] Install profile file on the device. 
+   ios profile list                                                   List the profiles on the device
+   ios profile remove <profileName>                                   Remove the profileName from the device
+   ios profile add <profileFile> [--p12file=<orgid>] [--password=<p12password>] Install profile file on the device. If supervised set p12file and password or the environment variable 'P12_PASSWORD'
+   ios httpproxy <host> <port> [<user>] [<pass>] --p12file=<orgid> [--password=<p12password>] set global http proxy on supervised device. Use the password argument or set the environment variable 'P12_PASSWORD'
    >                                                                  Use p12 file and password for silent installation on supervised devices.
    ios ps [options]                                                   Dumps a list of running processes on the device
    ios ip [options]                                                   Uses the live pcap iOS packet capture to wait until it finds one that contains the IP address of the device.
@@ -359,14 +361,14 @@ The commands work as following:
 		return
 	}
 
-	b, _ = arguments.Bool("profiles")
+	b, _ = arguments.Bool("profile")
 	if b {
 		if listCommand {
 			handleProfileList(device)
 		}
 		b, _ = arguments.Bool("add")
 		if b {
-			name, _ := arguments.String("<profileName>")
+			name, _ := arguments.String("<profileFile>")
 			p12file, _ := arguments.String("--p12file")
 			p12password, _ := arguments.String("--password")
 			if p12password == "" {
@@ -811,9 +813,7 @@ func handleProfileAddSupervised(device ios.DeviceEntry, file string, p12file str
 	exitIfError("could not read profile-file", err)
 	p12bytes, err := ioutil.ReadFile(p12file)
 	exitIfError("could not read p12-file", err)
-	err = profileService.Escalate(p12bytes, p12password)
-	exitIfError("failed escalating with supervision certificate", err)
-	err = profileService.AddProfile(filebytes)
+	err = profileService.AddProfileSupervised(filebytes,p12bytes, p12password)
 	exitIfError("failed adding profile", err)
 }
 


### PR DESCRIPTION
Allows to install configuration profiles generated by apple configurator, to set global http proxies, add wifi connections and do other cool things. 
`ios profile list` shows a list of all currently installed profiles, including identifier
`ios profile remove <profileIdentifier>` removes a profile from the device using its identifier. Example: `ios profile remove Daniels-MacBook-Pro-2.C10C60E6-94ED-4F50-B882-0D709A6103DF`
`ios profile add <profileFilePath>` adds the profile to the device unsupervised. That means you have to manually accept it on the device by going to the settings app. 

if your device is supervised though, you can use `ios profile add <profileFile> [--p12file=<orgid>] [--password=<p12password>]` and have all the profiles be silently installed to set advanced settings on devices seamlessly. 