### PR TITLE
Add human-friendly ps output.  Add --all option to apps command.

### DIFF
--- a/ios/installationproxy/installationproxy.go
+++ b/ios/installationproxy/installationproxy.go
@@ -28,11 +28,15 @@ func New(device ios.DeviceEntry) (*Connection, error) {
 	return &Connection{deviceConn: deviceConn, plistCodec: ios.NewPlistCodec()}, nil
 }
 func (conn *Connection) BrowseUserApps() ([]AppInfo, error) {
-	return conn.browseApps(browseUserApps())
+	return conn.browseApps(browseApps("User", true))
 }
 
 func (conn *Connection) BrowseSystemApps() ([]AppInfo, error) {
-	return conn.browseApps(browseSystemApps())
+	return conn.browseApps(browseApps("System", false))
+}
+
+func (conn *Connection) BrowseAllApps() ([]AppInfo, error) {
+	return conn.browseApps(browseApps("", true))
 }
 
 func (conn *Connection) browseApps(request interface{}) ([]AppInfo, error) {
@@ -123,7 +127,7 @@ func plistFromBytes(plistBytes []byte) (BrowseResponse, error) {
 	}
 	return browseResponse, nil
 }
-func browseSystemApps() map[string]interface{} {
+func browseApps(applicationType string, showLaunchProhibitedApps bool) map[string]interface{} {
 	returnAttributes := []string{
 		"ApplicationDSID",
 		"ApplicationType",
@@ -145,37 +149,13 @@ func browseSystemApps() map[string]interface{} {
 		"UIRequiredDeviceCapabilities",
 	}
 	clientOptions := map[string]interface{}{
-		"ApplicationType":  "System",
 		"ReturnAttributes": returnAttributes,
 	}
-	return map[string]interface{}{"ClientOptions": clientOptions, "Command": "Browse"}
-}
-
-func browseUserApps() map[string]interface{} {
-	returnAttributes := []string{
-		"ApplicationDSID",
-		"ApplicationType",
-		"CFBundleDisplayName",
-		"CFBundleExecutable",
-		"CFBundleIdentifier",
-		"CFBundleName",
-		"CFBundleShortVersionString",
-		"CFBundleVersion",
-		"Container",
-		"Entitlements",
-		"EnvironmentVariables",
-		"MinimumOSVersion",
-		"Path",
-		"ProfileValidated",
-		"SBAppTags",
-		"SignerIdentity",
-		"UIDeviceFamily",
-		"UIRequiredDeviceCapabilities",
+	if applicationType != "" {
+		clientOptions["ApplicationType"] = applicationType
 	}
-	clientOptions := map[string]interface{}{
-		"ApplicationType":          "User",
-		"ReturnAttributes":         returnAttributes,
-		"ShowLaunchProhibitedApps": true,
+	if showLaunchProhibitedApps {
+                clientOptions["ShowLaunchProhibitedApps"] = true
 	}
 	return map[string]interface{}{"ClientOptions": clientOptions, "Command": "Browse"}
 }


### PR DESCRIPTION
This commit adds a human-friendly line-per-process table output to the "ios ps" command, piggy-backing on the previously-unused --nojson option.  In order to actually fit on the screen, this does *not* print all of the fields available in the JSON, and also adds the app's bundle ID if available.   (This could add confusion given that the bundleID now appears *missing* from the json output.  I have at least noted this discrepancy in the "-help" output.  If desired, BundleID could be added to the JSON, or else the entire appInfo structure could be added as a nested field when available).

The JSON for "ps" returns an "IsApplication" flag, which is most likely usable for limiting output that is irrelevant to some users.  Rather than display "true/false" for IsApplication as an additional column, I have added a filter "--apps". (For backward compatibility, I have left the "all" behavior as the default).  "--apps" will limit output to processes where isApplication == true only.  The filter applies to both JSON and nojson output.

go-ios previously offered the app-browsing choices BrowseUserApps() and BrowseSystemApps(), whose results were mutually exclusive, and which did not show some hidden apps. This commit adds BrowseAllApps(), which is used in the "ps" command to cross-reference with all running processes.

With the addition of BrowseAllApps(), it seemed logical to also add the --all" option to the "apps" command itself, and expose this functionality to the user.