### PR TITLE
Update runtest to accept additional arguments

### DIFF
--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -3,10 +3,11 @@ package testmanagerd
 import (
 	"context"
 	"fmt"
-	"github.com/danielpaulus/go-ios/ios/house_arrest"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/danielpaulus/go-ios/ios/house_arrest"
 
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
@@ -247,8 +248,7 @@ const testmanagerdiOS14 = "com.apple.testmanagerd.lockdown.secure"
 
 const testBundleSuffix = "UITests.xctrunner"
 
-func RunXCUITest(bundleID string, device ios.DeviceEntry, env []string) error {
-	testRunnerBundleID := bundleID + testBundleSuffix
+func RunXCUITest(bundleID string, testRunnerBundleID string, xctestConfigName string, device ios.DeviceEntry, env []string) error {
 	//FIXME: this is redundant code, getting the app list twice and creating the appinfos twice
 	//just to generate the xctestConfigFileName. Should be cleaned up at some point.
 	installationProxy, err := installationproxy.New(device)
@@ -256,6 +256,10 @@ func RunXCUITest(bundleID string, device ios.DeviceEntry, env []string) error {
 		return err
 	}
 	defer installationProxy.Close()
+
+	if testRunnerBundleID == "" {
+		testRunnerBundleID = bundleID + testBundleSuffix
+	}
 
 	apps, err := installationProxy.BrowseUserApps()
 	if err != nil {
@@ -265,8 +269,12 @@ func RunXCUITest(bundleID string, device ios.DeviceEntry, env []string) error {
 	if err != nil {
 		return err
 	}
-	xctestConfigFileName := info.targetAppBundleName + "UITests.xctest"
-	return RunXCUIWithBundleIdsCtx(nil, bundleID, testRunnerBundleID, xctestConfigFileName, device, nil, env)
+
+	if xctestConfigName == "" {
+		xctestConfigName = info.targetAppBundleName + "UITests.xctest"
+	}
+
+	return RunXCUIWithBundleIdsCtx(nil, bundleID, testRunnerBundleID, xctestConfigName, device, nil, env)
 }
 
 var closeChan = make(chan interface{})

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ The commands work as following:
    ios apps [--system] [--all] [--list]                               Retrieves a list of installed applications. --system prints out preinstalled system apps. --all prints all apps, including system, user, and hidden apps. --list only prints bundle ID, bundle name and version number.
    ios launch <bundleID> [--wait]                                     Launch app with the bundleID on the device. Get your bundle ID from the apps command. --wait keeps the connection open if you want logs.
    ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options] Kill app with the specified bundleID, process id, or process name on the device.
-   ios runtest [--bundle-id=<bundleid>] [--test-runner-bundle-id=<testbundleid>] [--xctest-config=<xctestconfig>] [--env=<e>]... [options]                    Run a XCUITest. If you provide only bundleid go-ios will try to dynamically create testrunnerbundleid and xctestconfig.
+   ios runtest [--bundle-id=<bundleid>] [--test-runner-bundle-id=<testbundleid>] [--xctest-config=<xctestconfig>] [--env=<e>]... [options]                    Run a XCUITest. If you provide only bundle-id go-ios will try to dynamically create test-runner-bundle-id and xctest-config.
    ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]...[options]  runs WebDriverAgents
    >                                                                  specify runtime args and env vars like --env ENV_1=something --env ENV_2=else  and --arg ARG1 --arg ARG2
    ios ax [options]                                                   Access accessibility inspector features. 

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ Usage:
   ios apps [--system] [--all] [--list] [options]
   ios launch <bundleID> [--wait] [options]
   ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options]
-  ios runtest [--bundleid=<bundleid>] [--testrunnerbundleid=<testrunnerbundleid>] [--xctestconfig=<xctestconfig>] [--env=<e>]... [options]
+  ios runtest [--bundle-id=<bundleid>] [--test-runner-bundle-id=<testrunnerbundleid>] [--xctest-config=<xctestconfig>] [--env=<e>]... [options]
   ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]... [options]
   ios ax [options]
   ios debug [options] [--stop-at-entry] <app_path>
@@ -180,7 +180,7 @@ The commands work as following:
    ios apps [--system] [--all] [--list]                               Retrieves a list of installed applications. --system prints out preinstalled system apps. --all prints all apps, including system, user, and hidden apps. --list only prints bundle ID, bundle name and version number.
    ios launch <bundleID> [--wait]                                     Launch app with the bundleID on the device. Get your bundle ID from the apps command. --wait keeps the connection open if you want logs.
    ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options] Kill app with the specified bundleID, process id, or process name on the device.
-   ios runtest [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--env=<e>]... [options]                    Run a XCUITest. If you provide only bundleid go-ios will try to dynamically create testrunnerbundleid and xctestconfig.
+   ios runtest [--bundle-id=<bundleid>] [--test-runner-bundle-id=<testbundleid>] [--xctest-config=<xctestconfig>] [--env=<e>]... [options]                    Run a XCUITest. If you provide only bundleid go-ios will try to dynamically create testrunnerbundleid and xctestconfig.
    ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]...[options]  runs WebDriverAgents
    >                                                                  specify runtime args and env vars like --env ENV_1=something --env ENV_2=else  and --arg ARG1 --arg ARG2
    ios ax [options]                                                   Access accessibility inspector features. 
