### PR TITLE
Add command-line option to kill processes by process-name or PID

### DIFF
--- a/main.go
+++ b/main.go
@@ -546,11 +546,11 @@ The commands work as following:
 			}
 		}
 		if bundleID != "" {
-			log.Errorf("process of ", bundleID, " not found")
+			log.Error("process of ", bundleID, " not found")
 		} else if processName != "" {
-			log.Errorf("process named ", processName, " not found")
+			log.Error("process named ", processName, " not found")
 		} else {
-			log.Errorf("process with pid ", processID, " not found")
+			log.Error("process with pid ", processID, " not found")
 		}
 		os.Exit(1)
 		return


### PR DESCRIPTION
This commit also adds a "--system" option that allows built-in processes, such as com.apple.Maps, to be killed by bundleID.  (When specifying --pid or --process, there are no restrictions)

Examples of processes that one might want to kill this way:
com.apple.Maps   (using the --system option)
replayd          (when broadcast streaming becomes irrevocably hung)
assistivetouchd  (useful as a test.  If the AssistiveTouch home button is active, killing this makes the button briefly disappear, but it restarts automatically).

This commit attempts to preserve all previous behavior, but a few changes have been made:
* Some typos were corrected ("killd" -> "killed")
* Some spaces were added in log messages where variables were concatenated with no spaces
* The "kill" command now exits with a non-zero exit status for any failure to kill a process. previously log.Error() was called, followed by exit(0).  Now it should be possible to tell whether a process was actually killed based on the exit status of the application.

Note: Currently, using "--system" *prevents* killing user applications.  After PR #151, replacing a call to "BrowseSystemApps()" with the new "BrowseAllApps()" will enable killing by bundle ID without considering how the app was installed.