### PR TITLE
Replace DeviceConnectionInterface with io.ReadWriteCloser for DTX

### DIFF
--- a/ios/deviceconnection.go
+++ b/ios/deviceconnection.go
@@ -13,9 +13,11 @@ import (
 
 // DeviceConnectionInterface contains a physical network connection to a usbmuxd socket.
 type DeviceConnectionInterface interface {
-	Close() error
+	// Deprecated: use the Read([]byte) (int, error) function instead
 	Send(message []byte) error
+	// Deprecated: use the Read([]byte) (int, error) function
 	Reader() io.Reader
+	// Deprecated: use the Write([]byte) (int, error) function
 	Writer() io.Writer
 	EnableSessionSsl(pairRecord PairRecord) error
 	EnableSessionSslServerMode(pairRecord PairRecord) error
@@ -23,6 +25,7 @@ type DeviceConnectionInterface interface {
 	EnableSessionSslServerModeHandshakeOnly(pairRecord PairRecord) error
 	DisableSessionSSL()
 	Conn() net.Conn
+	io.ReadWriteCloser
 }
 
 // DeviceConnection wraps the net.Conn to the ios Device and has support for
@@ -30,6 +33,14 @@ type DeviceConnectionInterface interface {
 type DeviceConnection struct {
 	c               net.Conn
 	unencryptedConn net.Conn
+}
+
+func (conn *DeviceConnection) Read(p []byte) (n int, err error) {
+	return conn.Reader().Read(p)
+}
+
+func (conn *DeviceConnection) Write(p []byte) (n int, err error) {
+	return conn.Writer().Write(p)
 }
 
 // NewDeviceConnection creates a new DeviceConnection pointing to the given socket waiting for a call to Connect()


### PR DESCRIPTION
The `DeviceConnectionInterface` doesn't look like a very useful interface. Most of the service should only require a `io.ReadWriteCloser` to communicate with the device. And that's what kind of already happens, but since `DeviceConnectionInterface` exposes the `io.Reader` and `io.Writer` interfaces on separate methods, we still have to go through that instead of simply using the `io.ReadWriteCloser` interface directly.

For DTX the changes are very minimal, and most other services should not be more complex as most of the additional methods in `DeviceConnectionInterface` are either used by the debugproxy or lockdown.