### PR TITLE
Add deviceinfo service info to info command

### DIFF
--- a/ios/instruments/helper.go
+++ b/ios/instruments/helper.go
@@ -1,8 +1,10 @@
 package instruments
 
 import (
+	"fmt"
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
+	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -28,4 +30,38 @@ func connectInstruments(device ios.DeviceEntry) (*dtx.Connection, error) {
 		}
 	}
 	return dtxConn, nil
+}
+
+func toMap(msg dtx.Message) (string, map[string]interface{}, error) {
+	if len(msg.Payload) != 1 {
+		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v has payload size !=1", msg)
+	}
+	selector, ok := msg.Payload[0].(string)
+	if !ok {
+		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v payload: %+v wasn't a string", msg, msg.Payload[0])
+	}
+	args := msg.Auxiliary.GetArguments()
+	if len(args) == 0 {
+		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v has an empty auxiliary dictionary", msg)
+	}
+
+	data, ok := args[0].([]byte)
+	if !ok {
+		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v invalid aux", msg)
+	}
+
+	unarchived, err := nskeyedarchiver.Unarchive(data)
+	if err != nil {
+		return "", map[string]interface{}{}, err
+	}
+	if len(unarchived) == 0 {
+		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v invalid aux", msg)
+	}
+
+	aux, ok := unarchived[0].(map[string]interface{})
+	if !ok {
+		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v auxiliary: %+v didn't contain a map[string]interface{}", msg, msg.Payload[0])
+	}
+
+	return selector, aux, nil
 }

--- a/ios/instruments/helper.go
+++ b/ios/instruments/helper.go
@@ -65,3 +65,14 @@ func toMap(msg dtx.Message) (string, map[string]interface{}, error) {
 
 	return selector, aux, nil
 }
+
+func extractMapPayload(message dtx.Message) (map[string]interface{}, error) {
+	if len(message.Payload) != 1 {
+		return map[string]interface{}{}, fmt.Errorf("payload of message should have only one element: %+v", message)
+	}
+	response, ok := message.Payload[0].(map[string]interface{})
+	if !ok {
+		return map[string]interface{}{}, fmt.Errorf("payload type of message should be map[string]interface{}: %+v", message)
+	}
+	return response, nil
+}

--- a/ios/instruments/instruments_deviceinfo.go
+++ b/ios/instruments/instruments_deviceinfo.go
@@ -1,7 +1,6 @@
 package instruments
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/danielpaulus/go-ios/ios"
@@ -34,17 +33,6 @@ func (d DeviceInfoService) NameForPid(pid uint64) error {
 	return err
 }
 
-func ExtractMapPayload(message dtx.Message) (map[string]interface{}, error) {
-	if len(message.Payload) != 1 {
-		return map[string]interface{}{}, fmt.Errorf("payload of message should have only one element: %+v", message)
-	}
-	response, ok := message.Payload[0].(map[string]interface{})
-	if !ok {
-		return map[string]interface{}{}, fmt.Errorf("payload type of message should be map[string]interface{}: %+v", message)
-	}
-	return response, nil
-}
-
 // HardwareInformation gets some nice extra details from Instruments. Here is an example result for an old iPhone 5:
 // map[hwCPU64BitCapable:1 hwCPUsubtype:1 hwCPUtype:16777228 numberOfCpus:2 numberOfPhysicalCpus:2 speedOfCpus:0]
 func (d DeviceInfoService) HardwareInformation() (map[string]interface{}, error) {
@@ -52,7 +40,7 @@ func (d DeviceInfoService) HardwareInformation() (map[string]interface{}, error)
 	if err != nil {
 		return map[string]interface{}{}, err
 	}
-	return ExtractMapPayload(response)
+	return extractMapPayload(response)
 }
 
 // NetworkInformation gets a list of all network interfaces for the device. Example result:
@@ -63,7 +51,7 @@ func (d DeviceInfoService) NetworkInformation() (map[string]interface{}, error) 
 	if err != nil {
 		return map[string]interface{}{}, err
 	}
