### PR TITLE
Fix shutdown error in TestXcuiTest() added in recent commit with new …

### DIFF
--- a/ios/testmanagerd/xcuitestrunner_test.go
+++ b/ios/testmanagerd/xcuitestrunner_test.go
@@ -53,7 +53,7 @@ func TestXcuiTest(t *testing.T) {
 	var wdaargs []string
 	var wdaenv []string
 	go func() {
-		err := testmanagerd.RunXCUIWithBundleIdsCtx(context.Background(), bundleID, testbundleID, xctestconfig, device, wdaargs, wdaenv)
+		err := testmanagerd.RunXCUIWithBundleIdsCtx(nil, bundleID, testbundleID, xctestconfig, device, wdaargs, wdaenv)
 
 		if err != nil {
 			log.WithFields(log.Fields{"error": err}).Fatal("Failed running WDA")


### PR DESCRIPTION
…context support

The new semantics of testmanagerd.RunXCUIWithBundleIdsCtx() are that if a context is passed, the context is supposed to have an associated cancel() method, which should be called to abort the method.  

Passing a context does not interact well with testmanagerd.CloseXCUITestRunner().  It appears that you should use one (the context) or the other (testmanagerd.CloseXCUITestRunner), not both.

It's arguable that this warrants a separate test, one for each invocation technique.

As it stands, I haven't run the test since I don't have wda available to install, but I can confirm this is an issue in the invocation made from main.go "runwda".