### PR TITLE
Add --wait to ios launch

### DIFF
--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -2,10 +2,10 @@ package dtx
 
 import (
 	"io"
+	"math"
 	"strings"
 	"sync"
 	"time"
-	"math"
 
 	ios "github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
@@ -73,6 +73,7 @@ func (g GlobalDispatcher) Dispatch(msg Message) {
 		}
 		//TODO: use the dispatchFunctions map
 		if "outputReceived:fromProcess:atTime:" == msg.Payload[0] {
+			log.Info("HAAA")
 			msg, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
 			if err == nil {
 				log.Info(msg[0])

--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -74,7 +74,6 @@ func (g GlobalDispatcher) Dispatch(msg Message) {
 		//TODO: use the dispatchFunctions map
 		if "outputReceived:fromProcess:atTime:" == msg.Payload[0] {
 			logmsg, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
-
 			if err == nil {
 				log.WithFields(log.Fields{
 					"msg":  logmsg[0],

--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -1,13 +1,13 @@
 package dtx
 
 import (
+	"github.com/danielpaulus/go-ios/ios"
 	"io"
 	"math"
 	"strings"
 	"sync"
 	"time"
 
-	ios "github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
 	log "github.com/sirupsen/logrus"
 )

--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -73,10 +73,14 @@ func (g GlobalDispatcher) Dispatch(msg Message) {
 		}
 		//TODO: use the dispatchFunctions map
 		if "outputReceived:fromProcess:atTime:" == msg.Payload[0] {
-			log.Info("HAAA")
-			msg, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
+			logmsg, err := nskeyedarchiver.Unarchive(msg.Auxiliary.GetArguments()[0].([]byte))
+
 			if err == nil {
-				log.Info(msg[0])
+				log.WithFields(log.Fields{
+					"msg":  logmsg[0],
+					"pid":  msg.Auxiliary.GetArguments()[1],
+					"time": msg.Auxiliary.GetArguments()[2],
+				}).Info("outputReceived:fromProcess:atTime:")
 			}
 			return
 		}

--- a/ios/instruments/processcontrol.go
+++ b/ios/instruments/processcontrol.go
@@ -5,7 +5,6 @@ import (
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 type ProcessControl struct {
@@ -19,16 +18,18 @@ func (p *ProcessControl) LaunchApp(bundleID string) (uint64, error) {
 	opts := map[string]interface{}{
 		"StartSuspendedKey": uint64(0),
 	}
-	env := map[string]interface{}{"CA_ASSERT_MAIN_THREAD_TRANSACTIONS": "0", "CA_DEBUG_TRANSACTIONS": "0", "LLVM_PROFILE_FILE": "/dev/null", "METAL_DEBUG_ERROR_MODE": "0", "METAL_DEVICE_WRAPPER_TYPE": "1", "NSUnbufferedIO": "YES", "OS_ACTIVITY_DT_MODE": "YES", "SQLITE_ENABLE_THREAD_ASSERTIONS": "1", "__XPC_LLVM_PROFILE_FILE": "/dev/null"}
+	// Xcode sends all these, no idea if we need them for sth. later.
+	//"CA_ASSERT_MAIN_THREAD_TRANSACTIONS": "0", "CA_DEBUG_TRANSACTIONS": "0", "LLVM_PROFILE_FILE": "/dev/null", "METAL_DEBUG_ERROR_MODE": "0", "METAL_DEVICE_WRAPPER_TYPE": "1",
+	//"OS_ACTIVITY_DT_MODE": "YES", "SQLITE_ENABLE_THREAD_ASSERTIONS": "1", "__XPC_LLVM_PROFILE_FILE": "/dev/null"
+	// NSUnbufferedIO seems to make the app send its logs via instruments using the outputReceived:fromProcess:atTime: selector
+	// We'll supply per default to get logs
+	env := map[string]interface{}{"NSUnbufferedIO": "YES"}
 	// map[string]interface{}{}
-	p.StartProcess(bundleID, env, []interface{}{}, opts)
-	time.Sleep(5 * time.Second)
-	time.Sleep(5 * time.Second)
-	return 2, nil
+	return p.StartProcess(bundleID, env, []interface{}{}, opts)
 }
 
-func (p *ProcessControl) Close() {
-	p.conn.Close()
+func (p *ProcessControl) Close() error {
+	return p.conn.Close()
 }
 
 func NewProcessControl(device ios.DeviceEntry) (*ProcessControl, error) {

--- a/ios/instruments/processcontrol.go
+++ b/ios/instruments/processcontrol.go
@@ -24,7 +24,6 @@ func (p *ProcessControl) LaunchApp(bundleID string) (uint64, error) {
 	// NSUnbufferedIO seems to make the app send its logs via instruments using the outputReceived:fromProcess:atTime: selector
 	// We'll supply per default to get logs
 	env := map[string]interface{}{"NSUnbufferedIO": "YES"}
-	// map[string]interface{}{}
 	return p.StartProcess(bundleID, env, []interface{}{}, opts)
 }
 
@@ -37,7 +36,6 @@ func NewProcessControl(device ios.DeviceEntry) (*ProcessControl, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	processControlChannel := dtxConn.RequestChannelIdentifier(procControlChannel, loggingDispatcher{dtxConn})
 	return &ProcessControl{processControlChannel: processControlChannel, conn: dtxConn}, nil
 }
@@ -73,7 +71,6 @@ func (p ProcessControl) StartProcess(bundleID string, envVars map[string]interfa
 		log.WithFields(log.Fields{"channel_id": procControlChannel, "pid": pid}).Info("Process started successfully")
 		return pid, nil
 	}
-
 	return 0, fmt.Errorf("pid returned in payload was not of type uint64 for processcontroll.startprocess, instead: %s", msg.Payload)
 
 }

--- a/main.go
+++ b/main.go
@@ -525,7 +525,6 @@ The commands work as following:
 
 		pid, err := pControl.LaunchApp(bundleID)
 		exitIfError("launch app command failed", err)
-		time.Sleep(time.Second * 5)
 		log.WithFields(log.Fields{"pid": pid}).Info("Process launched")
 		if wait {
 			c := make(chan os.Signal, 1)

--- a/main.go
+++ b/main.go
@@ -524,7 +524,7 @@ The commands work as following:
 
 		pid, err := pControl.LaunchApp(bundleID)
 		exitIfError("launch app command failed", err)
-
+		time.Sleep(time.Second * 5)
 		log.WithFields(log.Fields{"pid": pid}).Info("Process launched")
 	}
 

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ Usage:
   ios install --path=<ipaOrAppFolder> [options]
   ios uninstall <bundleID> [options]
   ios apps [--system] [--all] [--list] [options]
-  ios launch <bundleID> [options]
+  ios launch <bundleID> [--wait] [options]
   ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options]
   ios runtest <bundleID> [options]
   ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]... [options]
@@ -177,7 +177,7 @@ The commands work as following:
    ios install --path=<ipaOrAppFolder> [options]                      Specify a .app folder or an installable ipa file that will be installed.  
    ios pcap [options] [--pid=<processID>] [--process=<processName>]   Starts a pcap dump of network traffic, use --pid or --process to filter specific processes.
    ios apps [--system] [--all] [--list]                               Retrieves a list of installed applications. --system prints out preinstalled system apps. --all prints all apps, including system, user, and hidden apps. --list only prints bundle ID, bundle name and version number.
-   ios launch <bundleID>                                              Launch app with the bundleID on the device. Get your bundle ID from the apps command.
+   ios launch <bundleID> [--wait]                                     Launch app with the bundleID on the device. Get your bundle ID from the apps command. --wait keeps the connection open if you want logs.
    ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options] Kill app with the specified bundleID, process id, or process name on the device.
    ios runtest <bundleID>                                             Run a XCUITest. 
    ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]...[options]  runs WebDriverAgents
@@ -515,6 +515,7 @@ The commands work as following:
 
 	b, _ = arguments.Bool("launch")
 	if b {
+		wait, _ := arguments.Bool("--wait")
 		bundleID, _ := arguments.String("<bundleID>")
 		if bundleID == "" {
 			log.Fatal("please provide a bundleID")
@@ -526,6 +527,12 @@ The commands work as following:
 		exitIfError("launch app command failed", err)
 		time.Sleep(time.Second * 5)
 		log.WithFields(log.Fields{"pid": pid}).Info("Process launched")
+		if wait {
+			c := make(chan os.Signal, 1)
+			signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+			<-c
+			log.WithFields(log.Fields{"pid": pid}).Info("stop listening to logs")
+		}
 	}
 
 	b, _ = arguments.Bool("kill")


### PR DESCRIPTION
adds new --wait switch to keep the command running and display application logs when an app is launched with ios launch [bundleID]