### PR TITLE
Add mjpeg server to screenshotr

### DIFF
--- a/ios/screenshotr/mjpeg_server.go
+++ b/ios/screenshotr/mjpeg_server.go
@@ -17,7 +17,7 @@ import (
 var consumers sync.Map
 var conversionQueue = make(chan []byte, 20)
 
-func StartStreamingServer(device ios.DeviceEntry) error {
+func StartStreamingServer(device ios.DeviceEntry, port string) error {
 	conn, err := New(device)
 	if err != nil {
 		return err
@@ -25,7 +25,9 @@ func StartStreamingServer(device ios.DeviceEntry) error {
 	go startScreenshotting(conn)
 	go startConversionQueue()
 	http.HandleFunc("/", mjpegHandler)
-	return http.ListenAndServe(":3333", nil)
+	location := fmt.Sprintf("0.0.0.0:%s", port)
+	log.WithFields(log.Fields{"host": "0.0.0.0", "port": port}).Infof("starting server, open your browser here: http://%s/", location)
+	return http.ListenAndServe(location, nil)
 }
 func startConversionQueue() {
 	var opt jpeg.Options

--- a/ios/screenshotr/mjpeg_server.go
+++ b/ios/screenshotr/mjpeg_server.go
@@ -1,0 +1,106 @@
+package screenshotr
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"github.com/danielpaulus/go-ios/ios"
+	log "github.com/sirupsen/logrus"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+var consumers sync.Map
+var conversionQueue = make(chan []byte, 20)
+
+func StartStreamingServer(device ios.DeviceEntry) error {
+	conn, err := New(device)
+	if err != nil {
+		return err
+	}
+	go startScreenshotting(conn)
+	go startConversionQueue()
+	http.HandleFunc("/", mjpegHandler)
+	return http.ListenAndServe(":3333", nil)
+}
+func startConversionQueue() {
+	var opt jpeg.Options
+	opt.Quality = 80
+
+	for {
+		pngBytes := <-conversionQueue
+		start := time.Now()
+		img, err := png.Decode(bytes.NewReader(pngBytes))
+		if err != nil {
+			log.Warnf("failed decoding png %v", err)
+			continue
+		}
+		var b bytes.Buffer
+		foo := bufio.NewWriter(&b)
+		err = jpeg.Encode(foo, img, &opt)
+		if err != nil {
+			log.Warnf("failed encoding jpg %v", err)
+			continue
+		}
+		elapsed := time.Since(start)
+		log.Debugf("conversion took %fs", elapsed.Seconds())
+		consumers.Range(func(key, value interface{}) bool {
+			c := value.(chan []byte)
+			go func() { c <- b.Bytes() }()
+			return true
+		})
+	}
+}
+func startScreenshotting(conn *Connection) {
+	for {
+		start := time.Now()
+		pngBytes, err := conn.TakeScreenshot()
+		if err != nil {
+			log.Fatal("screenshotr failed", err)
+		}
+		elapsed := time.Since(start)
+		log.Debugf("shot took %fs", elapsed.Seconds())
+		conversionQueue <- pngBytes
+	}
+}
+
+const mjpegFrameFooter = "\r\n\r\n"
+const mjpegFrameHeader = "--BoundaryString\r\nContent-type: image/jpg\r\nContent-Length: %d\r\n\r\n"
+
+func mjpegHandler(w http.ResponseWriter, r *http.Request) {
+	log.Infof("starting mjpeg stream for new client")
+	c := make(chan []byte)
+	consumers.Store(r, c)
+	w.Header().Add("Server", "go-ios-screenshotr-mjpeg-stream")
+	w.Header().Add("Connection", "Close")
+	w.Header().Add("Content-Type", "multipart/x-mixed-replace; boundary=--BoundaryString")
+	w.Header().Add("Max-Age", "0")
+	w.Header().Add("Expires", "0")
+	w.Header().Add("Cache-Control", "no-cache, private")
+	w.Header().Add("Pragma", "no-cache")
+
+	//io.WriteString(w, mjpegStreamHeader)
+	w.WriteHeader(200)
+	for {
+		jpg := <-c
+		_, err := io.WriteString(w, fmt.Sprintf(mjpegFrameHeader, len(jpg)))
+		if err != nil {
+			break
+		}
+		_, err = w.Write(jpg)
+		if err != nil {
+			break
+		}
+		_, err = io.WriteString(w, mjpegFrameFooter)
+		if err != nil {
+			break
+		}
+	}
+	consumers.Delete(r)
+	close(c)
+	log.Info("client disconnected")
+}

--- a/main.go
+++ b/main.go
@@ -1195,6 +1195,8 @@ func printDeviceName(device ios.DeviceEntry) {
 
 func saveScreenshot(device ios.DeviceEntry, outputPath string) {
 	log.Debug("take screenshot")
+	screenshotr.StartStreamingServer(device)
+	return
 	screenshotrService, err := screenshotr.New(device)
 	exitIfError("Starting Screenshotr failed with", err)
 


### PR DESCRIPTION
start a simple mjpeg server by running
`ios screenshot --stream` on 0.0.0.0:3333. If you provide the port argument like so: 
`ios screenshot --stream --port=8082` the server will run on your specified port. Then watch a slow stream in your browser. 
This is only a fun feature or to use in debugging if all else fails. Screenshotr is too slow to be really useable on Retina/High Res devices because it sends huge PNG files. Those reach memory bandwith limits on the device. Also it is too unstable to be used in production scenarios. For useable mjpeg streams, use WebDriverAgent's built in server. 
On older devices, this works quite well though :-D 