### PR TITLE
Exit with error when attempting to forward an unavailable port.

### DIFF
--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -22,11 +22,11 @@ func Forward(device ios.DeviceEntry, hostPort uint16, phonePort uint16) error {
 	log.Infof("Start listening on port %d forwarding to port %d on device", hostPort, phonePort)
 	l, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", hostPort))
 
-	go connectionAccept(l, device.DeviceID, phonePort)
-
 	if err != nil {
 		return err
 	}
+
+	go connectionAccept(l, device.DeviceID, phonePort)
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -1095,7 +1095,8 @@ func handleProfileList(device ios.DeviceEntry) {
 }
 
 func startForwarding(device ios.DeviceEntry, hostPort int, targetPort int) {
-	forward.Forward(device, uint16(hostPort), uint16(targetPort))
+	err := forward.Forward(device, uint16(hostPort), uint16(targetPort))
+	exitIfError("failed to forward port", err)
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	<-c


### PR DESCRIPTION
Previous code has an out-of-order error check, starting a thread and *then* returning on error.  This leads to a null-pointer panic if you attempt to forward a port that is already in use.
