### PR TITLE
Remove panics from code 

### DIFF
--- a/ios/accessibility/accessibility_control.go
+++ b/ios/accessibility/accessibility_control.go
@@ -3,7 +3,7 @@ package accessibility
 import (
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
 	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // ControlInterface provides a simple interface to controlling the AX service on the device
@@ -17,10 +17,10 @@ func (a ControlInterface) readhostAppStateChanged() {
 		msg := a.channel.ReceiveMethodCall("hostAppStateChanged:")
 		stateChange, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
 		if err != nil {
-			logrus.WithError(err).Error("Failed unarchiving NSKeyedArchiver plists")
+			log.WithError(err).Error("Failed unarchiving NSKeyedArchiver plists")
 		}
 		value := stateChange[0]
-		logrus.Infof("hostAppStateChanged:%s", value)
+		log.Infof("hostAppStateChanged:%s", value)
 	}
 }
 
@@ -29,10 +29,10 @@ func (a ControlInterface) readhostInspectorNotificationReceived() {
 		msg := a.channel.ReceiveMethodCall("hostInspectorNotificationReceived:")
 		notification, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
 		if err != nil {
-			logrus.WithError(err).Error("Failed unarchiving NSKeyedArchiver plists")
+			log.WithError(err).Error("Failed unarchiving NSKeyedArchiver plists")
 		}
 		value := notification[0].(map[string]interface{})["Value"]
-		logrus.Infof("hostInspectorNotificationReceived:%s", value)
+		log.Infof("hostInspectorNotificationReceived:%s", value)
 	}
 }
 
@@ -55,30 +55,30 @@ func (a ControlInterface) init() error {
 		return err
 	}
 
-	logrus.Info("Device Capabilities:", deviceCapabilities)
+	log.Info("Device Capabilities:", deviceCapabilities)
 	apiVersion, err := a.deviceAPIVersion()
 	if err != nil {
 		return err
 	}
-	logrus.Info("Api version:", apiVersion)
+	log.Info("Api version:", apiVersion)
 
 	auditCaseIds, err := a.deviceAllAuditCaseIDs()
 	if err != nil {
 		return err
 	}
-	logrus.Info("AuditCaseIDs", auditCaseIds)
+	log.Info("AuditCaseIDs", auditCaseIds)
 
 	deviceInspectorSupportedEventTypes, err := a.deviceInspectorSupportedEventTypes()
 	if err != nil {
 		return err
 	}
-	logrus.Info("deviceInspectorSupportedEventTypes:", deviceInspectorSupportedEventTypes)
+	log.Info("deviceInspectorSupportedEventTypes:", deviceInspectorSupportedEventTypes)
 
 	canNav, err := a.deviceInspectorCanNavWhileMonitoringEvents()
 	if err != nil {
 		return err
 	}
-	logrus.Info("deviceInspectorCanNavWhileMonitoringEvents:", canNav)
+	log.Info("deviceInspectorCanNavWhileMonitoringEvents:", canNav)
 
 	err = a.deviceSetAppMonitoringEnabled(true)
 	if err != nil {
@@ -90,7 +90,7 @@ func (a ControlInterface) init() error {
 		if err != nil {
 			return err
 		}
-		logrus.Infof("%s -- %s", v, name)
+		log.Infof("%s -- %s", v, name)
 	}
 	return nil
 }
