### PR TITLE
Fix fsync fd, fd leak and export some useful method

### DIFF
--- a/ios/afc/fsync.go
+++ b/ios/afc/fsync.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/danielpaulus/go-ios/ios"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/danielpaulus/go-ios/ios"
+	log "github.com/sirupsen/logrus"
 )
 
 const serviceName = "com.apple.afc"
@@ -326,7 +327,7 @@ func (conn *Connection) TreeView(dpath string, prefix string, treePoint bool) er
 	return nil
 }
 
-func (conn *Connection) openFile(path string, mode uint64) (byte, error) {
+func (conn *Connection) OpenFile(path string, mode uint64) (uint64, error) {
 	pathBytes := []byte(path)
 	pathBytes = append(pathBytes, 0)
 	headerLength := 8 + uint64(len(pathBytes))
@@ -345,12 +346,17 @@ func (conn *Connection) openFile(path string, mode uint64) (byte, error) {
 	if err = conn.checkOperationStatus(response); err != nil {
 		return 0, fmt.Errorf("open file: unexpected afc status: %v", err)
 	}
-	return response.HeaderPayload[0], nil
+	fd := binary.LittleEndian.Uint64(response.HeaderPayload)
+	if fd == 0 {
+		return 0, fmt.Errorf("file descriptor should not be zero")
+	}
+
+	return fd, nil
 }
 
-func (conn *Connection) closeFile(handle byte) error {
+func (conn *Connection) CloseFile(fd uint64) error {
 	headerPayload := make([]byte, 8)
-	headerPayload[0] = handle
+	binary.LittleEndian.PutUint64(headerPayload, fd)
 	thisLength := 8 + Afc_header_size
 	header := AfcPacketHeader{Magic: Afc_magic, Packet_num: conn.packageNumber, Operation: Afc_operation_file_close, This_length: thisLength, Entire_length: thisLength}
 	conn.packageNumber++
@@ -373,11 +379,11 @@ func (conn *Connection) PullSingleFile(srcPath, dstPath string) error {
 	if fileInfo.IsLink() {
 		srcPath = fileInfo.stLinktarget
 	}
-	fd, err := conn.openFile(srcPath, Afc_Mode_RDONLY)
+	fd, err := conn.OpenFile(srcPath, Afc_Mode_RDONLY)
 	if err != nil {
 		return err
 	}
-	defer conn.closeFile(fd)
+	defer conn.CloseFile(fd)
 
 	f, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
@@ -389,7 +395,7 @@ func (conn *Connection) PullSingleFile(srcPath, dstPath string) error {
 	maxReadSize := 64 * 1024
 	for leftSize > 0 {
 		headerPayload := make([]byte, 16)
-		headerPayload[0] = fd
+		binary.LittleEndian.PutUint64(headerPayload, fd)
 		thisLength := Afc_header_size + 16
 		binary.LittleEndian.PutUint64(headerPayload[8:], uint64(maxReadSize))
 		header := AfcPacketHeader{Magic: Afc_magic, Packet_num: conn.packageNumber, Operation: Afc_operation_file_read, This_length: thisLength, Entire_length: thisLength}
@@ -461,18 +467,17 @@ func (conn *Connection) Push(srcPath, dstPath string) error {
 }
 
 func (conn *Connection) WriteToFile(reader io.Reader, dstPath string) error {
-
 	if fileInfo, _ := conn.Stat(dstPath); fileInfo != nil {
 		if fileInfo.IsDir() {
 			return fmt.Errorf("%s is a directory, cannot write to it as file", dstPath)
 		}
 	}
 
-	fd, err := conn.openFile(dstPath, Afc_Mode_WR)
+	fd, err := conn.OpenFile(dstPath, Afc_Mode_WR)
 	if err != nil {
 		return err
 	}
-	defer conn.closeFile(fd)
+	defer conn.CloseFile(fd)
 
 	maxWriteSize := 64 * 1024
 	chunk := make([]byte, maxWriteSize)
@@ -486,7 +491,7 @@ func (conn *Connection) WriteToFile(reader io.Reader, dstPath string) error {
 		}
 		bytesRead := chunk[:n]
 		headerPayload := make([]byte, 8)
-		headerPayload[0] = fd
+		binary.LittleEndian.PutUint64(headerPayload, fd)
 		thisLength := Afc_header_size + 8
 		header := AfcPacketHeader{Magic: Afc_magic, Packet_num: conn.packageNumber, Operation: Afc_operation_file_write, This_length: thisLength, Entire_length: thisLength + uint64(n)}
 		conn.packageNumber++

--- a/ios/deviceconnection.go
+++ b/ios/deviceconnection.go
@@ -18,9 +18,9 @@ type DeviceConnectionInterface interface {
 	Reader() io.Reader
 	Writer() io.Writer
 	EnableSessionSsl(pairRecord PairRecord) error
-	EnableSessionSslServerMode(pairRecord PairRecord)
+	EnableSessionSslServerMode(pairRecord PairRecord) error
 	EnableSessionSslHandshakeOnly(pairRecord PairRecord) error
-	EnableSessionSslServerModeHandshakeOnly(pairRecord PairRecord)
+	EnableSessionSslServerModeHandshakeOnly(pairRecord PairRecord) error
 	DisableSessionSSL()
 	Conn() net.Conn
 }
@@ -136,16 +136,22 @@ func (conn *DeviceConnection) DisableSessionSSL() {
 }
 
 // EnableSessionSslServerMode wraps the underlying net.Conn in a server tls.Conn using the pairRecord.
-func (conn *DeviceConnection) EnableSessionSslServerMode(pairRecord PairRecord) {
-	tlsConn, _ := conn.createServerTLSConn(pairRecord)
+func (conn *DeviceConnection) EnableSessionSslServerMode(pairRecord PairRecord) error {
+	tlsConn, err := conn.createServerTLSConn(pairRecord)
+	if err != nil {
+		return err
+	}
+
 	conn.unencryptedConn = conn.c
 	conn.c = net.Conn(tlsConn)
+	return nil
 }
 
 // EnableSessionSslServerModeHandshakeOnly enables SSL only for the Handshake and then falls back to plaintext
 // DTX based services do that currently. Server mode is needed only in the debugproxy.
-func (conn *DeviceConnection) EnableSessionSslServerModeHandshakeOnly(pairRecord PairRecord) {
-	conn.createServerTLSConn(pairRecord)
+func (conn *DeviceConnection) EnableSessionSslServerModeHandshakeOnly(pairRecord PairRecord) error {
+	_, err := conn.createServerTLSConn(pairRecord)
+	return err
 }
 
 // EnableSessionSsl wraps the underlying net.Conn in a client tls.Conn using the pairRecord.

--- a/ios/dtx_codec/decoder.go
+++ b/ios/dtx_codec/decoder.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
 )
@@ -70,7 +71,7 @@ func ReadMessage(reader io.Reader) (Message, error) {
 		if err != nil {
 			return Message{}, err
 		}
-		result.Auxiliary = decodeAuxiliary(auxBytes)
+		result.Auxiliary = DecodeAuxiliary(auxBytes)
 	}
 
 	result.RawBytes = make([]byte, 0)
@@ -149,7 +150,7 @@ func DecodeNonBlocking(messageBytes []byte) (Message, []byte, error) {
 			return Message{}, make([]byte, 0), NewIncomplete("Aux Payload missing")
 		}
 		auxBytes := messageBytes[64 : 48+result.PayloadHeader.AuxiliaryLength]
-		result.Auxiliary = decodeAuxiliary(auxBytes)
+		result.Auxiliary = DecodeAuxiliary(auxBytes)
 	}
 
 	totalMessageLength := result.MessageLength + int(DtxMessageHeaderLength)

--- a/ios/dtx_codec/dtxprimitivedictionary.go
+++ b/ios/dtx_codec/dtxprimitivedictionary.go
@@ -126,7 +126,7 @@ func (d PrimitiveDictionary) String() string {
 			result += fmt.Sprintf("{t:%s, v:%s},", toString(v), prettyString)
 			continue
 		}
-		if v == t_string{
+		if v == t_string {
 			result += d.values[i].(string)
 		}
 		if v == t_uint32 {
@@ -139,7 +139,7 @@ func (d PrimitiveDictionary) String() string {
 	return result
 }
 
-func decodeAuxiliary(auxBytes []byte) PrimitiveDictionary {
+func DecodeAuxiliary(auxBytes []byte) PrimitiveDictionary {
 	result := PrimitiveDictionary{}
 	result.keyValuePairs = list.New()
 	for {
@@ -191,7 +191,7 @@ func readEntry(auxBytes []byte) (uint32, interface{}, []byte) {
 	if hasLength(readType) {
 		length := binary.LittleEndian.Uint32(auxBytes[4:])
 		data := auxBytes[8 : 8+length]
-		if readType==t_string{
+		if readType == t_string {
 			return readType, string(data), auxBytes[8+length:]
 		}
 		return readType, data, auxBytes[8+length:]

--- a/ios/listdevices.go
+++ b/ios/listdevices.go
@@ -101,6 +101,6 @@ func ListDevices() (DeviceList, error) {
 	if err != nil {
 		return DeviceList{}, err
 	}
-	defer muxConnection.ReleaseDeviceConnection()
+	defer muxConnection.Close()
 	return muxConnection.ListDevices()
 }

--- a/ios/lockdown.go
+++ b/ios/lockdown.go
@@ -1,49 +1,49 @@
 package ios
 
 import (
-	log "github.com/sirupsen/logrus"
 	"net"
+
+	log "github.com/sirupsen/logrus"
 )
 
-//Lockdownport is the port of the always running lockdownd on the iOS device.
+// Lockdownport is the port of the always running lockdownd on the iOS device.
 const Lockdownport uint16 = 32498
 
-//LockDownConnection allows you to interact with the Lockdown service on the phone.
-//You can use this to grab basic info from the device and start other services on the phone.
+// LockDownConnection allows you to interact with the Lockdown service on the phone.
+// You can use this to grab basic info from the device and start other services on the phone.
 type LockDownConnection struct {
 	deviceConnection DeviceConnectionInterface
 	sessionID        string
 	plistCodec       PlistCodec
 }
 
-//NewLockDownConnection creates a new LockDownConnection with empty sessionId and a PlistCodec.
+// NewLockDownConnection creates a new LockDownConnection with empty sessionId and a PlistCodec.
 func NewLockDownConnection(dev DeviceConnectionInterface) *LockDownConnection {
 	return &LockDownConnection{deviceConnection: dev, plistCodec: NewPlistCodec()}
 }
 
-//Close closes the underlying DeviceConnection
+// Close closes the underlying DeviceConnection
 func (lockDownConn *LockDownConnection) Close() {
 	lockDownConn.StopSession()
 	lockDownConn.deviceConnection.Close()
 }
 
-//DisableSessionSSL see documentation in DeviceConnection
+// DisableSessionSSL see documentation in DeviceConnection
 func (lockDownConn LockDownConnection) DisableSessionSSL() {
 	lockDownConn.deviceConnection.DisableSessionSSL()
 }
 
-//EnableSessionSsl see documentation in DeviceConnection
+// EnableSessionSsl see documentation in DeviceConnection
 func (lockDownConn LockDownConnection) EnableSessionSsl(pairRecord PairRecord) error {
 	return lockDownConn.deviceConnection.EnableSessionSsl(pairRecord)
 }
 
-//EnableSessionSslServerMode see documentation in DeviceConnection
-func (lockDownConn LockDownConnection) EnableSessionSslServerMode(pairRecord PairRecord) {
-	lockDownConn.deviceConnection.EnableSessionSslServerMode(pairRecord)
-
+// EnableSessionSslServerMode see documentation in DeviceConnection
+func (lockDownConn LockDownConnection) EnableSessionSslServerMode(pairRecord PairRecord) error {
+	return lockDownConn.deviceConnection.EnableSessionSslServerMode(pairRecord)
 }
 
-//Send takes a go struct, converts it to a PLIST and sends it with a 4 byte length field.
+// Send takes a go struct, converts it to a PLIST and sends it with a 4 byte length field.
 func (lockDownConn LockDownConnection) Send(msg interface{}) error {
 	bytes, err := lockDownConn.plistCodec.Encode(msg)
 	if err != nil {
@@ -53,8 +53,8 @@ func (lockDownConn LockDownConnection) Send(msg interface{}) error {
 	return lockDownConn.deviceConnection.Send(bytes)
 }
 
-//ReadMessage grabs the next LockDown Message using the PlistDecoder from the underlying
-//DeviceConnection and returns the Plist as a byte slice.
+// ReadMessage grabs the next LockDown Message using the PlistDecoder from the underlying
+// DeviceConnection and returns the Plist as a byte slice.
 func (lockDownConn *LockDownConnection) ReadMessage() ([]byte, error) {
 	reader := lockDownConn.deviceConnection.Reader()
 	resp, err := lockDownConn.plistCodec.Decode(reader)

--- a/ios/pair_read.go
+++ b/ios/pair_read.go
@@ -97,6 +97,6 @@ func ReadPairRecord(udid string) (PairRecord, error) {
 	if err != nil {
 		return PairRecord{}, fmt.Errorf("Could not create usbmuxConnection with error %v", err)
 	}
-	defer muxConnection.ReleaseDeviceConnection()
+	defer muxConnection.Close()
 	return muxConnection.ReadPair(udid)
 }

--- a/ios/usbmuxconnection_test.go
+++ b/ios/usbmuxconnection_test.go
@@ -96,7 +96,7 @@ type DeviceConnectionMock struct {
 	mock.Mock
 }
 
-func (mock *DeviceConnectionMock) Close() error{
+func (mock *DeviceConnectionMock) Close() error {
 	mock.Called()
 	return nil
 }
@@ -116,15 +116,17 @@ func (mock *DeviceConnectionMock) EnableSessionSsl(pairRecord ios.PairRecord) er
 	args := mock.Called(pairRecord)
 	return args.Error(0)
 }
-func (mock *DeviceConnectionMock) EnableSessionSslServerMode(pairRecord ios.PairRecord) {
-	mock.Called(pairRecord)
+func (mock *DeviceConnectionMock) EnableSessionSslServerMode(pairRecord ios.PairRecord) error {
+	args := mock.Called(pairRecord)
+	return args.Error(0)
 }
 func (mock *DeviceConnectionMock) EnableSessionSslHandshakeOnly(pairRecord ios.PairRecord) error {
 	args := mock.Called(pairRecord)
 	return args.Error(0)
 }
-func (mock *DeviceConnectionMock) EnableSessionSslServerModeHandshakeOnly(pairRecord ios.PairRecord) {
-	mock.Called(pairRecord)
+func (mock *DeviceConnectionMock) EnableSessionSslServerModeHandshakeOnly(pairRecord ios.PairRecord) error {
+	args := mock.Called(pairRecord)
+	return args.Error(0)
 }
 func (mock *DeviceConnectionMock) DisableSessionSSL() {
 	mock.Called()


### PR DESCRIPTION
1. fix fsync fd > 256
2. close connection fd in ListDevices and ReadPair
3. return error when EnableSSL failed
4. export dtx.decodeAuxiliary for custom use