### PR TITLE
Reuse code logic in image auto, tiny cleanup

### DIFF
--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -242,32 +242,6 @@ func (conn *Connection) hangUp() error {
 	return nil
 }
 
-// FixDevImage checks if a dev image is already installed and does nothing in that case. Otherwise it
-// looks for the image for the device version in baseDir. If it is not present it will download it from
-// github and install.
-func FixDevImage(device ios.DeviceEntry, baseDir string) error {
-	conn, err := New(device)
-	if err != nil {
-		return fmt.Errorf("failed connecting to image mounter: %v", err)
-	}
-	signatures, err := conn.ListImages()
-	if err != nil {
-		return fmt.Errorf("failed getting image list: %v", err)
-	}
-
-	if len(signatures) != 0 {
-		log.Warn("there is already a developer image mounted, reboot the device if you want to remove it. aborting.")
-		return nil
-	}
-	imagePath, err := DownloadImageFor(device, baseDir)
-	if err != nil {
-		return fmt.Errorf("failed downloading image: %v", err)
-	}
-
-	log.Infof("installing downloaded image '%s'", imagePath)
-	return MountImage(device, imagePath)
-}
-
 func MountImage(device ios.DeviceEntry, path string) error {
 	conn, err := New(device)
 	if err != nil {

--- a/ios/testmanagerd/xcuitestrunner_test.go
+++ b/ios/testmanagerd/xcuitestrunner_test.go
@@ -40,8 +40,16 @@ func TestXcuiTest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// mounts&downloads developer image if needed
-	err = imagemounter.FixDevImage(device, ".")
+
+	// download the image, if needed
+	imagePath, err := imagemounter.DownloadImageFor(device, ".")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// mounts developer image if needed
+	err = imagemounter.MountImage(device, imagePath)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
Fixes #252 , as the developer image does not mount properly with the current implementation.
I am not sure for the reason, that the current code will fail that often, however, this reuses the code, and auto now only downloads the image, which I think is ideal.