@@ -610,9 +610,9 @@ The commands work as following:
 
 	b, _ = arguments.Bool("runtest")
 	if b {
-		bundleID, _ := arguments.String("--bundleid")
-		testRunnerBundleId, _ := arguments.String("--testrunnerbundleid")
-		xctestConfig, _ := arguments.String("--xctestconfig")
+		bundleID, _ := arguments.String("--bundle-id")
+		testRunnerBundleId, _ := arguments.String("--test-runner-bundle-id")
+		xctestConfig, _ := arguments.String("--xctest-config")
 
 		env := arguments["--env"].([]string)
 		err := testmanagerd.RunXCUITest(bundleID, testRunnerBundleId, xctestConfig, device, env)

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ Usage:
   ios apps [--system] [--all] [--list] [options]
   ios launch <bundleID> [--wait] [options]
   ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options]
-  ios runtest <bundleID> [--env=<e>]... [options]
+  ios runtest <bundleID> <testRunnerBundleID> <xctestConfigName> [--env=<e>]... [options]
   ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]... [options]
   ios ax [options]
   ios debug [options] [--stop-at-entry] <app_path>
@@ -180,7 +180,7 @@ The commands work as following:
    ios apps [--system] [--all] [--list]                               Retrieves a list of installed applications. --system prints out preinstalled system apps. --all prints all apps, including system, user, and hidden apps. --list only prints bundle ID, bundle name and version number.
    ios launch <bundleID> [--wait]                                     Launch app with the bundleID on the device. Get your bundle ID from the apps command. --wait keeps the connection open if you want logs.
    ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options] Kill app with the specified bundleID, process id, or process name on the device.
-   ios runtest <bundleID> [--env=<e>]... [options]                    Run a XCUITest. 
+   ios runtest <bundleID> <testRunnerBundleID> <xctestConfigName> [--env=<e>]... [options]                    Run a XCUITest. If you provide only bundleID go-ios will try to dynamically create testRunnerBundleID and xctestConfig. Example: ios runtest com.example.App com.example.App.xctrunner App.xctest
    ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]...[options]  runs WebDriverAgents
    >                                                                  specify runtime args and env vars like --env ENV_1=something --env ENV_2=else  and --arg ARG1 --arg ARG2
    ios ax [options]                                                   Access accessibility inspector features. 
@@ -611,8 +611,11 @@ The commands work as following:
 	b, _ = arguments.Bool("runtest")
 	if b {
 		bundleID, _ := arguments.String("<bundleID>")
+		testRunnerBundleId, _ := arguments.String("<testRunnerBundleID>")
+		xctestConfig, _ := arguments.String("<xctestConfigName>")
+
 		env := arguments["--env"].([]string)
-		err := testmanagerd.RunXCUITest(bundleID, device, env)
+		err := testmanagerd.RunXCUITest(bundleID, testRunnerBundleId, xctestConfig, device, env)
 		if err != nil {
 			log.WithFields(log.Fields{"error": err}).Info("Failed running Xcuitest")
 		}

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ Usage:
   ios apps [--system] [--all] [--list] [options]
   ios launch <bundleID> [--wait] [options]
   ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options]
-  ios runtest <bundleID> <testRunnerBundleID> <xctestConfigName> [--env=<e>]... [options]
+  ios runtest [--bundleid=<bundleid>] [--testrunnerbundleid=<testrunnerbundleid>] [--xctestconfig=<xctestconfig>] [--env=<e>]... [options]
   ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]... [options]
   ios ax [options]
   ios debug [options] [--stop-at-entry] <app_path>
@@ -180,7 +180,7 @@ The commands work as following:
    ios apps [--system] [--all] [--list]                               Retrieves a list of installed applications. --system prints out preinstalled system apps. --all prints all apps, including system, user, and hidden apps. --list only prints bundle ID, bundle name and version number.
    ios launch <bundleID> [--wait]                                     Launch app with the bundleID on the device. Get your bundle ID from the apps command. --wait keeps the connection open if you want logs.
    ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options] Kill app with the specified bundleID, process id, or process name on the device.
-   ios runtest <bundleID> <testRunnerBundleID> <xctestConfigName> [--env=<e>]... [options]                    Run a XCUITest. If you provide only bundleID go-ios will try to dynamically create testRunnerBundleID and xctestConfig. Example: ios runtest com.example.App com.example.App.xctrunner App.xctest
+   ios runtest [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--env=<e>]... [options]                    Run a XCUITest. If you provide only bundleid go-ios will try to dynamically create testrunnerbundleid and xctestconfig.
    ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]...[options]  runs WebDriverAgents
    >                                                                  specify runtime args and env vars like --env ENV_1=something --env ENV_2=else  and --arg ARG1 --arg ARG2
    ios ax [options]                                                   Access accessibility inspector features. 
@@ -610,9 +610,9 @@ The commands work as following:
 
 	b, _ = arguments.Bool("runtest")
 	if b {
-		bundleID, _ := arguments.String("<bundleID>")
-		testRunnerBundleId, _ := arguments.String("<testRunnerBundleID>")
-		xctestConfig, _ := arguments.String("<xctestConfigName>")
+		bundleID, _ := arguments.String("--bundleid")
+		testRunnerBundleId, _ := arguments.String("--testrunnerbundleid")
+		xctestConfig, _ := arguments.String("--xctestconfig")
 
 		env := arguments["--env"].([]string)
 		err := testmanagerd.RunXCUITest(bundleID, testRunnerBundleId, xctestConfig, device, env)


### PR DESCRIPTION
* Updated `runtest` command to accept 3 arguments so users can fine tune the test execution based on their own configuration - #224 
* Added `--bundle-id`, `test-runner-bundle-id` and `xctest-config` arguments to `runtest`  
* `test-runner-bundle-id` and `xctest-config` can be omitted which will use the initial logic of building them dynamically  