### PR TITLE
Added battery diagnostics domain

### DIFF
--- a/ios/batterydiagnostics.go
+++ b/ios/batterydiagnostics.go
@@ -1,0 +1,57 @@
+package ios
+
+type BatteryInfo struct {
+	BatteryCurrentCapacity uint64
+	BatteryIsCharging      bool
+	ExternalChargeCapable  bool
+	ExternalConnected      bool
+	FullyCharged           bool
+	GasGaugeCapability     bool
+	HasBattery             bool
+}
+
+const batteryDomain = "com.apple.mobile.battery"
+
+type Connection struct {
+	deviceConn DeviceConnectionInterface
+	plistCodec PlistCodec
+}
+
+func GetBatteryDiagnostics(device DeviceEntry) (BatteryInfo, error) {
+	batteryConn, err := ConnectLockdownWithSession(device)
+	if err != nil {
+		return BatteryInfo{}, err
+	}
+	defer batteryConn.Close()
+
+	capacityResp, err := batteryConn.GetValueForDomain("BatteryCurrentCapacity", batteryDomain)
+	if err != nil {
+		return BatteryInfo{}, err
+	}
+	chargingResp, err := batteryConn.GetValueForDomain("BatteryIsCharging", batteryDomain)
+	if err != nil {
+		return BatteryInfo{}, err
+	}
+	externalChargeResp, err := batteryConn.GetValueForDomain("ExternalChargeCapable", batteryDomain)
+	if err != nil {
+		return BatteryInfo{}, err
+	}
+	externalResp, err := batteryConn.GetValueForDomain("ExternalConnected", batteryDomain)
+	if err != nil {
+		return BatteryInfo{}, err
+	}
+	chargedResp, err := batteryConn.GetValueForDomain("FullyCharged", batteryDomain)
+	if err != nil {
+		return BatteryInfo{}, err
+	}
+	gasGaugeResp, err := batteryConn.GetValueForDomain("GasGaugeCapability", batteryDomain)
+	if err != nil {
+		return BatteryInfo{}, err
+	}
+	hasBatteryResp, err := batteryConn.GetValueForDomain("HasBattery", batteryDomain)
+	if err != nil {
+		return BatteryInfo{}, err
+	}
+
+	return BatteryInfo{BatteryCurrentCapacity: capacityResp.(uint64), BatteryIsCharging: chargingResp.(bool), ExternalChargeCapable: externalChargeResp.(bool), ExternalConnected: externalResp.(bool), FullyCharged: chargedResp.(bool), GasGaugeCapability: gasGaugeResp.(bool), HasBattery: hasBatteryResp.(bool)}, nil
+}

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ Usage:
   ios crash ls [<pattern>] [options]
   ios crash cp <srcpattern> <target> [options]
   ios crash rm <cwd> <pattern> [options]
-  ios devicename [options] 
+  ios devicename [options]
   ios date [options]
   ios devicestate list [options]
   ios devicestate enable <profileTypeId> <profileId> [options]
@@ -100,7 +100,7 @@ Usage:
   ios ax [options]
   ios debug [options] [--stop-at-entry] <app_path>
   ios fsync (rm [--r] | tree | mkdir) --path=<targetPath>
-  ios fsync (pull | push) --srcPath=<srcPath> --dstPath=<dstPath> 
+  ios fsync (pull | push) --srcPath=<srcPath> --dstPath=<dstPath>
   ios reboot [options]
   ios -h | --help
   ios --version | version [options]
@@ -109,6 +109,7 @@ Usage:
   ios resetlocation [options]
   ios assistivetouch (enable | disable | toggle | get) [--force] [options]
   ios diskspace [options]
+  ios batterycheck [options]
 
 Options:
   -v --verbose   Enable Debug Logging.
@@ -119,7 +120,7 @@ Options:
   --udid=<udid>  UDID of the device.
 
 The commands work as following:
-	The default output of all commands is JSON. Should you prefer human readable outout, specify the --nojson option with your command. 
+	The default output of all commands is JSON. Should you prefer human readable outout, specify the --nojson option with your command.
 	By default, the first device found will be used for a command unless you specify a --udid=some_udid switch.
 	Specify -v for debug logging and -t for dumping every message.
 
