### PR TITLE
When setting device language, print language to debug log, not locale.

### DIFF
--- a/ios/lockdown_language_locale.go
+++ b/ios/lockdown_language_locale.go
@@ -33,7 +33,7 @@ func SetLanguage(device DeviceEntry, config LanguageConfiguration) error {
 		}
 	}
 	if config.Language != "" {
-		log.Debugf("Setting language: %s", config.Locale)
+		log.Debugf("Setting language: %s", config.Language)
 		return lockDownConn.SetValueForDomain("Language", languageDomain, config.Language)
 	}
 	return nil


### PR DESCRIPTION
Small copy/paste issue.