### PR TITLE
fail if more than one device is connected, add panic handlers to move…

### DIFF
--- a/ios/debugproxy/binforward.go
+++ b/ios/debugproxy/binforward.go
@@ -94,6 +94,17 @@ func handleConnectToService(connectRequest ios.UsbMuxMessage,
 }
 
 func proxyBinDumpConnection(p *ProxyConnection, binOnUnixSocket BinaryForwardingProxy, binToDevice BinaryForwardingProxy) {
+	defer func() {
+		log.Println("done") // Println executes normally even if there is a panic
+		if x := recover(); x != nil {
+			log.Printf("run time panic, moving back socket %v", x)
+			err := MoveBack(ios.DefaultUsbmuxdSocket)
+			if err != nil {
+				log.WithFields(log.Fields{"error": err}).Error("Failed moving back socket")
+			}
+			panic(x)
+		}
+	}()
 	go proxyBinFromDeviceToHost(p, binOnUnixSocket, binToDevice)
 	for {
 		bytes, err := binOnUnixSocket.ReadMessage()
@@ -114,6 +125,17 @@ func proxyBinDumpConnection(p *ProxyConnection, binOnUnixSocket BinaryForwarding
 }
 
 func proxyBinFromDeviceToHost(p *ProxyConnection, binOnUnixSocket BinaryForwardingProxy, binToDevice BinaryForwardingProxy) {
+	defer func() {
+		log.Println("done") // Println executes normally even if there is a panic
+		if x := recover(); x != nil {
+			log.Printf("run time panic, moving back socket %v", x)
+			err := MoveBack(ios.DefaultUsbmuxdSocket)
+			if err != nil {
+				log.WithFields(log.Fields{"error": err}).Error("Failed moving back socket")
+			}
+			panic(x)
+		}
+	}()
 	for {
 		bytes, err := binToDevice.ReadMessage()
 		binToDevice.decoder.decode(bytes)

--- a/ios/debugproxy/debugproxy.go
+++ b/ios/debugproxy/debugproxy.go
@@ -84,6 +84,10 @@ func NewDebugProxy() *DebugProxy {
 
 //Launch moves the original /var/run/usbmuxd to /var/run/usbmuxd.real and starts the server at /var/run/usbmuxd
 func (d *DebugProxy) Launch(device ios.DeviceEntry, binaryMode bool) error {
+	list, _ := ios.ListDevices()
+	if len(list.DeviceList) > 1 {
+		return fmt.Errorf("dproxy currently does not work when more than one device is connected to the host. please disconnect all but one device.")
+	}
 	if binaryMode {
 		log.Info("Lauching proxy in full binary mode")
 	}

--- a/ios/debugproxy/muxhandler.go
+++ b/ios/debugproxy/muxhandler.go
@@ -11,6 +11,17 @@ import (
 )
 
 func proxyUsbMuxConnection(p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnection, muxToDevice *ios.UsbMuxConnection) {
+	defer func() {
+		log.Println("done") // Println executes normally even if there is a panic
+		if x := recover(); x != nil {
+			log.Printf("run time panic, moving back socket %v", x)
+			err := MoveBack(ios.DefaultUsbmuxdSocket)
+			if err != nil {
+				log.WithFields(log.Fields{"error": err}).Error("Failed moving back socket")
+			}
+			panic(x)
+		}
+	}()
 	for {
 		request, err := muxOnUnixSocket.ReadMessage()
 		if err != nil {


### PR DESCRIPTION
I finally got that in golang to properly handle panics, you have to add the panic handler in every goroutine. I added that so dproxy will now always fix and move back the broken socket even if it fails with a panic. 
Also, dproxy currently does not work with multiple devices. I made it fail with an error in case more than one device is connected. 