### PR TITLE
Add endpoints for changing device location

### DIFF
--- a/ios/simlocation/simlocation.go
+++ b/ios/simlocation/simlocation.go
@@ -162,7 +162,10 @@ func SetLocationGPX(device ios.DeviceEntry, filePath string) error {
 				pointLat := point.PointLatitude
 
 				// Set the current point location by its latitude and longitude
-				SetLocation(device, pointLat, pointLon)
+				err = SetLocation(device, pointLat, pointLon)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/restapi/api/device_endpoints.go
+++ b/restapi/api/device_endpoints.go
@@ -95,9 +95,9 @@ func SetLocation(c *gin.Context) {
 	err := simlocation.SetLocation(device, latitude, longtitude)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, GenericResponse{Error: err.Error()})
-	} else {
-		c.JSON(http.StatusOK, GenericResponse{Message: "Device location set to latitude=" + latitude + ", longtitude=" + longtitude})
+		return
 	}
+	c.JSON(http.StatusOK, GenericResponse{Message: "Device location set to latitude=" + latitude + ", longtitude=" + longtitude})
 }
 
 // Reset to the actual device location
@@ -113,7 +113,7 @@ func ResetLocation(c *gin.Context) {
 	err := simlocation.ResetLocation(device)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, GenericResponse{Error: err.Error()})
-	} else {
-		c.JSON(http.StatusOK, GenericResponse{Message: "Device location reset"})
+		return
 	}
+	c.JSON(http.StatusOK, GenericResponse{Message: "Device location reset"})
 }

--- a/restapi/api/device_endpoints.go
+++ b/restapi/api/device_endpoints.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/instruments"
 	"github.com/danielpaulus/go-ios/ios/screenshotr"
+	"github.com/danielpaulus/go-ios/ios/simlocation"
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
-	"net/http"
 )
 
 // Info gets device info
@@ -63,4 +65,55 @@ func Screenshot(c *gin.Context) {
 
 	c.Header("Content-Type", "image/png")
 	c.Data(http.StatusOK, "application/octet-stream", b)
+}
+
+// Change the current device location
+// @Summary      Change the current device location
+// @Description Change the current device location to provided latitude and longtitude
+// @Tags         general_device_specific
+// @Produce      json
+// @Param        latitude  query      string  true  "Location latitude"
+// @Param        longtitude  query      string  true  "Location longtitude"
+// @Success      200  {object}  GenericResponse
+// @Failure		 422  {object}  GenericResponse
+// @Failure		 500  {object}  GenericResponse
+// @Router       /device/{udid}/setlocation [post]
+func SetLocation(c *gin.Context) {
+	device := c.MustGet(IOS_KEY).(ios.DeviceEntry)
+	latitude := c.Query("latitude")
+	if latitude == "" {
+		c.JSON(http.StatusUnprocessableEntity, GenericResponse{Error: "latitude query param is missing"})
+		return
+	}
+
+	longtitude := c.Query("longtitude")
+	if longtitude == "" {
+		c.JSON(http.StatusUnprocessableEntity, GenericResponse{Error: "longtitude query param is missing"})
+		return
+	}
+
+	err := simlocation.SetLocation(device, latitude, longtitude)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, GenericResponse{Error: err.Error()})
+	} else {
+		c.JSON(http.StatusOK, GenericResponse{Message: "Device location set to latitude=" + latitude + ", longtitude=" + longtitude})
+	}
+}
+
+// Reset to the actual device location
+// @Summary      Reset the changed device location
+// @Description  Reset the changed device location to the actual one
+// @Tags         general_device_specific
+// @Produce      json
+// @Success      200
+// @Failure      500  {object}  GenericResponse
+// @Router       /device/{udid}/resetlocation [post]
+func ResetLocation(c *gin.Context) {
+	device := c.MustGet(IOS_KEY).(ios.DeviceEntry)
+	err := simlocation.ResetLocation(device)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, GenericResponse{Error: err.Error()})
+	} else {
+		c.JSON(http.StatusOK, GenericResponse{Message: "Device location reset"})
+	}
 }

--- a/restapi/api/routes.go
+++ b/restapi/api/routes.go
@@ -8,7 +8,7 @@ func registerRoutes(router *gin.RouterGroup) {
 	device.Use(DeviceMiddleware())
 	device.GET("/info", Info)
 	device.GET("/screenshot", Screenshot)
-	device.POST("/setlocation", SetLocation)
+	device.PUT("/setlocation", SetLocation)
 	device.POST("/resetlocation", ResetLocation)
 
 	initAppRoutes(device)

--- a/restapi/api/routes.go
+++ b/restapi/api/routes.go
@@ -8,6 +8,8 @@ func registerRoutes(router *gin.RouterGroup) {
 	device.Use(DeviceMiddleware())
 	device.GET("/info", Info)
 	device.GET("/screenshot", Screenshot)
+	device.POST("/setlocation", SetLocation)
+	device.POST("/resetlocation", ResetLocation)
 
 	initAppRoutes(device)
 	initStreamingResponseRoutes(device, router)

--- a/restapi/api/util.go
+++ b/restapi/api/util.go
@@ -3,14 +3,20 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"math"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
+
+type GenericResponse struct {
+	Message string `json:"message,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
 
 //GetVersion reads the contents of the file version.txt and returns it.
 //If the file cannot be read, it returns "could not read version"


### PR DESCRIPTION
* Added `GenericResponse` struct to have a single interface that can be used to return both errors and meaningful messages where applicable, instead of generating JSON on each spot with `gin.H` or whatever. If you are okay with this I can later update the existing functions
* Added endpoint to change the current device location by `latitude` and `longtitude` query params  
* Added endpoint to reset the device location to the actual one  
* Bubbled up an unhandled error in my own code for device location simulation