### PR TITLE
When one forwarding tunnel connection closes, close the other as well.

### DIFF
--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -60,9 +60,13 @@ func startNewProxyConnection(clientConn net.Conn, deviceID int, phonePort uint16
 	//proxyConn := iosproxy{clientConn, deviceConn}
 	go func() {
 		io.Copy(clientConn, deviceConn.Reader())
+                clientConn.Close()
+                deviceConn.Close()
 	}()
 	go func() {
 		io.Copy(deviceConn.Writer(), clientConn)
+                clientConn.Close()
+                deviceConn.Close()
 	}()
 }
 


### PR DESCRIPTION
Issue: port-forwarding clients hang indefinitely if/when the target device port closes.

At the end of io.Copy(deviceConn,clientConn), only one of the two connections is
guaranteed to be closed. If deviceConn fails (because an application on the
iOS device was shut down, crashed, or closed a connection), the client connection is
left open.  The effect is that the client will hang indefinitely, continuing to send
traffic we cannot forward, and listening for traffic that will never arrive.