### PR TITLE
Add ability to enable/disable AssistiveTouch soft "home" button. iOS 11+

### DIFF
--- a/ios/lockdown_assistivetouch.go
+++ b/ios/lockdown_assistivetouch.go
@@ -1,0 +1,52 @@
+package ios
+
+import log "github.com/sirupsen/logrus"
+import "fmt"
+
+const accessibilityDomain = "com.apple.Accessibility"
+const assistiveTouchKey  = "AssistiveTouchEnabledByiTunes"
+
+// EnableAssistiveTouch creates a new lockdown session for the device and enables or disables
+// AssistiveTouch (the on-screen software home button), by using the special key AssistiveTouchEnabledByiTunes.
+// Setting to true will enable AssistiveTouch
+// Setting to false will disable AssistiveTouch, regardless of whether it was previously-enabled through
+// a non-iTunes-related method.
+func SetAssistiveTouch(device DeviceEntry, enabled bool) error {
+	lockDownConn, err := ConnectLockdownWithSession(device)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Setting %s: %s", assistiveTouchKey, enabled)
+	defer lockDownConn.Close()
+	err = lockDownConn.SetValueForDomain(assistiveTouchKey, accessibilityDomain, enabled)
+	return err
+}
+func GetAssistiveTouch(device DeviceEntry) (bool, error) {
+	lockDownConn, err := ConnectLockdownWithSession(device)
+
+	if err != nil {
+		return false, err
+	}
+	defer lockDownConn.Close()
+
+	enabledIntf, err := lockDownConn.GetValueForDomain(assistiveTouchKey, accessibilityDomain)
+
+	if err != nil {
+		return false, err
+	}else if enabledIntf == nil{
+		// In testing, nil was returned in only one case, on an iOS 14.7 device that should already have been paired.
+		// Calling SetAssistiveTouch() directly returned the somewhat more useful error: SetProhibited
+		// After re-running "go-ios pair", full functionality returned.
+		return false, fmt.Errorf("Received null response when querying %s.%s. Try re-pairing the device.", accessibilityDomain, assistiveTouchKey, enabledIntf, enabledIntf)
+	}
+	enabledUint64, ok := enabledIntf.(uint64)
+	if !ok {
+		// On iOS 10.x at least, "false" is returned, perhaps for any key at all.  Attempting to manipulate AssistiveTouchEnabledByiTunes had no effect
+		return false, fmt.Errorf("Expected unit64 0 or 1 when querying %s.%s, but received %T:%+v. Is this device running iOS 11+.", accessibilityDomain, assistiveTouchKey, enabledIntf, enabledIntf)
+	} else if enabledUint64 != 0 && enabledUint64 != 1{
+		// So far this has never happened
+		return false, fmt.Errorf("Expected a value of 0 or 1 for %s.%s, received %d instead!", accessibilityDomain, assistiveTouchKey, enabledUint64)
+	}
+
+	return enabledUint64 == 1, nil
+}

--- a/ios/lockdown_value.go
+++ b/ios/lockdown_value.go
@@ -114,7 +114,7 @@ type valueRequest struct {
 	Key     string `plist:"Key,omitempty"`
 	Request string
 	Domain  string `plist:"Domain,omitempty"`
-	Value   string `plist:"Value,omitempty"`
+	Value   interface{} `plist:"Value,omitempty"`
 }
 
 func newGetValue(key string) valueRequest {
@@ -126,7 +126,7 @@ func newGetValue(key string) valueRequest {
 	return data
 }
 
-func newSetValue(key string, domain string, value string) valueRequest {
+func newSetValue(key string, domain string, value interface{}) valueRequest {
 	data := valueRequest{
 		Label:   "go.ios.control",
 		Key:     key,
@@ -215,7 +215,7 @@ func (lockDownConn *LockDownConnection) GetValueForDomain(key string, domain str
 }
 
 //SetValueForDomain sets the string value for the lockdown key and domain. If the device returns an error it will be returned as a go error.
-func (lockDownConn *LockDownConnection) SetValueForDomain(key string, domain string, value string) error {
+func (lockDownConn *LockDownConnection) SetValueForDomain(key string, domain string, value interface{}) error {
 	gv := newSetValue(key, domain, value)
 	lockDownConn.Send(gv)
 	resp, err := lockDownConn.ReadMessage()


### PR DESCRIPTION
Using the same technique already used for querying and setting the device language and locale, go-ios can now enable and disable AssistiveTouch using the the magic boolean com.apple.Accessibility.AssistiveTouchEnabledByiTunes

This commit slightly modifies the existing SetValueForDomain() and related methods and structs to take an interface{} value (rather than a string) in order to pass a raw bool to lockdown.

This commit also replaces a few inconsistently used tabs in the verbose command-line "help" output.

Thank you to the team at alibaba/taobao-iphone-device (tidevice) for sharing the magic word to make this happen.

Validated on iPhone 5s, 6, 6s, 6s plus, 7, 8, se 1st gen, se 2nd gen, and 11 pro max.  iOS 11.4.1, 12.1, 12.5.5, 13.4, 13.6, 14.0.1, 14.7, 15.0, 15.3, and 16.0.1 beta.

Failed on an iPhone 6+ running iOS 10.2.1 (Programmed to exit with custom error including hint: “Is this device running iOS 11+?”)