@@ -130,12 +131,12 @@ The commands work as following:
    ios image mount [--path=<imagepath>] [options]                     Mount a image from <imagepath>
    ios image auto [--basedir=<where_dev_images_are_stored>] [options] Automatically download correct dev image from the internets and mount it.
    >                                                                  You can specify a dir where images should be cached.
-   >                                                                  The default is the current dir. 
+   >                                                                  The default is the current dir.
    ios syslog [options]                                               Prints a device's log output
    ios screenshot [options] [--output=<outfile>] [--stream] [--port=<port>]  Takes a screenshot and writes it to the current dir or to <outfile>  If --stream is supplied it
    >                                                                  starts an mjpeg server at 0.0.0.0:3333. Use --port to set another port.
-   ios instruments notifications [options]                            Listen to application state notifications                                    
-   ios crash ls [<pattern>] [options]                                 run "ios crash ls" to get all crashreports in a list, 
+   ios instruments notifications [options]                            Listen to application state notifications
+   ios crash ls [<pattern>] [options]                                 run "ios crash ls" to get all crashreports in a list,
    >                                                                  or use a pattern like 'ios crash ls "*ips*"' to filter
    ios crash cp <srcpattern> <target> [options]                       copy "file pattern" to the target dir. Ex.: 'ios crash cp "*" "./crashes"'
    ios crash rm <cwd> <pattern> [options]                             remove file pattern from dir. Ex.: 'ios crash rm "." "*"' to delete everything
@@ -146,10 +147,10 @@ The commands work as following:
    >                                                                  Ex. "ios devicestate enable SlowNetworkCondition SlowNetwork3GGood"
    ios lang [--setlocale=<locale>] [--setlang=<newlang>] [options]    Sets or gets the Device language
    ios mobilegestalt <key>... [--plist] [options]                     Lets you query mobilegestalt keys. Standard output is json but if desired you can get
-   >                                                                  it in plist format by adding the --plist param. 
+   >                                                                  it in plist format by adding the --plist param.
    >                                                                  Ex.: "ios mobilegestalt MainScreenCanvasSizes ArtworkTraits --plist"
    ios diagnostics list [options]                                     List diagnostic infos
-   ios pair [--p12file=<orgid>] [--password=<p12password>] [options]  Pairs the device. If the device is supervised, specify the path to the p12 file 
+   ios pair [--p12file=<orgid>] [--password=<p12password>] [options]  Pairs the device. If the device is supervised, specify the path to the p12 file
    >                                                                  to pair without a trust dialog. Specify the password either with the argument or
    >                                                                  by setting the environment variable 'P12_PASSWORD'
    ios profile list                                                   List the profiles on the device
@@ -164,18 +165,18 @@ The commands work as following:
    >                                                                  --apps limits output to processes flagged by iOS as "isApplication". This greatly-filtered list
    >                                                                  should at least include user-installed software.  Additional packages will also be displayed depending on the version of iOS.
    ios ip [options]                                                   Uses the live pcap iOS packet capture to wait until it finds one that contains the IP address of the device.
-   >                                                                  It relies on the MAC address of the WiFi adapter to know which is the right IP. 
+   >                                                                  It relies on the MAC address of the WiFi adapter to know which is the right IP.
    >                                                                  You have to disable the "automatic wifi address"-privacy feature of the device for this to work.
    >                                                                  If you wanna speed it up, open apple maps or similar to force network traffic.
    >                                                                  f.ex. "ios launch com.apple.Maps"
    ios forward [options] <hostPort> <targetPort>                      Similar to iproxy, forward a TCP connection to the device.
-   ios dproxy [--binary]                                              Starts the reverse engineering proxy server. 
-   >                                                                  It dumps every communication in plain text so it can be implemented easily. 
+   ios dproxy [--binary]                                              Starts the reverse engineering proxy server.
+   >                                                                  It dumps every communication in plain text so it can be implemented easily.
    >                                                                  Use "sudo launchctl unload -w /Library/Apple/System/Library/LaunchDaemons/com.apple.usbmuxd.plist"
    >                                                                  to stop usbmuxd and load to start it again should the proxy mess up things.
