### PR TITLE
Fix build on armv7l

### DIFF
--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"math"
 
 	ios "github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
@@ -171,7 +172,7 @@ func (dtxConn *Connection) ForChannelRequest(messageDispatcher Dispatcher) *Chan
 // This channel seems to always be there without explicitly requesting it and sometimes it is used.
 func (dtxConn *Connection) AddDefaultChannelReceiver(messageDispatcher Dispatcher) *Channel {
 	channel := &Channel{channelCode: -1, channelName: "c -1/ 4294967295 receiver channel ", messageIdentifier: 1, connection: dtxConn, messageDispatcher: messageDispatcher, responseWaiters: map[int]chan Message{}, defragmenters: map[int]*FragmentDecoder{}, timeout: 5 * time.Second}
-	dtxConn.activeChannels.Store(4294967295, channel)
+	dtxConn.activeChannels.Store(uint32(math.MaxUint32), channel)
 	return channel
 }
 


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19AzwRdqzwn13RkocrFYbYMaMMcbaCW8LU%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=USFGXaU)
If we try to build on armv7l we have this error : 
ios/dtx_codec/connection.go:174:31: cannot use 4294967295 (untyped int constant) as int value in argument to dtxConn.activeChannels.Store (overflows)

this fix this issue : #175 