### PR TITLE
`fsync`: support app container jails

### DIFF
--- a/ios/afc/fsync.go
+++ b/ios/afc/fsync.go
@@ -3,6 +3,7 @@ package afc
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/danielpaulus/go-ios/ios"
 	log "github.com/sirupsen/logrus"
+	"howett.net/plist"
 )
 
 const serviceName = "com.apple.afc"
@@ -46,6 +48,67 @@ func New(device ios.DeviceEntry) (*Connection, error) {
 		return nil, err
 	}
 	return &Connection{deviceConn: deviceConn}, nil
+}
+
+func NewContainer(device ios.DeviceEntry, bundleID string) (*Connection, error) {
+	deviceConn, err := ios.ConnectToService(device, "com.apple.mobile.house_arrest")
+	if err != nil {
+		return nil, err
+	}
+	err = vendContainer(deviceConn, bundleID)
+	if err != nil {
+		return nil, err
+	}
+	return &Connection{deviceConn: deviceConn}, nil
+}
+
+func vendContainer(deviceConn ios.DeviceConnectionInterface, bundleID string) error {
+	plistCodec := ios.NewPlistCodec()
+	vendContainer := map[string]interface{}{"Command": "VendContainer", "Identifier": bundleID}
+	msg, err := plistCodec.Encode(vendContainer)
+	if err != nil {
+		return fmt.Errorf("VendContainer Encoding cannot fail unless the encoder is broken: %v", err)
+	}
+	err = deviceConn.Send(msg)
+	if err != nil {
+		return err
+	}
+	reader := deviceConn.Reader()
+	response, err := plistCodec.Decode(reader)
+	if err != nil {
+		return err
+	}
+	return checkResponse(response)
+}
+
+func checkResponse(vendContainerResponseBytes []byte) error {
+	response, err := plistFromBytes(vendContainerResponseBytes)
+	if err != nil {
+		return err
+	}
+	if "Complete" == response.Status {
+		return nil
+	}
+	if response.Error != "" {
+		return errors.New(response.Error)
+	}
+	return errors.New("unknown error during vendcontainer")
+}
+
+func plistFromBytes(plistBytes []byte) (vendContainerResponse, error) {
+	var vendResponse vendContainerResponse
+	decoder := plist.NewDecoder(bytes.NewReader(plistBytes))
+
+	err := decoder.Decode(&vendResponse)
+	if err != nil {
+		return vendResponse, err
+	}
+	return vendResponse, nil
+}
+
+type vendContainerResponse struct {
+	Status string
+	Error  string
 }
 
 // NewFromConn allows to use AFC on a DeviceConnectionInterface, see crashreport for an example

--- a/main.go
+++ b/main.go
@@ -109,8 +109,8 @@ Usage:
   ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--arg=<a>]... [--env=<e>]... [options]
   ios ax [options]
   ios debug [options] [--stop-at-entry] <app_path>
-  ios fsync (rm [--r] | tree | mkdir) --path=<targetPath>
-  ios fsync (pull | push) --srcPath=<srcPath> --dstPath=<dstPath>
+  ios fsync [--app=bundleId] [options] (rm [--r] | tree | mkdir) --path=<targetPath>
+  ios fsync [--app=bundleId] [options] (pull | push) --srcPath=<srcPath> --dstPath=<dstPath>
   ios reboot [options]
   ios -h | --help
   ios --version | version [options]
@@ -206,8 +206,8 @@ The commands work as following:
    >                                                                  specify runtime args and env vars like --env ENV_1=something --env ENV_2=else  and --arg ARG1 --arg ARG2
    ios ax [options]                                                   Access accessibility inspector features.
    ios debug [--stop-at-entry] <app_path>                             Start debug with lldb
-   ios fsync (rm [--r] | tree | mkdir) --path=<targetPath>            Remove | treeview | mkdir in target path. --r used alongside rm will recursively remove all files and directories from target path.
-   ios fsync (pull | push) --srcPath=<srcPath> --dstPath=<dstPath>    Pull or Push file from srcPath to dstPath.
+   ios fsync [--app=bundleId] [options] (rm [--r] | tree | mkdir) --path=<targetPath>            Remove | treeview | mkdir in target path. --r used alongside rm will recursively remove all files and directories from target path.
+   ios fsync [--app=bundleId] [options] (pull | push) --srcPath=<srcPath> --dstPath=<dstPath>    Pull or Push file from srcPath to dstPath.
    ios reboot [options]                                               Reboot the given device
    ios -h | --help                                                    Prints this screen.
    ios --version | version [options]                                  Prints the version
@@ -825,7 +825,13 @@ The commands work as following:
 
 	b, _ = arguments.Bool("fsync")
 	if b {
-		afcService, err := afc.New(device)
+		containerBundleId, _ := arguments.String("--app")
+		var afcService *afc.Connection
+		if containerBundleId == "" {
+			afcService, err = afc.New(device)
+		} else {
+			afcService, err = afc.NewContainer(device, containerBundleId)
+		}
 		exitIfError("fsync: connect afc service failed", err)
 		b, _ = arguments.Bool("rm")
 		if b {


### PR DESCRIPTION
First off, thanks for the fantastic work on go-ios! :smiley: 🍰 Extending go-ios was super easy after figuring out what I needed with the debug proxy.

I've had a use case where I wanted to read/write files from/to a specific app container jail. Fortunately `house_arrest` already had everything I needed, and adding an `--app` switch to the fsync commands was straightforward.

1. Is accessing app jails for fsync something you folks are interested in supporting?
2. If yes, where do we want vendContainer to live? I've just copied it over from `house_arrest.go` to avoid a circular dependency, but I'm happy to do the legwork and move it into something like `afc/house_arrest.go` and have everything point there.