### PR TITLE
Support for USBMUXD_SOCKET_ADDRESS environment variable

### DIFF
--- a/ios/debugproxy/binforward.go
+++ b/ios/debugproxy/binforward.go
@@ -98,7 +98,7 @@ func proxyBinDumpConnection(p *ProxyConnection, binOnUnixSocket BinaryForwarding
 		log.Println("done") // Println executes normally even if there is a panic
 		if x := recover(); x != nil {
 			log.Printf("run time panic, moving back socket %v", x)
-			err := MoveBack(ios.DefaultUsbmuxdSocket)
+			err := MoveBack(ios.GetUsbmuxdSocket())
 			if err != nil {
 				log.WithFields(log.Fields{"error": err}).Error("Failed moving back socket")
 			}
@@ -129,7 +129,7 @@ func proxyBinFromDeviceToHost(p *ProxyConnection, binOnUnixSocket BinaryForwardi
 		log.Println("done") // Println executes normally even if there is a panic
 		if x := recover(); x != nil {
 			log.Printf("run time panic, moving back socket %v", x)
-			err := MoveBack(ios.DefaultUsbmuxdSocket)
+			err := MoveBack(ios.ToUnixSocketPath(ios.GetUsbmuxdSocket()))
 			if err != nil {
 				log.WithFields(log.Fields{"error": err}).Error("Failed moving back socket")
 			}

--- a/ios/debugproxy/debugproxy.go
+++ b/ios/debugproxy/debugproxy.go
@@ -100,18 +100,18 @@ func (d *DebugProxy) Launch(device ios.DeviceEntry, binaryMode bool) error {
 		}
 		log.Infof("Successfully retrieved pairrecord: %s for device %s", pairRecord.HostID, device.Properties.SerialNumber)
 	}
-	originalSocket, err := MoveSock(ios.DefaultUsbmuxdSocket)
+	originalSocket, err := MoveSock(ios.ToUnixSocketPath(ios.GetUsbmuxdSocket()))
 	if err != nil {
-		log.WithFields(log.Fields{"error": err, "socket": ios.DefaultUsbmuxdSocket}).Error("Unable to move, lacking permissions?")
+		log.WithFields(log.Fields{"error": err, "socket": ios.GetUsbmuxdSocket()}).Error("Unable to move, lacking permissions?")
 		return err
 	}
 	d.setupDirectory()
-	listener, err := net.Listen("unix", ios.DefaultUsbmuxdSocket)
+	listener, err := net.Listen("unix", ios.ToUnixSocketPath(ios.GetUsbmuxdSocket()))
 	if err != nil {
 		log.Error("Could not listen on usbmuxd socket, do I have access permissions?", err)
 		return err
 	}
-	if err := os.Chmod(ios.DefaultUsbmuxdSocket, 0777); err != nil {
+	if err := os.Chmod(ios.ToUnixSocketPath(ios.GetUsbmuxdSocket()), 0777); err != nil {
 		log.Error("Could not change permission on usbmuxd socket", err)
 		return err
 	}
@@ -168,7 +168,7 @@ func startProxyConnection(conn net.Conn, originalSocket string, pairRecord ios.P
 //Close moves /var/run/usbmuxd.real back to /var/run/usbmuxd and disconnects all active proxy connections
 func (d *DebugProxy) Close() {
 	log.Info("Moving back original socket")
-	err := MoveBack(ios.DefaultUsbmuxdSocket)
+	err := MoveBack(ios.ToUnixSocketPath(ios.GetUsbmuxdSocket()))
 	if err != nil {
 		log.WithFields(log.Fields{"error": err}).Error("Failed moving back socket")
 	}

--- a/ios/debugproxy/muxhandler.go
+++ b/ios/debugproxy/muxhandler.go
@@ -15,7 +15,7 @@ func proxyUsbMuxConnection(p *ProxyConnection, muxOnUnixSocket *ios.UsbMuxConnec
 		log.Println("done") // Println executes normally even if there is a panic
 		if x := recover(); x != nil {
 			log.Printf("run time panic, moving back socket %v", x)
-			err := MoveBack(ios.DefaultUsbmuxdSocket)
+			err := MoveBack(ios.ToUnixSocketPath(ios.GetUsbmuxdSocket()))
 			if err != nil {
 				log.WithFields(log.Fields{"error": err}).Error("Failed moving back socket")
 			}

--- a/ios/deviceconnection.go
+++ b/ios/deviceconnection.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"io"
 	"net"
-	"runtime"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -45,13 +44,7 @@ func NewDeviceConnectionWithConn(conn net.Conn) *DeviceConnection {
 
 //ConnectToSocketAddress connects to the USB multiplexer with a specified socket addres
 func (conn *DeviceConnection) connectToSocketAddress(socketAddress string) error {
-	var network, address string
-	switch runtime.GOOS {
-	case "windows":
-		network, address = "tcp", "127.0.0.1:27015"
-	default:
-		network, address = "unix", socketAddress
-	}
+	network, address := GetSocketTypeAndAddress(socketAddress);
 	c, err := net.Dial(network, address)
 	if err != nil {
 		return err

--- a/ios/listen.go
+++ b/ios/listen.go
@@ -3,6 +3,7 @@ package ios
 import (
 	"bytes"
 	"fmt"
+
 	"howett.net/plist"
 )
 
@@ -86,7 +87,7 @@ func (muxConn *UsbMuxConnection) Listen() (func() (AttachedMessage, error), erro
 }
 
 func Listen() (func() (AttachedMessage, error), func() error, error) {
-	deviceConn, err := NewDeviceConnection(DefaultUsbmuxdSocket)
+	deviceConn, err := NewDeviceConnection(GetUsbmuxdSocket())
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not connect to usbmuxd: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -1368,10 +1368,10 @@ func outputProcessListNoJSON(device ios.DeviceEntry, processes []instruments.Pro
 func startListening() {
 	go func() {
 		for {
-			deviceConn, err := ios.NewDeviceConnection(ios.DefaultUsbmuxdSocket)
+			deviceConn, err := ios.NewDeviceConnection(ios.GetUsbmuxdSocket())
 			defer deviceConn.Close()
 			if err != nil {
-				log.Errorf("could not connect to %s with err %+v, will retry in 3 seconds...", ios.DefaultUsbmuxdSocket, err)
+				log.Errorf("could not connect to %s with err %+v, will retry in 3 seconds...", ios.GetUsbmuxdSocket(), err)
 				time.Sleep(time.Second * 3)
 				continue
 			}


### PR DESCRIPTION
Support for `USBMUXD_SOCKET_ADDRESS` as recently introduced in [libusbmuxd](https://github.com/libimobiledevice/libusbmuxd#environment)