-	return ExtractMapPayload(response)
+	return extractMapPayload(response)
 }
 
 func mapToProcInfo(procList []interface{}) []ProcessInfo {

--- a/ios/instruments/instruments_notifications.go
+++ b/ios/instruments/instruments_notifications.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
-	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
 	log "github.com/sirupsen/logrus"
 	"io"
 	"time"
@@ -13,40 +12,6 @@ import (
 type channelDispatcher struct {
 	messageChannel chan dtx.Message
 	closeChannel   chan struct{}
-}
-
-func toMap(msg dtx.Message) (string, map[string]interface{}, error) {
-	if len(msg.Payload) != 1 {
-		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v has payload size !=1", msg)
-	}
-	selector, ok := msg.Payload[0].(string)
-	if !ok {
-		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v payload: %+v wasn't a string", msg, msg.Payload[0])
-	}
-	args := msg.Auxiliary.GetArguments()
-	if len(args) == 0 {
-		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v has an empty auxiliary dictionary", msg)
-	}
-
-	data, ok := args[0].([]byte)
-	if !ok {
-		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v invalid aux", msg)
-	}
-
-	unarchived, err := nskeyedarchiver.Unarchive(data)
-	if err != nil {
-		return "", map[string]interface{}{}, err
-	}
-	if len(unarchived) == 0 {
-		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v invalid aux", msg)
-	}
-
-	aux, ok := unarchived[0].(map[string]interface{})
-	if !ok {
-		return "", map[string]interface{}{}, fmt.Errorf("error extracting, msg %+v auxiliary: %+v didn't contain a map[string]interface{}", msg, msg.Payload[0])
-	}
-
-	return selector, aux, nil
 }
 
 func ListenAppStateNotifications(device ios.DeviceEntry) (func() (map[string]interface{}, error), func() error, error) {

--- a/main.go
+++ b/main.go
@@ -343,15 +343,13 @@ The commands work as following:
 		}
 		b, _ = arguments.Bool("toggle")
 		if b {
-			assistiveTouch(device, "toggle" , force)
+			assistiveTouch(device, "toggle", force)
 		}
 		b, _ = arguments.Bool("get")
 		if b {
 			assistiveTouch(device, "get", force)
 		}
 	}
-
-
 
 	b, _ = arguments.Bool("dproxy")
 	if b {
@@ -960,10 +958,10 @@ func assistiveTouch(device ios.DeviceEntry, operation string, force bool) {
 
 	wasEnabled, err := ios.GetAssistiveTouch(device)
 
-	if err != nil{
-		if force && ( operation == "enable" || operation == "disable" ) {
+	if err != nil {
+		if force && (operation == "enable" || operation == "disable") {
 			log.WithFields(log.Fields{"error": err}).Warn("Failed getting current AssistiveTouch status. Continuing anyway.")
-		} else{
+		} else {
 			exitIfError("failed getting current AssistiveTouch status", err)
 		}
 	}
@@ -973,12 +971,12 @@ func assistiveTouch(device ios.DeviceEntry, operation string, force bool) {
 		enable = true
 	case operation == "disable":
 		enable = false
-	case operation == "toggle": 
+	case operation == "toggle":
 		enable = !wasEnabled
 	default: // get
 		enable = wasEnabled
 	}
-	if operation != "get" && ( force || wasEnabled != enable ) {
+	if operation != "get" && (force || wasEnabled != enable) {
 		err = ios.SetAssistiveTouch(device, enable)
 		exitIfError("failed setting AssistiveTouch", err)
 	}
@@ -986,7 +984,7 @@ func assistiveTouch(device ios.DeviceEntry, operation string, force bool) {
 		if JSONdisabled {
 			fmt.Printf("%t\n", enable)
 		} else {
-			fmt.Println(convertToJSONString(map[string]bool{"AssistiveTouchEnabled":enable}))
+			fmt.Println(convertToJSONString(map[string]bool{"AssistiveTouchEnabled": enable}))
 		}
 	}
 }
@@ -1353,6 +1351,25 @@ func printDeviceInfo(device ios.DeviceEntry) {
 	if err != nil {
 		exitIfError("failed getting info", err)
 	}
+	svc, err := instruments.NewDeviceInfoService(device)
+	if err != nil {
+		log.Debugf("could not open instruments, probably dev image not mounted %v", err)
+	}
+	if err == nil {
+		info, err := svc.NetworkInformation()
+		if err != nil {
+			log.Debugf("error getting networkinfo from instruments %v", err)
+		} else {
+			allValues["instruments:networkInformation"] = info
+		}
+		info, err = svc.HardwareInformation()
+		if err != nil {
+			log.Debugf("error getting hardwareinfo from instruments %v", err)
+		} else {
+			allValues["instruments:hardwareInformation"] = info
+		}
+	}
+
 	fmt.Println(convertToJSONString(allValues))
 }
 


### PR DESCRIPTION
I added two new fields to the info command. The response of hardwareInformation and networkInformation from the instruments service are now in the results if a developer image is mounted. 
hardWareInformation contains various cpu infos. Here is an example:
map[hwCPU64BitCapable:1 hwCPUsubtype:1 hwCPUtype:16777228 numberOfCpus:2 numberOfPhysicalCpus:2 speedOfCpus:0]

networkInformation contains a list of all network interfaces on the device. Example: 
map[en0:Wi-Fi en1:Ethernet Adaptor (en1) en2:Ethernet Adaptor (en2) lo0:Loopback pdp_ip0:Cellular (pdp_ip0)
pdp_ip1:Cellular (pdp_ip1) pdp_ip2:Cellular (pdp_ip2) pdp_ip3:Cellular (pdp_ip3) pdp_ip4:Cellular (pdp_ip4)]

Those are now part of the `ios info` command output only if the developer image was mounted on the device. 