-   >                                                                  The --binary flag will dump everything in raw binary without any decoding. 
+   >                                                                  The --binary flag will dump everything in raw binary without any decoding.
    ios readpair                                                       Dump detailed information about the pairrecord for a device.
-   ios install --path=<ipaOrAppFolder> [options]                      Specify a .app folder or an installable ipa file that will be installed.  
+   ios install --path=<ipaOrAppFolder> [options]                      Specify a .app folder or an installable ipa file that will be installed.
    ios pcap [options] [--pid=<processID>] [--process=<processName>]   Starts a pcap dump of network traffic, use --pid or --process to filter specific processes.
    ios apps [--system] [--all] [--list]                               Retrieves a list of installed applications. --system prints out preinstalled system apps. --all prints all apps, including system, user, and hidden apps. --list only prints bundle ID, bundle name and version number.
    ios launch <bundleID> [--wait]                                     Launch app with the bundleID on the device. Get your bundle ID from the apps command. --wait keeps the connection open if you want logs.
@@ -183,7 +184,7 @@ The commands work as following:
    ios runtest [--bundle-id=<bundleid>] [--test-runner-bundle-id=<testbundleid>] [--xctest-config=<xctestconfig>] [--env=<e>]... [options]                    Run a XCUITest. If you provide only bundle-id go-ios will try to dynamically create test-runner-bundle-id and xctest-config.
    ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]...[options]  runs WebDriverAgents
    >                                                                  specify runtime args and env vars like --env ENV_1=something --env ENV_2=else  and --arg ARG1 --arg ARG2
-   ios ax [options]                                                   Access accessibility inspector features. 
+   ios ax [options]                                                   Access accessibility inspector features.
    ios debug [--stop-at-entry] <app_path>                             Start debug with lldb
    ios fsync (rm [--r] | tree | mkdir) --path=<targetPath>            Remove | treeview | mkdir in target path. --r used alongside rm will recursively remove all files and directories from target path.
    ios fsync (pull | push) --srcPath=<srcPath> --dstPath=<dstPath>    Pull or Push file from srcPath to dstPath.
@@ -195,6 +196,7 @@ The commands work as following:
    ios resetlocation [options]                                        Resets the location of the device to the actual one
    ios assistivetouch (enable | disable | toggle | get) [--force] [options] Enables, disables, toggles, or returns the state of the "AssistiveTouch" software home-screen button. iOS 11+ only (Use --force to try on older versions).
    ios diskspace [options]											  Prints disk space info.
+   ios batterycheck [options]                                         Prints battery info.
 
   `, version)
 	arguments, err := docopt.ParseDoc(usage)
@@ -727,6 +729,12 @@ The commands work as following:
 		fmt.Printf(" TotalSpace: %s\n", ios.ByteCountDecimal(int64(info.TotalBytes)))
 		return
 	}
+
+	b, _ = arguments.Bool("batterycheck")
+	if b {
+	    printBatteryDiagnostics(device)
+	    return
+	}
 }
 
 func mobileGestaltCommand(device ios.DeviceEntry, arguments docopt.Opts) bool {
@@ -1157,6 +1165,13 @@ func printDiagnostics(device ios.DeviceEntry) {
 	exitIfError("getting valued failed", err)
 
 	fmt.Println(convertToJSONString(values))
+}
+
+func printBatteryDiagnostics(device ios.DeviceEntry) {
+	battery, err := ios.GetBatteryDiagnostics(device)
+	exitIfError("failed getting battery diagnostics", err)
+
+	fmt.Println(convertToJSONString(battery))
 }
 
 func printDeviceDate(device ios.DeviceEntry) {


### PR DESCRIPTION
Added support for domain "com.apple.mobile.battery"
(from libimobiledevice: `ideviceinfo -u {self.impl.device_udid} --domain com.apple.mobile.battery"`)