### PR TITLE
support list parameter when print apps && get disk space info

### DIFF
--- a/ios/afc/afc.go
+++ b/ios/afc/afc.go
@@ -16,6 +16,7 @@ const (
 	Afc_operation_remove_path      uint64 = 0x00000008
 	Afc_operation_make_dir         uint64 = 0x00000009
 	Afc_operation_file_info        uint64 = 0x0000000A
+	Afc_operation_device_info      uint64 = 0x0000000B
 	Afc_operation_file_open        uint64 = 0x0000000D
 	Afc_operation_file_close       uint64 = 0x00000014
 	Afc_operation_file_write       uint64 = 0x00000010

--- a/ios/utils.go
+++ b/ios/utils.go
@@ -115,3 +115,16 @@ func FixWindowsPaths(path string) string {
 	}
 	return path
 }
+
+func ByteCountDecimal(b int64) string {
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%dB", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%cB", float64(b)/float64(div), "kMGTPE"[exp])
+}

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ Usage:
   ios setlocationgpx [options] [--gpxfilepath=<gpxfilepath>]
   ios resetlocation [options]
   ios assistivetouch (enable | disable | toggle | get) [--force] [options]
+  ios diskspace
 
 Options:
   -v --verbose   Enable Debug Logging.
@@ -191,6 +192,7 @@ The commands work as following:
    ios setlocationgpx [options] [--gpxfilepath=<gpxfilepath>]         Updates the location of the device based on the data in a GPX file. Example: setlocationgpx --gpxfilepath=/home/username/location.gpx
    ios resetlocation [options]                                        Resets the location of the device to the actual one
    ios assistivetouch (enable | disable | toggle | get) [--force] [options] Enables, disables, toggles, or returns the state of the "AssistiveTouch" software home-screen button. iOS 11+ only (Use --force to try on older versions).
+   ios diskspace 													  Prints disk space info.
 
   `, version)
 	arguments, err := docopt.ParseDoc(usage)
@@ -680,6 +682,22 @@ The commands work as following:
 			exitIfError("fsync: push failed", err)
 		}
 		afcService.Close()
+		return
+	}
+
+	b, _ = arguments.Bool("diskspace")
+	if b {
+		afcService, err := afc.New(device)
+		exitIfError("connect afc service failed", err)
+		info, err := afcService.GetSpaceInfo()
+		if err != nil {
+			exitIfError("get device info push failed", err)
+		}
+		fmt.Printf("      Model: %s\n", info.Model)
+		fmt.Printf("  BlockSize: %d\n", info.BlockSize/8)
+		fmt.Printf("  FreeSpace: %s\n", ios.ByteCountDecimal(int64(info.FreeBytes)))
+		fmt.Printf("  UsedSpace: %s\n", ios.ByteCountDecimal(int64(info.TotalBytes-info.FreeBytes)))
+		fmt.Printf(" TotalSpace: %s\n", ios.ByteCountDecimal(int64(info.TotalBytes)))
 		return
 	}
 }

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ Usage:
   ios pcap [options] [--pid=<processID>] [--process=<processName>]
   ios install --path=<ipaOrAppFolder> [options]
   ios uninstall <bundleID> [options]
-  ios apps [--system] [--all] [options]
+  ios apps [--system] [--all] [--list] [options]
   ios launch <bundleID> [options]
   ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options]
   ios runtest <bundleID> [options]
@@ -409,9 +409,10 @@ The commands work as following:
 	b, _ = arguments.Bool("apps")
 
 	if b {
+		list, _ := arguments.Bool("--list")
 		system, _ := arguments.Bool("--system")
 		all, _ := arguments.Bool("--all")
-		printInstalledApps(device, system, all)
+		printInstalledApps(device, system, all, list)
 		return
 	}
 
@@ -1124,7 +1125,7 @@ func printDeviceDate(device ios.DeviceEntry) {
 	}
 
 }
-func printInstalledApps(device ios.DeviceEntry, system bool, all bool) {
+func printInstalledApps(device ios.DeviceEntry, system bool, all bool, list bool) {
 	svc, _ := installationproxy.New(device)
 	var err error
 	var response []installationproxy.AppInfo
@@ -1140,6 +1141,13 @@ func printInstalledApps(device ios.DeviceEntry, system bool, all bool) {
 		appType = "user"
 	}
 	exitIfError("browsing "+appType+" apps failed", err)
+
+	if list {
+		for _, v := range response {
+			fmt.Printf("%s %s %s\n", v.CFBundleIdentifier, v.CFBundleName, v.CFBundleShortVersionString)
+		}
+		return
+	}
 
 	if JSONdisabled {
 		log.Info(response)


### PR DESCRIPTION
* [support list parameter when print apps](https://github.com/danielpaulus/go-ios/pull/165/commits/2db3aee41e77095fbc8df56b4b6357c086c06ac3)
```
go-ios apps --list
```
why do this?
now, every time we check the app list, it outputs a lot of information. But more often, we only care about the bundle ID, bundle name and version number. Therefore, adding a -- list parameter can clearly display the three information mentioned above.

* [support get disk space info](https://github.com/danielpaulus/go-ios/pull/165/commits/c45fe938fbfca286cece0e11bf06dc46e5152431)
```
go-ios diskspace
```
from this command, we can obtain the disk space information, including: total size, used szie, free size and block size.
