### PR TITLE
Adding support to modify Time Format

### DIFF
--- a/ios/lockdown_time_format.go
+++ b/ios/lockdown_time_format.go
@@ -1,0 +1,48 @@
+package ios
+
+import log "github.com/sirupsen/logrus"
+import "fmt"
+
+const uses24HourClockKey = "Uses24HourClock"
+
+// Enable24HourClock creates a new lockdown session for the device and enables or disables
+// 24HourClock, by using the special key Uses24HourClock.
+// Setting to true will enable 24Hour Clock
+// Setting to false will disable 24Hour Clock, regardless of whether it was previously-enabled through
+// a non-iTunes-related method.
+func SetUses24HourClock(device DeviceEntry, enabled bool) error {
+	lockDownConn, err := ConnectLockdownWithSession(device)
+	if err != nil {
+		return err
+	}
+	log.Debugf("Setting %s: %t", uses24HourClockKey, enabled)
+	defer lockDownConn.Close()
+	err = lockDownConn.SetValueForDomain(uses24HourClockKey, "", enabled)
+	return err
+}
+func GetUses24HourClock(device DeviceEntry) (bool, error) {
+	lockDownConn, err := ConnectLockdownWithSession(device)
+
+	if err != nil {
+		return false, err
+	}
+	defer lockDownConn.Close()
+
+	enabledBoolf, err := lockDownConn.GetValueForDomain(uses24HourClockKey, "")
+
+	if err != nil {
+		return false, err
+	}
+	if enabledBoolf == nil {
+		// In testing, nil was returned in only one case, on an iOS 14.7 device that should already have been paired.
+		// Calling SetUses24HourClock() directly returned the somewhat more useful error: SetProhibited
+		// After re-running "go-ios pair", full functionality returned.
+		return false, fmt.Errorf("Received null response when querying %s.%s. Try re-pairing the device.", "", uses24HourClockKey)
+	}
+	enabledBool, ok := enabledBoolf.(bool)
+	if !ok {
+		return false, fmt.Errorf("Expected bool false or true when querying %s.%s, but received %T:%+v. Is this device running iOS 11+?", "", uses24HourClockKey, enabledBoolf, enabledBoolf)
+	}
+
+	return enabledBool, nil
+}

--- a/main.go
+++ b/main.go
@@ -1346,7 +1346,7 @@ func timeFormat(device ios.DeviceEntry, operation string, force bool) {
 			timeFormat = "12h"
 		}
 		if JSONdisabled {
-			fmt.Printf("%t\n", timeFormat)
+			fmt.Printf("%s\n", timeFormat)
 		} else {
 			fmt.Println(convertToJSONString(map[string]string{"TimeFormat": timeFormat}))
 		}

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ Usage:
   ios crash rm <cwd> <pattern> [options]
   ios devicename [options]
   ios date [options]
+  ios timeformat (24h | 12h | toggle | get) [--force] [options]
   ios devicestate list [options]
   ios devicestate enable <profileTypeId> <profileId> [options]
   ios erase [--force] [options]
@@ -119,7 +120,6 @@ Usage:
   ios assistivetouch (enable | disable | toggle | get) [--force] [options]
   ios voiceover (enable | disable | toggle | get) [--force] [options]
   ios zoomtouch (enable | disable | toggle | get) [--force] [options]
-  ios timeformat (24h | 12h | toggle | get) [--force] [options]
   ios diskspace [options]
   ios batterycheck [options]
 
@@ -1341,7 +1341,6 @@ func timeFormat(device ios.DeviceEntry, operation string, force bool) {
 		exitIfError("failed setting Time Format", err)
 	}
 	if operation == "get" {
-		fmt.Printf("Inside 1")
 		timeFormat := "24h"
 		if !enable {
 			timeFormat = "12h"

--- a/main.go
+++ b/main.go
@@ -217,7 +217,7 @@ The commands work as following:
    ios assistivetouch (enable | disable | toggle | get) [--force] [options] Enables, disables, toggles, or returns the state of the "AssistiveTouch" software home-screen button. iOS 11+ only (Use --force to try on older versions).
    ios voiceover (enable | disable | toggle | get) [--force] [options] Enables, disables, toggles, or returns the state of the "VoiceOver" software home-screen button. iOS 11+ only (Use --force to try on older versions).
    ios zoom (enable | disable | toggle | get) [--force] [options] Enables, disables, toggles, or returns the state of the "ZoomTouch" software home-screen button. iOS 11+ only (Use --force to try on older versions).
-   ios timeformat (24h | 12h | get) [--force] [options] Sets, or returns the state of the "time format". iOS 11+ only (Use --force to try on older versions).
+   ios timeformat (24h | 12h | toggle | get) [--force] [options] Sets, or returns the state of the "time format". iOS 11+ only (Use --force to try on older versions).
    ios diskspace [options]											  Prints disk space info.
    ios batterycheck [options]                                         Prints battery info.
 


### PR DESCRIPTION
Added support to modify timeformat of an iOS device.
In lockdown, there is a key `Uses24HourClock` that returns values as true or false, when 24 Hour Clock is enabled or disabled, respectively.
Turns out this key's value can also be modified over Lockdown Connection, to enable or disable 24 Hour Clock on the device, in turn changing time format of the device.

![image](https://github.com/danielpaulus/go-ios/assets/14928914/e7ca71c4-f9ae-47eb-913a-68f7382a7aef)