@@ -108,7 +108,7 @@ func (a ControlInterface) EnableSelectionMode() {
 func (a ControlInterface) SwitchToDevice() {
 	a.TurnOff()
 	resp, _ := a.deviceAccessibilitySettings()
-	logrus.Info("AX Settings received:", resp)
+	log.Info("AX Settings received:", resp)
 	a.deviceInspectorShowIgnoredElements(false)
 	a.deviceSetAuditTargetPid(0)
 	a.deviceInspectorFocusOnElement()
@@ -131,20 +131,20 @@ func (a ControlInterface) TurnOff() {
 
 // GetElement moves the green selection rectangle one element further
 func (a ControlInterface) GetElement() {
-	logrus.Info("changing")
+	log.Info("changing")
 	a.deviceInspectorMoveWithOptions()
 	//a.deviceInspectorMoveWithOptions()
 
 	resp := a.awaitHostInspectorCurrentElementChanged()
-	logrus.Info("item changed", resp)
+	log.Info("item changed", resp)
 }
 
 func (a ControlInterface) awaitHostInspectorCurrentElementChanged() map[string]interface{} {
 	msg := a.channel.ReceiveMethodCall("hostInspectorCurrentElementChanged:")
-	logrus.Info("received hostInspectorCurrentElementChanged")
+	log.Info("received hostInspectorCurrentElementChanged")
 	result, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
 	if err != nil {
-		logrus.WithError(err).Error("Failed unarchiving NSKeyedArchiver plists")
+		log.WithError(err).Error("Failed unarchiving NSKeyedArchiver plists")
 	}
 	return result[0].(map[string]interface{})
 }
@@ -152,7 +152,7 @@ func (a ControlInterface) awaitHostInspectorCurrentElementChanged() map[string]i
 func (a ControlInterface) awaitHostInspectorMonitoredEventTypeChanged() {
 	msg := a.channel.ReceiveMethodCall("hostInspectorMonitoredEventTypeChanged:")
 	n, _ := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
-	logrus.Infof("hostInspectorMonitoredEventTypeChanged: was set to %d by the device", n[0])
+	log.Infof("hostInspectorMonitoredEventTypeChanged: was set to %d by the device", n[0])
 }
 
 func (a ControlInterface) deviceInspectorMoveWithOptions() {

--- a/ios/debugproxy/binforward.go
+++ b/ios/debugproxy/binforward.go
@@ -6,17 +6,17 @@ import (
 	"path"
 
 	ios "github.com/danielpaulus/go-ios/ios"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type serviceConfig struct {
-	codec            func(string, string, *log.Entry) decoder
+	codec            func(string, string, *logrus.Entry) decoder
 	handshakeOnlySSL bool
 }
 
-//serviceConfigurations stores info about which codec to use for which service by name.
-//In addition, DTX based services only execute a SSL Handshake
-//and then go back to sending unencrypted data right after the handshake.
+// serviceConfigurations stores info about which codec to use for which service by name.
+// In addition, DTX based services only execute a SSL Handshake
+// and then go back to sending unencrypted data right after the handshake.
 var serviceConfigurations = map[string]serviceConfig{
 	"com.apple.instruments.remoteserver":                      {NewDtxDecoder, true},
 	"com.apple.accessibility.axAuditDaemon.remoteserver":      {NewDtxDecoder, true},
@@ -64,7 +64,7 @@ func handleConnectToService(connectRequest ios.UsbMuxMessage,
 	serviceInfo PhoneServiceInformation) {
 	err := muxToDevice.SendMuxMessage(connectRequest)
 	if err != nil {
-		panic("Failed sending muxmessage to device")
+		logrus.WithError(err).Error("Failed sending muxmessage to device")
 	}
 	connectResponse, err := muxToDevice.ReadMessage()
 	muxOnUnixSocket.SendMuxMessage(connectResponse)
@@ -128,7 +128,7 @@ func proxyBinFromDeviceToHost(p *ProxyConnection, binOnUnixSocket BinaryForwardi
 			p.log.Debug("Failed reading bytes", err)
 			return
 		}
-		p.log.WithFields(log.Fields{"direction": "device2host"}).Trace(hex.Dump(bytes))
+		p.log.WithFields(logrus.Fields{"direction": "device2host"}).Trace(hex.Dump(bytes))
 		binOnUnixSocket.Send(bytes)
 	}
 }

--- a/ios/debugproxy/binforward.go
+++ b/ios/debugproxy/binforward.go
@@ -6,11 +6,11 @@ import (
 	"path"
 
 	ios "github.com/danielpaulus/go-ios/ios"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type serviceConfig struct {
-	codec            func(string, string, *logrus.Entry) decoder
+	codec            func(string, string, *log.Entry) decoder
 	handshakeOnlySSL bool
 }
 
@@ -64,7 +64,7 @@ func handleConnectToService(connectRequest ios.UsbMuxMessage,
 	serviceInfo PhoneServiceInformation) {
 	err := muxToDevice.SendMuxMessage(connectRequest)
 	if err != nil {
-		logrus.WithError(err).Error("Failed sending muxmessage to device")
+		log.WithError(err).Error("Failed sending muxmessage to device")
 	}
 	connectResponse, err := muxToDevice.ReadMessage()
 	muxOnUnixSocket.SendMuxMessage(connectResponse)
@@ -128,7 +128,7 @@ func proxyBinFromDeviceToHost(p *ProxyConnection, binOnUnixSocket BinaryForwardi
 			p.log.Debug("Failed reading bytes", err)
 			return
 		}
-		p.log.WithFields(logrus.Fields{"direction": "device2host"}).Trace(hex.Dump(bytes))
+		p.log.WithFields(log.Fields{"direction": "device2host"}).Trace(hex.Dump(bytes))
 		binOnUnixSocket.Send(bytes)
 	}
 }

--- a/ios/debugproxy/debugproxy.go
+++ b/ios/debugproxy/debugproxy.go
@@ -18,7 +18,7 @@ import (
 
 const connectionJSONFileName = "connections.json"
 
-//DebugProxy can be used to dump and modify communication between mac and host
+// DebugProxy can be used to dump and modify communication between mac and host
 type DebugProxy struct {
 	mux               sync.Mutex
 	serviceList       []PhoneServiceInformation
@@ -26,14 +26,14 @@ type DebugProxy struct {
 	WorkingDir        string
 }
 
-//PhoneServiceInformation contains info about a service started on the phone via lockdown.
+// PhoneServiceInformation contains info about a service started on the phone via lockdown.
 type PhoneServiceInformation struct {
 	ServicePort uint16
 	ServiceName string
 	UseSSL      bool
 }
 
-//ProxyConnection keeps track of the pairRecord and uses an ID to identify connections.
+// ProxyConnection keeps track of the pairRecord and uses an ID to identify connections.
 type ProxyConnection struct {
 	id         string
 	pairRecord ios.PairRecord
@@ -77,12 +77,12 @@ func (d *DebugProxy) retrieveServiceInfoByPort(port uint16) (PhoneServiceInforma
 	return PhoneServiceInformation{}, fmt.Errorf("No Service found for port %d", port)
 }
 
-//NewDebugProxy creates a new Default proxy
+// NewDebugProxy creates a new Default proxy
 func NewDebugProxy() *DebugProxy {
 	return &DebugProxy{mux: sync.Mutex{}, serviceList: []PhoneServiceInformation{}}
 }
 
-//Launch moves the original /var/run/usbmuxd to /var/run/usbmuxd.real and starts the server at /var/run/usbmuxd
+// Launch moves the original /var/run/usbmuxd to /var/run/usbmuxd.real and starts the server at /var/run/usbmuxd
 func (d *DebugProxy) Launch(device ios.DeviceEntry, binaryMode bool) error {
 	if binaryMode {
 		log.Info("Lauching proxy in full binary mode")
@@ -161,7 +161,7 @@ func startProxyConnection(conn net.Conn, originalSocket string, pairRecord ios.P
 
 }
 
-//Close moves /var/run/usbmuxd.real back to /var/run/usbmuxd and disconnects all active proxy connections
+// Close moves /var/run/usbmuxd.real back to /var/run/usbmuxd and disconnects all active proxy connections
 func (d *DebugProxy) Close() {
 	log.Info("Moving back original socket")
 	err := MoveBack(ios.DefaultUsbmuxdSocket)
@@ -206,7 +206,7 @@ func writeJSON(filePath string, JSON interface{}) {
 	file, err := os.OpenFile(filePath,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		panic(fmt.Sprintf("Could not write to file err: %v filepath:'%s'", err, filePath))
+		logrus.Info(fmt.Sprintf("Could not write to file err: %v filepath:'%s'", err, filePath))
 	}
 	jsonmsg, err := json.Marshal(JSON)
 	if err != nil {

--- a/ios/debugproxy/debugproxy.go
+++ b/ios/debugproxy/debugproxy.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	ios "github.com/danielpaulus/go-ios/ios"
-
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -39,7 +37,7 @@ type ProxyConnection struct {
 	pairRecord ios.PairRecord
 	debugProxy *DebugProxy
 	info       ConnectionInfo
-	log        *logrus.Entry
+	log        *log.Entry
 	mux        sync.Mutex
 	closed     bool
 }
@@ -206,7 +204,7 @@ func writeJSON(filePath string, JSON interface{}) {
 	file, err := os.OpenFile(filePath,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		logrus.Info(fmt.Sprintf("Could not write to file err: %v filepath:'%s'", err, filePath))
+		log.Info(fmt.Sprintf("Could not write to file err: %v filepath:'%s'", err, filePath))
 	}
 	jsonmsg, err := json.Marshal(JSON)
 	if err != nil {

--- a/ios/debugproxy/muxhandler.go
+++ b/ios/debugproxy/muxhandler.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	ios "github.com/danielpaulus/go-ios/ios"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"howett.net/plist"
 )
 
@@ -32,7 +32,7 @@ func proxyUsbMuxConnection(p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnec
 		}
 		p.logJSONMessageToDevice(map[string]interface{}{"header": request.Header, "payload": decodedRequest, "type": "USBMUX"})
 
-		p.log.WithFields(log.Fields{"ID": p.id, "direction": "host->device"}).Trace(decodedRequest)
+		p.log.WithFields(logrus.Fields{"ID": p.id, "direction": "host->device"}).Trace(decodedRequest)
 		if decodedRequest["MessageType"] == "Connect" {
 			handleConnect(request, decodedRequest, p, muxOnUnixSocket, muxToDevice)
 			return
@@ -45,7 +45,7 @@ func proxyUsbMuxConnection(p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnec
 			continue
 		}
 		if err != nil {
-			panic(fmt.Sprintf("Failed forwarding message to device: %+v", request))
+			logrus.WithField("message", request).WithError(err).Error("Failed forwarding message to device")
 		}
 		if decodedRequest["MessageType"] == "Listen" {
 			handleListen(p, muxOnUnixSocket, muxToDevice)
@@ -60,7 +60,7 @@ func proxyUsbMuxConnection(p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnec
 			p.log.Info("Failed decoding MuxMessage", decodedResponse, err)
 		}
 		p.logJSONMessageFromDevice(map[string]interface{}{"header": response.Header, "payload": decodedResponse, "type": "USBMUX"})
-		p.log.WithFields(log.Fields{"ID": p.id, "direction": "device->host"}).Trace(decodedResponse)
+		p.log.WithFields(logrus.Fields{"ID": p.id, "direction": "device->host"}).Trace(decodedResponse)
 		err = muxOnUnixSocket.SendMuxMessage(response)
 	}
 }
@@ -80,7 +80,7 @@ func handleReadPairRecord(p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnect
 	response.Payload = newPayload
 	response.Header.Length = uint32(len(newPayload) + 16)
 	p.logJSONMessageFromDevice(map[string]interface{}{"header": response.Header, "payload": decodedResponse, "type": "USBMUX"})
-	p.log.WithFields(log.Fields{"ID": p.id, "direction": "device->host"}).Trace(decodedResponse)
+	p.log.WithFields(logrus.Fields{"ID": p.id, "direction": "device->host"}).Trace(decodedResponse)
 	err = muxOnUnixSocket.SendMuxMessage(response)
 }
 
@@ -101,7 +101,7 @@ func handleConnect(connectRequest ios.UsbMuxMessage, decodedConnectRequest map[s
 	} else {
 		info, err := p.debugProxy.retrieveServiceInfoByPort(ios.Ntohs(uint16(port)))
 		if err != nil {
-			panic(fmt.Sprintf("ServiceInfo for port: %d not found, this is a bug :-)reqheader: %+v repayload: %x", port, connectRequest.Header, connectRequest.Payload))
+			logrus.Info(fmt.Sprintf("ServiceInfo for port: %d not found, this is a bug :-)reqheader: %+v repayload: %x", port, connectRequest.Header, connectRequest.Payload))
 		}
 		p.log.Infof("Connection to service '%s' detected on port %d", info.ServiceName, info.ServicePort)
 		handleConnectToService(connectRequest, decodedConnectRequest, p, muxOnUnixSocket, muxToDevice, info)
@@ -111,7 +111,7 @@ func handleConnect(connectRequest ios.UsbMuxMessage, decodedConnectRequest map[s
 func handleConnectToLockdown(connectRequest ios.UsbMuxMessage, decodedConnectRequest map[string]interface{}, p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnection, muxToDevice *ios.UsbMuxConnection) {
 	err := muxToDevice.SendMuxMessage(connectRequest)
 	if err != nil {
-		panic("Failed sending muxmessage to device")
+		logrus.WithError(err).Error("Failed sending muxmessage to device")
 	}
 	connectResponse, err := muxToDevice.ReadMessage()
 	muxOnUnixSocket.SendMuxMessage(connectResponse)
@@ -131,7 +131,7 @@ func handleListen(p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnection, mux
 			p.LogClosed()
 			return
 		}
-		p.log.WithFields(log.Fields{"error": err}).Error("Unexpected error on read for LISTEN connection")
+		p.log.WithFields(logrus.Fields{"error": err}).Error("Unexpected error on read for LISTEN connection")
 	}()
 
 	for {
@@ -157,7 +157,7 @@ func handleListen(p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnection, mux
 			p.log.Info("Failed decoding MuxMessage", decodedResponse, err)
 		}
 		p.logJSONMessageFromDevice(map[string]interface{}{"header": response.Header, "payload": decodedResponse, "type": "USBMUX"})
-		p.log.WithFields(log.Fields{"ID": p.id, "direction": "device->host"}).Trace(decodedResponse)
+		p.log.WithFields(logrus.Fields{"ID": p.id, "direction": "device->host"}).Trace(decodedResponse)
 		err = muxOnUnixSocket.SendMuxMessage(response)
 	}
 

--- a/ios/diagnostics/ioregistry.go
+++ b/ios/diagnostics/ioregistry.go
@@ -2,7 +2,7 @@ package diagnostics
 
 import (
 	ios "github.com/danielpaulus/go-ios/ios"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func ioregentryRequest(key string) []byte {
@@ -12,7 +12,7 @@ func ioregentryRequest(key string) []byte {
 	}
 	bt, err := ios.PlistCodec{}.Encode(requestMap)
 	if err != nil {
-		logrus.WithError(err).Error("query request encoding should never fail")
+		log.WithError(err).Error("query request encoding should never fail")
 	}
 	return bt
 }

--- a/ios/diagnostics/ioregistry.go
+++ b/ios/diagnostics/ioregistry.go
@@ -1,6 +1,9 @@
 package diagnostics
 
-import ios "github.com/danielpaulus/go-ios/ios"
+import (
+	ios "github.com/danielpaulus/go-ios/ios"
+	"github.com/sirupsen/logrus"
+)
 
 func ioregentryRequest(key string) []byte {
 	requestMap := map[string]interface{}{
@@ -9,7 +12,7 @@ func ioregentryRequest(key string) []byte {
 	}
 	bt, err := ios.PlistCodec{}.Encode(requestMap)
 	if err != nil {
-		panic("query request encoding should never fail")
+		logrus.WithError(err).Error("query request encoding should never fail")
 	}
 	return bt
 }

--- a/ios/diagnostics/mobilegestalt.go
+++ b/ios/diagnostics/mobilegestalt.go
@@ -1,6 +1,9 @@
 package diagnostics
 
-import ios "github.com/danielpaulus/go-ios/ios"
+import (
+	ios "github.com/danielpaulus/go-ios/ios"
+	"github.com/sirupsen/logrus"
+)
 
 func gestaltRequest(keys []string) []byte {
 	goodbyeMap := map[string]interface{}{
@@ -9,7 +12,7 @@ func gestaltRequest(keys []string) []byte {
 	}
 	bt, err := ios.PlistCodec{}.Encode(goodbyeMap)
 	if err != nil {
-		panic("gestalt request encoding should never fail")
+		logrus.WithError(err).Error("Encoding error")
 	}
 	return bt
 }

--- a/ios/diagnostics/mobilegestalt.go
+++ b/ios/diagnostics/mobilegestalt.go
@@ -2,7 +2,7 @@ package diagnostics
 
 import (
 	ios "github.com/danielpaulus/go-ios/ios"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func gestaltRequest(keys []string) []byte {
@@ -12,7 +12,7 @@ func gestaltRequest(keys []string) []byte {
 	}
 	bt, err := ios.PlistCodec{}.Encode(goodbyeMap)
 	if err != nil {
-		logrus.WithError(err).Error("Encoding error")
+		log.WithError(err).Error("Encoding error")
 	}
 	return bt
 }

--- a/ios/dtx_codec/dtxprimitivedictionary.go
+++ b/ios/dtx_codec/dtxprimitivedictionary.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
 	archiver "github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // PrimitiveDictionary contains a custom dictionary type
@@ -51,7 +51,7 @@ func (d PrimitiveDictionary) GetArguments() []interface{} {
 func (d *PrimitiveDictionary) AddNsKeyedArchivedObject(object interface{}) (err error) {
 	archivedObject, err := nskeyedarchiver.ArchiveBin(object)
 	if err != nil {
-		logrus.WithError(err).Error("query request encoding should never fail")
+		log.WithError(err).Error("query request encoding should never fail")
 		return err
 	}
 	d.AddBytes(archivedObject)
@@ -122,7 +122,7 @@ func (d PrimitiveDictionary) String() string {
 				jsonBytes, _ := json.Marshal(msg[0])
 				prettyString = string(jsonBytes)
 			} else {
-				logrus.Warnf("failed decoding with %+v", err)
+				log.Warnf("failed decoding with %+v", err)
 
 			}
 			result += fmt.Sprintf("{t:%s, v:%s},", toString(v), prettyString)
@@ -198,7 +198,7 @@ func readEntry(auxBytes []byte) (uint32, interface{}, []byte) {
 		}
 		return readType, data, auxBytes[8+length:]
 	}
-	logrus.Info(fmt.Sprintf("Unknown DtxPrimitiveDictionaryType: %d  rawbytes:%x", readType, auxBytes))
+	log.Info(fmt.Sprintf("Unknown DtxPrimitiveDictionaryType: %d  rawbytes:%x", readType, auxBytes))
 	return readType, nil, nil
 }
 
@@ -239,7 +239,7 @@ func (a *AuxiliaryEncoder) AddNsKeyedArchivedObject(object interface{}) (err err
 	a.writeEntry(t_null, nil)
 	bytes, err := archiver.ArchiveBin(object)
 	if err != nil {
-		logrus.WithError(err).Error("Failed archiving object")
+		log.WithError(err).Error("Failed archiving object")
 		return err
 	}
 	a.writeEntry(t_bytearray, bytes)
@@ -266,7 +266,7 @@ func (a *AuxiliaryEncoder) writeEntry(entryType uint32, object interface{}) {
 
 	}
 
-	logrus.Info(fmt.Sprintf("Unknown DtxPrimitiveDictionaryType: %d", entryType))
+	log.Info(fmt.Sprintf("Unknown DtxPrimitiveDictionaryType: %d", entryType))
 }
 
 func (a *AuxiliaryEncoder) GetBytes() []byte {

--- a/ios/dtx_codec/fragmentdecoder.go
+++ b/ios/dtx_codec/fragmentdecoder.go
@@ -2,7 +2,7 @@ package dtx
 
 import (
 	"encoding/binary"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // FragmentDecoder collects DtxMessage fragments and merges them into a single DtxMessage when they are complete.
@@ -25,7 +25,7 @@ type FragmentDecoder struct {
 // NewFragmentDecoder creates a new decoder with the first fragment
 func NewFragmentDecoder(firstFragment Message) *FragmentDecoder {
 	if !firstFragment.IsFirstFragment() {
-		logrus.Warn("Illegal state, need to pass in a firstFragment")
+		log.Warn("Illegal state, need to pass in a firstFragment")
 	}
 	return &FragmentDecoder{firstFragment, make([]Message, firstFragment.Fragments-1), false}
 }
@@ -51,7 +51,7 @@ func (f FragmentDecoder) HasFinished() bool {
 // Extract can be used to get an assembled DtxMessage from all the fragments. Never call this befor HasFinished is true.
 func (f FragmentDecoder) Extract() []byte {
 	if !f.finished {
-		logrus.Warn("Illegal state")
+		log.Warn("Illegal state")
 		return nil
 	}
 	assembledMessage := make([]byte, f.firstFragment.MessageLength+32)

--- a/ios/dtx_codec/fragmentdecoder.go
+++ b/ios/dtx_codec/fragmentdecoder.go
@@ -2,12 +2,13 @@ package dtx
 
 import (
 	"encoding/binary"
+	"github.com/sirupsen/logrus"
 )
 
-//FragmentDecoder collects DtxMessage fragments and merges them into a single DtxMessage when they are complete.
-//This makes it a little easier and it works perfectly fine with Xcode. I don't get the point in fragmenting USB messages
-//anyway..
-//DTX Fragment logic:
+// FragmentDecoder collects DtxMessage fragments and merges them into a single DtxMessage when they are complete.
+// This makes it a little easier and it works perfectly fine with Xcode. I don't get the point in fragmenting USB messages
+// anyway..
+// DTX Fragment logic:
 // 1. Fragment is only 32 bytes long, fragment index ==0, fragment length>1
 // following fragments contain the 32 bytes dtx header, then immediately the fragment data
 // once the last fragment is received (index == length-1), we can:
@@ -15,23 +16,22 @@ import (
 // 2. prepend the dtx header of the first message
 // 3. set fragment length to 1 and index to 0, and we have a defragmented single message that Xcode will
 // be able to use just the same as the fragmented one :-)
-//
 type FragmentDecoder struct {
 	firstFragment Message
 	fragments     []Message
 	finished      bool
 }
 
-//NewFragmentDecoder creates a new decoder with the first fragment
+// NewFragmentDecoder creates a new decoder with the first fragment
 func NewFragmentDecoder(firstFragment Message) *FragmentDecoder {
 	if !firstFragment.IsFirstFragment() {
-		panic("Illegalstate, need to pass in a firstFragment")
+		logrus.Warn("Illegal state, need to pass in a firstFragment")
 	}
 	return &FragmentDecoder{firstFragment, make([]Message, firstFragment.Fragments-1), false}
 }
 
-//AddFragment adds fragments if they match the firstFragment this FragmentDecoder was created with.
-//It returns true if the fragment was added and fals if the fragment was not matching this decoder's first fragment.
+// AddFragment adds fragments if they match the firstFragment this FragmentDecoder was created with.
+// It returns true if the fragment was added and fals if the fragment was not matching this decoder's first fragment.
 func (f *FragmentDecoder) AddFragment(fragment Message) bool {
 	if !f.firstFragment.MessageIsFirstFragmentFor(fragment) {
 		return false
@@ -43,15 +43,16 @@ func (f *FragmentDecoder) AddFragment(fragment Message) bool {
 	return true
 }
 
-//HasFinished can be used to check if all fragments have been added
+// HasFinished can be used to check if all fragments have been added
 func (f FragmentDecoder) HasFinished() bool {
 	return f.finished
 }
 
-//Extract can be used to get an assembled DtxMessage from all the fragments. Never call this befor HasFinished is true.
+// Extract can be used to get an assembled DtxMessage from all the fragments. Never call this befor HasFinished is true.
 func (f FragmentDecoder) Extract() []byte {
 	if !f.finished {
-		panic("illegal state")
+		logrus.Warn("Illegal state")
+		return nil
 	}
 	assembledMessage := make([]byte, f.firstFragment.MessageLength+32)
 	copy(assembledMessage, f.firstFragment.fragmentBytes)

--- a/ios/dtx_codec/fragmentdecoder_test.go
+++ b/ios/dtx_codec/fragmentdecoder_test.go
@@ -2,7 +2,7 @@ package dtx_test
 
 import (
 	"encoding/binary"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
@@ -30,7 +30,7 @@ func createHeader(fragmentIndex uint16, fragmentLength uint16, identifier uint32
 	}
 	msg, _, err := dtx.DecodeNonBlocking(messageBytes)
 	if err != nil {
-		logrus.WithError(err).Error("Failed decoding")
+		log.WithError(err).Error("Failed decoding")
 		return msg, err
 	}
 	return msg, err

--- a/ios/nskeyedarchiver/archiver.go
+++ b/ios/nskeyedarchiver/archiver.go
@@ -2,6 +2,7 @@ package nskeyedarchiver
 
 import (
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"reflect"
 
 	"howett.net/plist"
@@ -79,7 +80,8 @@ func archive(object interface{}, objects []interface{}) ([]interface{}, plist.UI
 		return encoderFunc(object, objects)
 	}
 
-	panic(fmt.Errorf("NSKeyedArchiver Unsupported object: '%s' of type:%s", object, typeOf))
+	logrus.Info(fmt.Errorf("NSKeyedArchiver Unsupported object: '%s' of type:%s", object, typeOf))
+	return nil, 0
 }
 
 func serializeArray(array []interface{}, objects []interface{}) ([]interface{}, plist.UID) {

--- a/ios/nskeyedarchiver/archiver.go
+++ b/ios/nskeyedarchiver/archiver.go
@@ -2,7 +2,7 @@ package nskeyedarchiver
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 
 	"howett.net/plist"
@@ -80,7 +80,7 @@ func archive(object interface{}, objects []interface{}) ([]interface{}, plist.UI
 		return encoderFunc(object, objects)
 	}
 
-	logrus.Info(fmt.Errorf("NSKeyedArchiver Unsupported object: '%s' of type:%s", object, typeOf))
+	log.Info(fmt.Errorf("NSKeyedArchiver Unsupported object: '%s' of type:%s", object, typeOf))
 	return nil, 0
 }
 

--- a/ios/nskeyedarchiver/archiverutils.go
+++ b/ios/nskeyedarchiver/archiverutils.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	plist "howett.net/plist"
 )
@@ -60,7 +60,7 @@ func toBinaryPlist(data interface{}) ([]byte, error) {
 func printAsJSON(obj interface{}) {
 	b, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
-		logrus.WithError(err).Error("Error while marshalling JSON")
+		log.WithError(err).Error("Error while marshalling JSON")
 	}
 	fmt.Print(string(b))
 }

--- a/ios/nskeyedarchiver/archiverutils.go
+++ b/ios/nskeyedarchiver/archiverutils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/sirupsen/logrus"
 
 	plist "howett.net/plist"
 )
@@ -16,7 +17,7 @@ func toInterfaceSlice(stringSlice []string) []interface{} {
 	return result
 }
 
-//toUidList type asserts a []interface{} to a []plist.UID by iterating through the list.
+// toUidList type asserts a []interface{} to a []plist.UID by iterating through the list.
 func toUidList(list []interface{}) []plist.UID {
 	l := len(list)
 	result := make([]plist.UID, l)
@@ -26,7 +27,7 @@ func toUidList(list []interface{}) []plist.UID {
 	return result
 }
 
-//plistFromBytes decodes a binary or XML based PLIST using the amazing github.com/DHowett/go-plist library and returns an interface{} or propagates the error raised by the library.
+// plistFromBytes decodes a binary or XML based PLIST using the amazing github.com/DHowett/go-plist library and returns an interface{} or propagates the error raised by the library.
 func plistFromBytes(plistBytes []byte) (interface{}, error) {
 	var test interface{}
 	decoder := plist.NewDecoder(bytes.NewReader(plistBytes))
@@ -38,9 +39,9 @@ func plistFromBytes(plistBytes []byte) (interface{}, error) {
 	return test, nil
 }
 
-//ToPlist converts a given struct to a Plist using the
-//github.com/DHowett/go-plist library. Make sure your struct is exported.
-//It returns a string containing the plist.
+// ToPlist converts a given struct to a Plist using the
+// github.com/DHowett/go-plist library. Make sure your struct is exported.
+// It returns a string containing the plist.
 func toPlist(data interface{}) (string, error) {
 	buf := &bytes.Buffer{}
 	encoder := plist.NewEncoder(buf)
@@ -55,11 +56,11 @@ func toBinaryPlist(data interface{}) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-//Print an object as JSON for debugging purposes, careful panics on error
+// Print an object as JSON for debugging purposes
 func printAsJSON(obj interface{}) {
 	b, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
-		panic(fmt.Sprintf("Error while marshalling Json:%s", err))
+		logrus.WithError(err).Error("Error while marshalling JSON")
 	}
 	fmt.Print(string(b))
 }
@@ -68,7 +69,7 @@ func buildClassDict(classes ...interface{}) map[string]interface{} {
 	return map[string]interface{}{"$classes": classes, "$classname": classes[0]}
 }
 
-//verifyCorrectArchiver makes sure the nsKeyedArchived plist has all the right keys and values and returns an error otherwise
+// verifyCorrectArchiver makes sure the nsKeyedArchived plist has all the right keys and values and returns an error otherwise
 func verifyCorrectArchiver(nsKeyedArchiverData map[string]interface{}) error {
 	if val, ok := nsKeyedArchiverData[archiverKey]; !ok {
 		return fmt.Errorf("Invalid NSKeyedAchiverObject, missing key '%s'", archiverKey)

--- a/ios/nskeyedarchiver/objectivec_classes.go
+++ b/ios/nskeyedarchiver/objectivec_classes.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"howett.net/plist"
 )
 
@@ -172,7 +172,7 @@ func DecodeXCActivityRecord(object map[string]interface{}, objects []interface{}
 	activityType_ref := object["activityType"].(plist.UID)
 	activityType := objects[activityType_ref].(string)
 
-	logrus.Info(objects[9])
+	log.Info(objects[9])
 
 	return XCActivityRecord{Finish: finish, Start: start, UUID: uuid, Title: title, Attachments: attachments, ActivityType: activityType}
 }
@@ -185,7 +185,7 @@ func NewNSUUIDFromBytes(object map[string]interface{}, objects []interface{}) in
 func NewNSUUID(id uuid.UUID) NSUUID {
 	bytes, err := id.MarshalBinary()
 	if err != nil {
-		logrus.Info(fmt.Sprintf("Unexpected Error: %v", err))
+		log.Info(fmt.Sprintf("Unexpected Error: %v", err))
 	}
 	return NSUUID{bytes}
 }

--- a/ios/nskeyedarchiver/objectivec_classes.go
+++ b/ios/nskeyedarchiver/objectivec_classes.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"howett.net/plist"
 )
 
@@ -172,7 +172,7 @@ func DecodeXCActivityRecord(object map[string]interface{}, objects []interface{}
 	activityType_ref := object["activityType"].(plist.UID)
 	activityType := objects[activityType_ref].(string)
 
-	log.Info(objects[9])
+	logrus.Info(objects[9])
 
 	return XCActivityRecord{Finish: finish, Start: start, UUID: uuid, Title: title, Attachments: attachments, ActivityType: activityType}
 }
@@ -185,7 +185,7 @@ func NewNSUUIDFromBytes(object map[string]interface{}, objects []interface{}) in
 func NewNSUUID(id uuid.UUID) NSUUID {
 	bytes, err := id.MarshalBinary()
 	if err != nil {
-		panic(fmt.Sprintf("Unexpected Error: %v", err))
+		logrus.Info(fmt.Sprintf("Unexpected Error: %v", err))
 	}
 	return NSUUID{bytes}
 }
@@ -303,7 +303,7 @@ func NewXCTTestIdentifier(object map[string]interface{}, objects []interface{}) 
 	}
 }
 
-//TODO: make this nice, partially extracting objects is not really cool
+// TODO: make this nice, partially extracting objects is not really cool
 type PartiallyExtractedXcTestConfig struct {
 	values map[string]interface{}
 }
@@ -339,7 +339,7 @@ func NewNSError(object map[string]interface{}, objects []interface{}) interface{
 	return NSError{ErrorCode: errorCode, Domain: domain, UserInfo: userinfo}
 }
 
-//Apples Reference Date is Jan 1st 2001 00:00
+// Apples Reference Date is Jan 1st 2001 00:00
 const nsReferenceDate = 978307200000
 
 type NSDate struct {

--- a/ios/pair_read.go
+++ b/ios/pair_read.go
@@ -3,7 +3,7 @@ package ios
 import (
 	"bytes"
 	"fmt"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	plist "howett.net/plist"
 )
@@ -75,7 +75,7 @@ func PairRecordfromBytes(plistBytes []byte) PairRecord {
 	err := decoder.Decode(&data)
 	if err != nil {
 		//this is unrecoverable and should not happen
-		logrus.Info(fmt.Sprintf("Failed decoding pair record plist %x", plistBytes))
+		log.Info(fmt.Sprintf("Failed decoding pair record plist %x", plistBytes))
 	}
 	return data
 }

--- a/ios/pair_read.go
+++ b/ios/pair_read.go
@@ -3,13 +3,14 @@ package ios
 import (
 	"bytes"
 	"fmt"
+	"github.com/sirupsen/logrus"
 
 	plist "howett.net/plist"
 )
 
-//ReadPair contains all the Infos necessary
-//to request a PairRecord from usbmuxd.
-//use newReadPair(udid string) to create one.
+// ReadPair contains all the Infos necessary
+// to request a PairRecord from usbmuxd.
+// use newReadPair(udid string) to create one.
 type ReadPair struct {
 	BundleID            string
 	ClientVersionString string
@@ -31,16 +32,16 @@ func newReadPair(udid string) ReadPair {
 	return data
 }
 
-//PairRecordData only holds a []byte containing the PairRecord data as
-//a serialized Plist.
+// PairRecordData only holds a []byte containing the PairRecord data as
+// a serialized Plist.
 type PairRecordData struct {
 	PairRecordData []byte
 }
 
-//PairRecord contains the HostID string,
-//the SystemBUID string, the HostCertificate []byte
-//and the HostPrivateKey []byte.
-//It is needed for enabling SSL Connections over Lockdown
+// PairRecord contains the HostID string,
+// the SystemBUID string, the HostCertificate []byte
+// and the HostPrivateKey []byte.
+// It is needed for enabling SSL Connections over Lockdown
 type PairRecord struct {
 	HostID            string
 	SystemBUID        string
@@ -67,20 +68,20 @@ func pairRecordDatafromBytes(plistBytes []byte) (PairRecordData, error) {
 	return data, nil
 }
 
-//PairRecordfromBytes parsed a plist into a PairRecord
+// PairRecordfromBytes parsed a plist into a PairRecord
 func PairRecordfromBytes(plistBytes []byte) PairRecord {
 	decoder := plist.NewDecoder(bytes.NewReader(plistBytes))
 	var data PairRecord
 	err := decoder.Decode(&data)
 	if err != nil {
 		//this is unrecoverable and should not happen
-		panic(fmt.Sprintf("Failed decoding pair record plist %x", plistBytes))
+		logrus.Info(fmt.Sprintf("Failed decoding pair record plist %x", plistBytes))
 	}
 	return data
 }
 
-//ReadPair reads the PairRecord from the usbmux socket for the given udid.
-//It returns the deserialized PairRecord.
+// ReadPair reads the PairRecord from the usbmux socket for the given udid.
+// It returns the deserialized PairRecord.
 func (muxConn *UsbMuxConnection) ReadPair(udid string) (PairRecord, error) {
 	muxConn.Send(newReadPair(udid))
 	resp, err := muxConn.ReadMessage()
@@ -91,7 +92,7 @@ func (muxConn *UsbMuxConnection) ReadPair(udid string) (PairRecord, error) {
 	return PairRecordfromBytes(pairRecordData.PairRecordData), err
 }
 
-//ReadPairRecord creates a new USBMuxConnection just to read the pair record and closes it right after than.
+// ReadPairRecord creates a new USBMuxConnection just to read the pair record and closes it right after than.
 func ReadPairRecord(udid string) (PairRecord, error) {
 	muxConnection, err := NewUsbMuxConnectionSimple()
 	if err != nil {

--- a/ios/utils.go
+++ b/ios/utils.go
@@ -8,48 +8,48 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	plist "howett.net/plist"
 )
 
-//ToPlist converts a given struct to a Plist using the
-//github.com/DHowett/go-plist library. Make sure your struct is exported.
-//It returns a string containing the plist.
+// ToPlist converts a given struct to a Plist using the
+// github.com/DHowett/go-plist library. Make sure your struct is exported.
+// It returns a string containing the plist.
 func ToPlist(data interface{}) string {
 	return string(ToPlistBytes(data))
 }
 
-//ParsePlist tries to parse the given bytes, which should be a Plist, into a map[string]interface.
-//It returns the map or an error if the decoding step fails.
+// ParsePlist tries to parse the given bytes, which should be a Plist, into a map[string]interface.
+// It returns the map or an error if the decoding step fails.
 func ParsePlist(data []byte) (map[string]interface{}, error) {
 	var result map[string]interface{}
 	_, err := plist.Unmarshal(data, &result)
 	return result, err
 }
 
-//ToPlistBytes converts a given struct to a Plist using the
-//github.com/DHowett/go-plist library. Make sure your struct is exported.
-//It returns a byte slice containing the plist.
+// ToPlistBytes converts a given struct to a Plist using the
+// github.com/DHowett/go-plist library. Make sure your struct is exported.
+// It returns a byte slice containing the plist.
 func ToPlistBytes(data interface{}) []byte {
 	bytes, err := plist.Marshal(data, plist.XMLFormat)
 	if err != nil {
 		//this should not happen
-		panic(fmt.Sprintf("Failed converting to plist %v error:%v", data, err))
+		logrus.Info(fmt.Sprintf("Failed converting to plist %v error:%v", data, err))
 	}
 	return bytes
 }
 
-//Ntohs is a re-implementation of the C function Ntohs.
-//it means networkorder to host oder and basically swaps
-//the endianness of the given int.
-//It returns port converted to little endian.
+// Ntohs is a re-implementation of the C function Ntohs.
+// it means networkorder to host oder and basically swaps
+// the endianness of the given int.
+// It returns port converted to little endian.
 func Ntohs(port uint16) uint16 {
 	buf := make([]byte, 2)
 	binary.BigEndian.PutUint16(buf, port)
 	return binary.LittleEndian.Uint16(buf)
 }
 
-//GetDevice returns:
+// GetDevice returns:
 // the device for the udid if a valid udid is provided.
 // if the env variable 'udid' is specified, the device with that udid
 // otherwise it returns the first device in the list.
@@ -57,10 +57,10 @@ func GetDevice(udid string) (DeviceEntry, error) {
 	if udid == "" {
 		udid = os.Getenv("udid")
 		if udid != "" {
-			log.Info("using udid from env.udid variable")
+			logrus.Info("using udid from env.udid variable")
 		}
 	}
-	log.Debugf("Looking for device '%s'", udid)
+	logrus.Debugf("Looking for device '%s'", udid)
 	deviceList, err := ListDevices()
 	if err != nil {
 		return DeviceEntry{}, err
@@ -69,7 +69,7 @@ func GetDevice(udid string) (DeviceEntry, error) {
 		if len(deviceList.DeviceList) == 0 {
 			return DeviceEntry{}, errors.New("no iOS devices are attached to this host")
 		}
-		log.WithFields(log.Fields{"udid": deviceList.DeviceList[0].Properties.SerialNumber}).
+		logrus.WithFields(logrus.Fields{"udid": deviceList.DeviceList[0].Properties.SerialNumber}).
 			Info("no udid specified using first device in list")
 		return deviceList.DeviceList[0], nil
 	}
@@ -81,8 +81,8 @@ func GetDevice(udid string) (DeviceEntry, error) {
 	return DeviceEntry{}, fmt.Errorf("Device '%s' not found. Is it attached to the machine?", udid)
 }
 
-//PathExists is used to determine whether the path folder exists
-//True if it exists, false otherwise
+// PathExists is used to determine whether the path folder exists
+// True if it exists, false otherwise
 func PathExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err == nil {
@@ -106,8 +106,8 @@ func IOS11() *semver.Version {
 	return semver.MustParse("11.0")
 }
 
-//FixWindowsPaths replaces backslashes with forward slashes and removes the X: style
-//windows drive letters
+// FixWindowsPaths replaces backslashes with forward slashes and removes the X: style
+// windows drive letters
 func FixWindowsPaths(path string) string {
 	path = strings.ReplaceAll(path, "\\", "/")
 	if strings.Contains(path, ":/") {

--- a/ios/utils.go
+++ b/ios/utils.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	plist "howett.net/plist"
 )
 
@@ -34,7 +34,7 @@ func ToPlistBytes(data interface{}) []byte {
 	bytes, err := plist.Marshal(data, plist.XMLFormat)
 	if err != nil {
 		//this should not happen
-		logrus.Info(fmt.Sprintf("Failed converting to plist %v error:%v", data, err))
+		log.Info(fmt.Sprintf("Failed converting to plist %v error:%v", data, err))
 	}
 	return bytes
 }
@@ -57,10 +57,10 @@ func GetDevice(udid string) (DeviceEntry, error) {
 	if udid == "" {
 		udid = os.Getenv("udid")
 		if udid != "" {
-			logrus.Info("using udid from env.udid variable")
+			log.Info("using udid from env.udid variable")
 		}
 	}
-	logrus.Debugf("Looking for device '%s'", udid)
+	log.Debugf("Looking for device '%s'", udid)
 	deviceList, err := ListDevices()
 	if err != nil {
 		return DeviceEntry{}, err
@@ -69,7 +69,7 @@ func GetDevice(udid string) (DeviceEntry, error) {
 		if len(deviceList.DeviceList) == 0 {
 			return DeviceEntry{}, errors.New("no iOS devices are attached to this host")
 		}
-		logrus.WithFields(logrus.Fields{"udid": deviceList.DeviceList[0].Properties.SerialNumber}).
+		log.WithFields(log.Fields{"udid": deviceList.DeviceList[0].Properties.SerialNumber}).
 			Info("no udid specified using first device in list")
 		return deviceList.DeviceList[0], nil
 	}

--- a/restapi/api/server.go
+++ b/restapi/api/server.go
@@ -5,14 +5,14 @@ import (
 	"os"
 
 	"github.com/gin-gonic/gin"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
 func Main() {
 	router := gin.Default()
-	log := logrus.New()
+	log := log.New()
 	myfile, _ := os.Create("go-ios.log")
 	gin.DefaultWriter = io.MultiWriter(myfile, os.Stdout)
 	router.Use(MyLogger(log), gin.Recovery())

--- a/restapi/api/util.go
+++ b/restapi/api/util.go
@@ -18,8 +18,8 @@ type GenericResponse struct {
 	Error   string `json:"error,omitempty"`
 }
 
-//GetVersion reads the contents of the file version.txt and returns it.
-//If the file cannot be read, it returns "could not read version"
+// GetVersion reads the contents of the file version.txt and returns it.
+// If the file cannot be read, it returns "could not read version"
 func GetVersion() string {
 	version, err := ioutil.ReadFile("version.txt")
 	if err != nil {
@@ -31,7 +31,7 @@ func GetVersion() string {
 func MustMarshal(v interface{}) string {
 	b, err := json.Marshal(v)
 	if err != nil {
-		panic(err)
+		logrus.WithError(err).Error("Failed marshalling object")
 	}
 	return string(b)
 }

--- a/restapi/api/util.go
+++ b/restapi/api/util.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type GenericResponse struct {
@@ -31,7 +31,7 @@ func GetVersion() string {
 func MustMarshal(v interface{}) string {
 	b, err := json.Marshal(v)
 	if err != nil {
-		logrus.WithError(err).Error("Failed marshalling object")
+		log.WithError(err).Error("Failed marshalling object")
 	}
 	return string(b)
 }
@@ -39,7 +39,7 @@ func MustMarshal(v interface{}) string {
 var timeFormat = "02/Jan/2006:15:04:05 -0700"
 
 // taken from https://github.com/toorop/gin-logrus/blob/master/logger.go
-func MyLogger(logger logrus.FieldLogger, notLogged ...string) gin.HandlerFunc {
+func MyLogger(logger log.FieldLogger, notLogged ...string) gin.HandlerFunc {
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "unknow"
@@ -75,7 +75,7 @@ func MyLogger(logger logrus.FieldLogger, notLogged ...string) gin.HandlerFunc {
 			return
 		}
 
-		entry := logger.WithFields(logrus.Fields{
+		entry := logger.WithFields(log.Fields{
 			"hostname":   hostname,
 			"statusCode": statusCode,
 			"latency":    latency, // time to process


### PR DESCRIPTION
Replaced panics with debugging messages and err's

- Todo check the places we need to return the error instead of just info debugging messages and the refactor effort needed in the whole codebase
- Test how the removal of the panics will affect the efficiency and consistency, in extreme occasions that is possibly needed the app to throw panics in order to prevent misbehaviour.