### PR TITLE
Add additional types to XPC codec

### DIFF
--- a/ios/xpc/encoding_test.go
+++ b/ios/xpc/encoding_test.go
@@ -3,6 +3,7 @@ package xpc
 import (
 	"bytes"
 	"encoding/base64"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"path"
@@ -106,6 +107,7 @@ func TestEncodeDecode(t *testing.T) {
 					"int64":  int64(123),
 					"uint64": uint64(321),
 					"data":   []byte{0x1},
+					"double": float64(1.2),
 				},
 			},
 			expectedFlags: alwaysSetFlag | dataFlag,
@@ -121,6 +123,16 @@ func TestEncodeDecode(t *testing.T) {
 			name: "dictionary with array",
 			input: map[string]interface{}{
 				"array": []interface{}{uint64(1), uint64(2), uint64(3)},
+			},
+			expectedFlags: alwaysSetFlag | dataFlag,
+		},
+		{
+			name: "encode uuid",
+			input: map[string]interface{}{
+				"uuidvalue": func() uuid.UUID {
+					u, _ := uuid.FromBytes(base64Decode("RYjS2yNAbEG+Y0WWxq5/4w=="))
+					return u
+				}(),
 			},
 			expectedFlags: alwaysSetFlag | dataFlag,
 		},


### PR DESCRIPTION
TODO: for file transfers we only read the initial message that opens the stream