### PR TITLE
Implement CPU, Memory etc. profiling

### DIFF
--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -159,13 +159,17 @@ func (dtxConn *Connection) ForChannelRequest(messageDispatcher Dispatcher) *Chan
 	//code := msg.Auxiliary.GetArguments()[0].(uint32)
 	identifier, _ := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[1].([]byte))
 	//TODO: Setting the channel code here manually to -1 for making testmanagerd work. For some reason it requests the TestDriver proxy channel with code 1 but sends messages on -1. Should probably be fixed somehow
+	//TODO: try to refactor testmanagerd/xcuitest code and use AddDefaultChannelReceiver instead of this function. The only code calling this is in testmanagerd right now.
 	channel := &Channel{channelCode: -1, channelName: identifier[0].(string), messageIdentifier: 1, connection: dtxConn, messageDispatcher: messageDispatcher, responseWaiters: map[int]chan Message{}, defragmenters: map[int]*FragmentDecoder{}, timeout: 5 * time.Second}
 	dtxConn.activeChannels.Store(-1, channel)
 	return channel
 }
 
-func (dtxConn *Connection) AddMinusOneReceiver(messageDispatcher Dispatcher) *Channel {
-	//4294967295
+//AddDefaultChannelReceiver let's you set the Dispatcher for the Channel with code -1 ( or 4294967295 for uint32).
+// I am just calling it the "default" channel now, without actually figuring out what it is for exactly from disassembled code.
+// If someone wants to do that and bring some clarity, please go ahead :-)
+// This channel seems to always be there without explicitly requesting it and sometimes it is used.
+func (dtxConn *Connection) AddDefaultChannelReceiver(messageDispatcher Dispatcher) *Channel {
 	channel := &Channel{channelCode: -1, channelName: "c -1/ 4294967295 receiver channel ", messageIdentifier: 1, connection: dtxConn, messageDispatcher: messageDispatcher, responseWaiters: map[int]chan Message{}, defragmenters: map[int]*FragmentDecoder{}, timeout: 5 * time.Second}
 	dtxConn.activeChannels.Store(4294967295, channel)
 	return channel

--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -133,7 +133,6 @@ func reader(dtxConn *Connection) {
 			log.Errorf("error reading dtx connection %+v", err)
 			return
 		}
-
 		if _channel, ok := dtxConn.activeChannels.Load(msg.ChannelCode); ok {
 			channel := _channel.(*Channel)
 			channel.Dispatch(msg)
@@ -162,6 +161,13 @@ func (dtxConn *Connection) ForChannelRequest(messageDispatcher Dispatcher) *Chan
 	//TODO: Setting the channel code here manually to -1 for making testmanagerd work. For some reason it requests the TestDriver proxy channel with code 1 but sends messages on -1. Should probably be fixed somehow
 	channel := &Channel{channelCode: -1, channelName: identifier[0].(string), messageIdentifier: 1, connection: dtxConn, messageDispatcher: messageDispatcher, responseWaiters: map[int]chan Message{}, defragmenters: map[int]*FragmentDecoder{}, timeout: 5 * time.Second}
 	dtxConn.activeChannels.Store(-1, channel)
+	return channel
+}
+
+func (dtxConn *Connection) AddMinusOneReceiver(messageDispatcher Dispatcher) *Channel {
+	//4294967295
+	channel := &Channel{channelCode: -1, channelName: "c -1/ 4294967295 receiver channel ", messageIdentifier: 1, connection: dtxConn, messageDispatcher: messageDispatcher, responseWaiters: map[int]chan Message{}, defragmenters: map[int]*FragmentDecoder{}, timeout: 5 * time.Second}
+	dtxConn.activeChannels.Store(4294967295, channel)
 	return channel
 }
 

--- a/ios/instruments/instruments_channels.go
+++ b/ios/instruments/instruments_channels.go
@@ -1,0 +1,15 @@
+package instruments
+
+const deviceInfoChannel = "com.apple.instruments.server.services.deviceinfo"
+
+const xpcControlChannel = "com.apple.instruments.server.services.device.xpccontrol"
+const procControlChannel = "com.apple.instruments.server.services.processcontrol"
+const procControlPosixSpawnChannel = "com.apple.instruments.server.services.processcontrol.posixspawn"
+const mobileNotificationsChannel = "com.apple.instruments.server.services.mobilenotifications"
+
+const appListingChannel = "com.apple.instruments.server.services.device.applictionListing"
+
+const watchProcessControlChannel = "com.apple.dt.Xcode.WatchProcessControl"
+
+const assetsChannel = "com.apple.instruments.server.services.assets"
+const activityTraceTapChannel = "com.apple.instruments.server.services.activitytracetap"

--- a/ios/instruments/metrics.go
+++ b/ios/instruments/metrics.go
@@ -1,3 +1,43 @@
 package instruments
 
+import (
+	"github.com/danielpaulus/go-ios/ios"
+	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
+	log "github.com/sirupsen/logrus"
+)
 
+type yo struct {
+}
+
+func (y yo) Dispatch(msg dtx.Message) {
+
+	log.Infof("%+v", msg.Payload[0])
+	if "applicationStateNotification:" == msg.Payload[0].(string) {
+		log.Infof("%+v", msg.Auxiliary)
+	}
+}
+
+func GetMetrics(device ios.DeviceEntry) error {
+	conn, err := connectInstruments(device)
+	if err != nil {
+		return err
+	}
+	conn.AddMinusOneReceiver(yo{})
+	channel := conn.RequestChannelIdentifier(mobileNotificationsChannel, yo{})
+	resp, err := channel.MethodCall("setApplicationStateNotificationsEnabled:", true)
+	if err != nil {
+		log.Errorf("resp:%+v, %+v", resp, resp.Payload[0])
+		return err
+	}
+	log.Infof("ok: %+v", resp)
+	resp, err = channel.MethodCall("setMemoryNotificationsEnabled:", true)
+	if err != nil {
+		log.Errorf("resp:%+v, %+v", resp, resp.Payload[0])
+		return err
+	}
+	log.Infof("ok: %+v", resp)
+	/*
+		INFO[0006] 9.0 c5 setApplicationStateNotificationsEnabled: [{t:binary, v:true},]  d=out id="#43"
+		INFO[0006] 10.0 c5 setMemoryNotificationsEnabled: [{t:binary, v:true},]  d=out id="#43"*/
+	return nil
+}

--- a/ios/instruments/metrics.go
+++ b/ios/instruments/metrics.go
@@ -1,8 +1,10 @@
 package instruments
 
 import (
+	"encoding/json"
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
+	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -13,7 +15,14 @@ func (y yo) Dispatch(msg dtx.Message) {
 
 	log.Infof("%+v", msg.Payload[0])
 	if "applicationStateNotification:" == msg.Payload[0].(string) {
-		log.Infof("%+v", msg.Auxiliary)
+		data, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
+		if err != nil {
+			log.Warn(err)
+		}
+		resp := data[0]
+		jsonString, err := json.Marshal(resp)
+		println(string(jsonString))
+		//log.Infof("%+v", data)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ Usage:
   ios image auto [--basedir=<where_dev_images_are_stored>] [options]
   ios syslog [options]
   ios screenshot [options] [--output=<outfile>]
+  ios instruments [options]
   ios crash ls [<pattern>] [options]
   ios crash cp <srcpattern> <target> [options]
   ios crash rm <cwd> <pattern> [options]
@@ -200,7 +201,7 @@ The commands work as following:
 	}
 
 	pretty, _ := arguments.Bool("--pretty")
-	if pretty{
+	if pretty {
 		prettyJSON = true
 	}
 
@@ -273,6 +274,9 @@ The commands work as following:
 	}
 
 	if crashCommand(device, arguments) {
+		return
+	}
+	if instrumentsCommand(device, arguments) {
 		return
 	}
 
@@ -514,7 +518,7 @@ The commands work as following:
 		svc, _ := installationproxy.New(device)
 
 		// Look for correct process exe name for this bundleID. By default, searches only user-installed apps.
-		if bundleID != ""{
+		if bundleID != "" {
 			response, err = svc.BrowseAllApps()
 			exitIfError("browsing apps failed", err)
 
@@ -745,6 +749,18 @@ func runWdaCommand(device ios.DeviceEntry, arguments docopt.Opts) bool {
 			os.Exit(1)
 		}
 		log.Info("Done Closing")
+	}
+	return b
+}
+
+func instrumentsCommand(device ios.DeviceEntry, arguments docopt.Opts) bool {
+	b, _ := arguments.Bool("instruments")
+	if b {
+		log.Info("yo")
+		instruments.GetMetrics(device)
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+		<-c
 	}
 	return b
 }
@@ -1036,7 +1052,7 @@ func printInstalledApps(device ios.DeviceEntry, system bool, all bool) {
 		response, err = svc.BrowseUserApps()
 		appType = "user"
 	}
-	exitIfError("browsing " + appType + " apps failed", err)
+	exitIfError("browsing "+appType+" apps failed", err)
 
 	if JSONdisabled {
 		log.Info(response)
@@ -1106,7 +1122,7 @@ func processList(device ios.DeviceEntry, applicationsOnly bool) {
 		var applicationProcessList []instruments.ProcessInfo
 		for _, processInfo := range processList {
 			if processInfo.IsApplication {
-				applicationProcessList = append(applicationProcessList,processInfo)
+				applicationProcessList = append(applicationProcessList, processInfo)
 			}
 		}
 		processList = applicationProcessList
@@ -1175,7 +1191,7 @@ func outputProcessListNoJSON(device ios.DeviceEntry, processes []instruments.Pro
 	})
 	svc, _ := installationproxy.New(device)
 	response, err := svc.BrowseAllApps()
-	appInfoByExecutableName := make(map[string] installationproxy.AppInfo)
+	appInfoByExecutableName := make(map[string]installationproxy.AppInfo)
 
 	if err != nil {
 		log.Error("browsing installed apps failed. bundleID will not be included in output")
@@ -1196,13 +1212,13 @@ func outputProcessListNoJSON(device ios.DeviceEntry, processes []instruments.Pro
 			maxNameLength = len(processInfo.Name)
 		}
 	}
-	maxPidLength := len(fmt.Sprintf("%d",maxPid))
+	maxPidLength := len(fmt.Sprintf("%d", maxPid))
 
 	fmt.Printf("%*s %-*s %s  %s\n", maxPidLength, "PID", maxNameLength, "NAME", "START_DATE         ", "BUNDLE_ID")
 	for _, processInfo := range processes {
 		bundleID := ""
 		appInfo, exists := appInfoByExecutableName[processInfo.Name]
-		if exists{
+		if exists {
 			bundleID = appInfo.CFBundleIdentifier
 		}
 		fmt.Printf("%*d %-*s %s  %s\n", maxPidLength, processInfo.Pid, maxNameLength, processInfo.Name, processInfo.StartDate.Format("2006-01-02 15:04:05"), bundleID)
@@ -1307,10 +1323,10 @@ func readPair(device ios.DeviceEntry) {
 	fmt.Printf("%s\n", json)
 }
 
-func marshalJSON(data interface{}) ([]byte, error){
-	if prettyJSON{
-		return json.MarshalIndent(data,"","    ")
-	}else{
+func marshalJSON(data interface{}) ([]byte, error) {
+	if prettyJSON {
+		return json.MarshalIndent(data, "", "    ")
+	} else {
 		return json.Marshal(data)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -756,7 +756,6 @@ func runWdaCommand(device ios.DeviceEntry, arguments docopt.Opts) bool {
 func instrumentsCommand(device ios.DeviceEntry, arguments docopt.Opts) bool {
 	b, _ := arguments.Bool("instruments")
 	if b {
-		log.Info("yo")
 		listenerFunc, closeFunc, err := instruments.ListenAppStateNotifications(device)
 		if err != nil {
 			log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ Usage:
   ios image auto [--basedir=<where_dev_images_are_stored>] [options]
   ios syslog [options]
   ios screenshot [options] [--output=<outfile>]
-  ios instruments [options]
+  ios instruments notifications [options]
   ios crash ls [<pattern>] [options]
   ios crash cp <srcpattern> <target> [options]
   ios crash rm <cwd> <pattern> [options]
@@ -130,6 +130,7 @@ The commands work as following:
    >                                                                  The default is the current dir. 
    ios syslog [options]                                               Prints a device's log output
    ios screenshot [options] [--output=<outfile>]                      Takes a screenshot and writes it to the current dir or to <outfile>
+   ios instruments notifications [options]                            Listen to application state notifications                                    
    ios crash ls [<pattern>] [options]                                 run "ios crash ls" to get all crashreports in a list, 
    >                                                                  or use a pattern like 'ios crash ls "*ips*"' to filter
    ios crash cp <srcpattern> <target> [options]                       copy "file pattern" to the target dir. Ex.: 'ios crash cp "*" "./crashes"'

--- a/main.go
+++ b/main.go
@@ -765,7 +765,8 @@ func instrumentsCommand(device ios.DeviceEntry, arguments docopt.Opts) bool {
 			for {
 				notification, err := listenerFunc()
 				if err != nil {
-					log.Fatal(err)
+					log.Error(err)
+					return
 				}
 				s, _ := json.Marshal(notification)
 				println(string(s))


### PR DESCRIPTION
As the first step of adding the remaining instruments features, I added listening to device state notifications. 
`ios instruments notifications [options]` will start a JSON stream of notifications that indicate when applications are opened or closed on the device. Example: 
```
{"appName":"Phone","displayID":"com.apple.mobilephone","elevated_state":2,"elevated_state_description":"Background Task Suspended","execName":"/Applications/MobilePhone.app","mach_absolute_time":2163024584939,"pid":379,"state":2,"state_description":"Background Task Suspended","timestamp":{"Timestamp":"2022-08-02T22:38:20.739+02:00"}}
```