### PR TITLE
Mount personalized developer disk images

### DIFF
--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -29,17 +29,6 @@ type ImageMounter interface {
 	io.Closer
 }
 
-// New returns a new mobile image mounter developerDiskImageMounter for the given DeviceID and Udid
-//
-// Deprecated: use NewDeveloperDiskImageMounter
-func New(device ios.DeviceEntry) (*DeveloperDiskImageMounter, error) {
-	version, err := ios.GetProductVersion(device)
-	if err != nil {
-		return nil, err
-	}
-	return NewDeveloperDiskImageMounter(device, version)
-}
-
 // NewDeveloperDiskImageMounter returns a new mobile image mounter DeveloperDiskImageMounter for the given device
 func NewDeveloperDiskImageMounter(device ios.DeviceEntry, version *semver.Version) (*DeveloperDiskImageMounter, error) {
 	deviceConn, err := ios.ConnectToService(device, serviceName)

--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -14,8 +14,8 @@ import (
 
 const serviceName string = "com.apple.mobile.mobile_image_mounter"
 
-// developerDiskImageMounter to mobile image mounter
-type developerDiskImageMounter struct {
+// DeveloperDiskImageMounter to mobile image mounter
+type DeveloperDiskImageMounter struct {
 	deviceConn ios.DeviceConnectionInterface
 	plistCodec ios.PlistCodec
 	version    *semver.Version
@@ -31,7 +31,7 @@ type ImageMounter interface {
 // New returns a new mobile image mounter developerDiskImageMounter for the given DeviceID and Udid
 //
 // Deprecated: use NewDeveloperDiskImageMounter
-func New(device ios.DeviceEntry) (*developerDiskImageMounter, error) {
+func New(device ios.DeviceEntry) (*DeveloperDiskImageMounter, error) {
 	version, err := ios.GetProductVersion(device)
 	if err != nil {
 		return nil, err
@@ -40,12 +40,12 @@ func New(device ios.DeviceEntry) (*developerDiskImageMounter, error) {
 }
 
 // NewDeveloperDiskImageMounter
-func NewDeveloperDiskImageMounter(device ios.DeviceEntry, version *semver.Version) (*developerDiskImageMounter, error) {
+func NewDeveloperDiskImageMounter(device ios.DeviceEntry, version *semver.Version) (*DeveloperDiskImageMounter, error) {
 	deviceConn, err := ios.ConnectToService(device, serviceName)
 	if err != nil {
 		return nil, err
 	}
-	return &developerDiskImageMounter{
+	return &DeveloperDiskImageMounter{
 		deviceConn: deviceConn,
 		plistCodec: ios.NewPlistCodec(),
 		version:    version,
@@ -66,12 +66,12 @@ func NewImageMounter(device ios.DeviceEntry) (ImageMounter, error) {
 }
 
 // ListImages returns a list with signatures of installed developer images
-func (conn *developerDiskImageMounter) ListImages() ([][]byte, error) {
+func (conn *DeveloperDiskImageMounter) ListImages() ([][]byte, error) {
 	return listImages(conn.plistRw, "Developer", conn.version)
 }
 
 // MountImage installs a .dmg image from imagePath after checking that it is present and valid.
-func (conn *developerDiskImageMounter) MountImage(imagePath string) error {
+func (conn *DeveloperDiskImageMounter) MountImage(imagePath string) error {
 	signatureBytes, imageSize, err := validatePathAndLoadSignature(imagePath)
 	if err != nil {
 		return err
@@ -102,7 +102,7 @@ func (conn *developerDiskImageMounter) MountImage(imagePath string) error {
 	return hangUp(conn.plistRw)
 }
 
-func (conn *developerDiskImageMounter) mountImage(signatureBytes []byte) error {
+func (conn *DeveloperDiskImageMounter) mountImage(signatureBytes []byte) error {
 	req := map[string]interface{}{
 		"Command":        "MountImage",
 		"ImageSignature": signatureBytes,
@@ -149,7 +149,7 @@ func validatePathAndLoadSignature(imagePath string) ([]byte, int64, error) {
 }
 
 // Close closes the underlying UsbMuxConnection
-func (conn *developerDiskImageMounter) Close() error {
+func (conn *DeveloperDiskImageMounter) Close() error {
 	return conn.deviceConn.Close()
 }
 

--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -203,17 +203,17 @@ func listImages(prw ios.PlistCodecReadWriter, imageType string, v *semver.Versio
 		"ImageType": imageType,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listImages: failed to write command 'LookupImage': %w", err)
 	}
 
 	var resp map[string]interface{}
 	err = prw.Read(&resp)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listImages: failed to read response for 'LookupImage': %w", err)
 	}
 	deviceError, ok := resp["Error"]
 	if ok {
-		return nil, fmt.Errorf("device error: %v", deviceError)
+		return nil, fmt.Errorf("listImages: device responded with error: %v", deviceError)
 	}
 
 	signatures, ok := resp["ImageSignature"]
@@ -221,7 +221,7 @@ func listImages(prw ios.PlistCodecReadWriter, imageType string, v *semver.Versio
 		if v.LessThan(ios.IOS14()) {
 			return [][]byte{}, nil
 		}
-		return nil, fmt.Errorf("invalid response: %+v", resp)
+		return nil, fmt.Errorf("listImages: invalid response: %+v", resp)
 	}
 
 	array, ok := signatures.([]interface{})
@@ -229,7 +229,7 @@ func listImages(prw ios.PlistCodecReadWriter, imageType string, v *semver.Versio
 	for i, intf := range array {
 		bytes, ok := intf.([]byte)
 		if !ok {
-			return nil, fmt.Errorf("could not convert %+v to byte slice", intf)
+			return nil, fmt.Errorf("listImages: could not convert %+v to byte slice", intf)
 		}
 		result[i] = bytes
 	}

--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -40,7 +40,7 @@ func New(device ios.DeviceEntry) (*DeveloperDiskImageMounter, error) {
 	return NewDeveloperDiskImageMounter(device, version)
 }
 
-// NewDeveloperDiskImageMounter
+// NewDeveloperDiskImageMounter returns a new mobile image mounter DeveloperDiskImageMounter for the given device
 func NewDeveloperDiskImageMounter(device ios.DeviceEntry, version *semver.Version) (*DeveloperDiskImageMounter, error) {
 	deviceConn, err := ios.ConnectToService(device, serviceName)
 	if err != nil {
@@ -54,10 +54,13 @@ func NewDeveloperDiskImageMounter(device ios.DeviceEntry, version *semver.Versio
 	}, nil
 }
 
+// NewImageMounter creates a new ImageMounter depending on the version of the given device.
+// For iOS 17+ devices a PersonalizedDeveloperDiskImageMounter is created, and for all other devices
+// a DeveloperDiskImageMounter gets created
 func NewImageMounter(device ios.DeviceEntry) (ImageMounter, error) {
 	version, err := ios.GetProductVersion(device)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get device version. %w", err)
+		return nil, fmt.Errorf("NewImageMounter: failed to get device version. %w", err)
 	}
 	if version.Major() < 17 {
 		return NewDeveloperDiskImageMounter(device, version)

--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -25,6 +25,7 @@ type developerDiskImageMounter struct {
 type ImageMounter interface {
 	ListImages() ([][]byte, error)
 	MountImage(imagePath string) error
+	io.Closer
 }
 
 // New returns a new mobile image mounter developerDiskImageMounter for the given DeviceID and Udid
@@ -136,8 +137,8 @@ func validatePathAndLoadSignature(imagePath string) ([]byte, int64, error) {
 }
 
 // Close closes the underlying UsbMuxConnection
-func (conn *developerDiskImageMounter) Close() {
-	conn.deviceConn.Close()
+func (conn *developerDiskImageMounter) Close() error {
+	return conn.deviceConn.Close()
 }
 
 func waitForUploadComplete(plistRw ios.PlistCodecReadWriter) error {
@@ -176,6 +177,7 @@ func MountImage(device ios.DeviceEntry, path string) error {
 	if err != nil {
 		return fmt.Errorf("failed connecting to image mounter: %v", err)
 	}
+	defer conn.Close()
 
 	signatures, err := conn.ListImages()
 	if err != nil {

--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -22,6 +22,7 @@ type DeveloperDiskImageMounter struct {
 	plistRw    ios.PlistCodecReadWriter
 }
 
+// ImageMounter mounts developer disk images to an iOS device, and give a list of already mounted images
 type ImageMounter interface {
 	ListImages() ([][]byte, error)
 	MountImage(imagePath string) error

--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -86,7 +86,7 @@ func (conn *developerDiskImageMounter) MountImage(imagePath string) error {
 		return err
 	}
 
-	return conn.hangUp()
+	return hangUp(conn.plistRw)
 }
 
 func (conn *developerDiskImageMounter) mountImage(signatureBytes []byte) error {
@@ -157,21 +157,12 @@ func waitForUploadComplete(plistRw ios.PlistCodecReadWriter) error {
 	return nil
 }
 
-func (conn *developerDiskImageMounter) hangUp() error {
+func hangUp(plistRw ios.PlistCodecReadWriter) error {
 	req := map[string]interface{}{
 		"Command": "Hangup",
 	}
 	log.Debugf("sending: %+v", req)
-	bytes, err := conn.plistCodec.Encode(req)
-	if err != nil {
-		return err
-	}
-
-	err = conn.deviceConn.Send(bytes)
-	if err != nil {
-		return err
-	}
-	return nil
+	return plistRw.Write(req)
 }
 
 func MountImage(device ios.DeviceEntry, path string) error {

--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -249,21 +249,21 @@ func sendUploadRequest(plistRw ios.PlistCodecReadWriter, imageType string, signa
 	log.Debugf("sending: %+v", req)
 	err := plistRw.Write(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("sendUploadRequest: failed to write command 'ReceiveBytes': %w", err)
 	}
 
 	var plist map[string]interface{}
 	err = plistRw.Read(&plist)
 	if err != nil {
-		return err
+		return fmt.Errorf("sendUploadRequest: failed to read response for 'ReceiveBytes': %w", err)
 	}
 	log.Debugf("upload response: %+v", plist)
 	status, ok := plist["Status"]
 	if !ok {
-		return fmt.Errorf("unexpected response: %+v", plist)
+		return fmt.Errorf("sendUploadRequest: unexpected response: %+v", plist)
 	}
 	if "ReceiveBytesAck" != status {
-		return fmt.Errorf("unexpected response: %+v", plist)
+		return fmt.Errorf("sendUploadRequest: unexpected status: %+v", plist)
 	}
 	return nil
 }

--- a/ios/imagemounter/personalized_image.go
+++ b/ios/imagemounter/personalized_image.go
@@ -1,0 +1,72 @@
+package imagemounter
+
+import (
+	"fmt"
+	"howett.net/plist"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type buildManifest struct {
+	BuildIdentities []buildIdentity
+}
+
+func loadBuildManifest(p string) (buildManifest, error) {
+	f, err := os.Open(p)
+	if err != nil {
+		return buildManifest{}, err
+	}
+	defer f.Close()
+	dec := plist.NewDecoder(f)
+	var m buildManifest
+	err = dec.Decode(&m)
+	if err != nil {
+		return buildManifest{}, err
+	}
+	return m, nil
+}
+
+func (m buildManifest) findIdentity(identifiers personalizationIdentifiers) (buildIdentity, error) {
+	for _, i := range m.BuildIdentities {
+		if i.ApBoardID() == identifiers.BoardId && i.ApChipID() == identifiers.ChipID {
+			return i, nil
+		}
+	}
+	return buildIdentity{}, fmt.Errorf("not found")
+}
+
+type buildIdentity struct {
+	BoardID  string `plist:"ApBoardID"`
+	ChipID   string `plist:"ApChipID"`
+	Manifest struct {
+		LoadableTrustCache struct {
+			Digest []byte
+		}
+		PersonalizedDmg struct {
+			Digest []byte
+		} `plist:"PersonalizedDMG"`
+	}
+}
+
+func (b buildIdentity) ApBoardID() int {
+	return hexToInt(b.BoardID)
+}
+
+func (b buildIdentity) ApChipID() int {
+	return hexToInt(b.ChipID)
+}
+
+type personalizationIdentifiers struct {
+	BoardId        int
+	ChipID         int
+	SecurityDomain int
+}
+
+func hexToInt(s string) int {
+	i, err := strconv.ParseInt(strings.ReplaceAll(strings.ToLower(s), "0x", ""), 16, 32)
+	if err != nil {
+		return 0
+	}
+	return int(i)
+}

--- a/ios/imagemounter/personalized_image.go
+++ b/ios/imagemounter/personalized_image.go
@@ -15,14 +15,14 @@ type buildManifest struct {
 func loadBuildManifest(p string) (buildManifest, error) {
 	f, err := os.Open(p)
 	if err != nil {
-		return buildManifest{}, err
+		return buildManifest{}, fmt.Errorf("loadBuildManifest: faild to open manifest file: %w", err)
 	}
 	defer f.Close()
 	dec := plist.NewDecoder(f)
 	var m buildManifest
 	err = dec.Decode(&m)
 	if err != nil {
-		return buildManifest{}, err
+		return buildManifest{}, fmt.Errorf("loadBuildManifest: could not decode manifest file: %w", err)
 	}
 	return m, nil
 }
@@ -33,7 +33,7 @@ func (m buildManifest) findIdentity(identifiers personalizationIdentifiers) (bui
 			return i, nil
 		}
 	}
-	return buildIdentity{}, fmt.Errorf("failed to find identity for ApBoardId 0x%x and ApChipId 0x%x", identifiers.BoardId, identifiers.ChipID)
+	return buildIdentity{}, fmt.Errorf("findIdentity: failed to find identity for ApBoardId 0x%x and ApChipId 0x%x", identifiers.BoardId, identifiers.ChipID)
 }
 
 type buildIdentity struct {

--- a/ios/imagemounter/personalized_image.go
+++ b/ios/imagemounter/personalized_image.go
@@ -33,7 +33,7 @@ func (m buildManifest) findIdentity(identifiers personalizationIdentifiers) (bui
 			return i, nil
 		}
 	}
-	return buildIdentity{}, fmt.Errorf("not found")
+	return buildIdentity{}, fmt.Errorf("failed to find identity for ApBoardId 0x%x and ApChipId 0x%x", identifiers.BoardId, identifiers.ChipID)
 }
 
 type buildIdentity struct {

--- a/ios/imagemounter/personalized_image.go
+++ b/ios/imagemounter/personalized_image.go
@@ -42,9 +42,15 @@ type buildIdentity struct {
 	Manifest struct {
 		LoadableTrustCache struct {
 			Digest []byte
+			Info   struct {
+				Path string
+			}
 		}
 		PersonalizedDmg struct {
 			Digest []byte
+			Info   struct {
+				Path string
+			}
 		} `plist:"PersonalizedDMG"`
 	}
 }

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -26,7 +26,7 @@ type PersonalizedDeveloperDiskImageMounter struct {
 func NewPersonalizedDeveloperDiskImageMounter(entry ios.DeviceEntry, version *semver.Version) (PersonalizedDeveloperDiskImageMounter, error) {
 	values, err := ios.GetValuesPlist(entry)
 	if err != nil {
-		return PersonalizedDeveloperDiskImageMounter{}, nil
+		return PersonalizedDeveloperDiskImageMounter{}, fmt.Errorf("NewPersonalizedDeveloperDiskImageMounter: could not read lockdown values: %w", err)
 	}
 	var ecid uint64
 	if e, ok := values["UniqueChipID"].(uint64); ok {

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -202,7 +202,7 @@ func (p PersonalizedDeveloperDiskImageMounter) mountPersonalizedImage(signatureB
 func getFileSize(p string) (uint64, error) {
 	info, err := os.Stat(p)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("getFileSize: could not get file stats for '%s': %w", p, err)
 	}
 	if info.IsDir() {
 		return 0, fmt.Errorf("getFileSize: expected a file, but got a directory: '%s'", p)

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -1,6 +1,7 @@
 package imagemounter
 
 import (
+	"fmt"
 	"github.com/Masterminds/semver"
 	"github.com/danielpaulus/go-ios/ios"
 	log "github.com/sirupsen/logrus"
@@ -12,6 +13,7 @@ type personalizedDeveloperDiskImageMounter struct {
 	plistRw    ios.PlistCodecReadWriter
 	version    *semver.Version
 	tss        tssClient
+	ecid       uint64
 }
 
 func (p personalizedDeveloperDiskImageMounter) ListImages() ([][]byte, error) {
@@ -20,7 +22,28 @@ func (p personalizedDeveloperDiskImageMounter) ListImages() ([][]byte, error) {
 
 func (p personalizedDeveloperDiskImageMounter) MountImage(imagePath string) error {
 	manifest, err := loadBuildManifest(path.Join(imagePath, "BuildManifest.plist"))
-	//TODO implement me
+	if err != nil {
+		return fmt.Errorf("failed to load build manifest. %w", err)
+	}
+
+	identifiers, err := p.queryIdentifiers()
+	if err != nil {
+		return fmt.Errorf("failed to query personalization identifiers. %w", err)
+	}
+	nonce, err := p.queryPersonalizedImageNonce()
+	if err != nil {
+		return fmt.Errorf("failed to get nonce. %w", err)
+	}
+
+	identity, err := manifest.findIdentity(identifiers)
+	if err != nil {
+		return err
+	}
+
+	signature, err := p.tss.getSignature(identity, identifiers, nonce, p.ecid)
+	if err != nil {
+		return fmt.Errorf("failed to get signature from Apple. %w", err)
+	}
 	panic("implement me")
 }
 
@@ -44,4 +67,34 @@ func (p personalizedDeveloperDiskImageMounter) queryPersonalizedImageNonce() ([]
 		return nonce, nil
 	}
 	return nil, nil
+}
+
+func (p personalizedDeveloperDiskImageMounter) queryIdentifiers() (personalizationIdentifiers, error) {
+	err := p.plistRw.Write(map[string]interface{}{
+		"Command":               "QueryPersonalizationIdentifiers",
+		"PersonalizedImageType": "DeveloperDiskImage",
+	})
+	if err != nil {
+		return personalizationIdentifiers{}, err
+	}
+
+	var resp map[string]interface{}
+	err = p.plistRw.Read(&resp)
+	log.WithField("response", resp).Info("QueryPersonalizationIdentifiers")
+
+	x := resp["PersonalizationIdentifiers"].(map[string]interface{})
+
+	var identifiers personalizationIdentifiers
+
+	if board, ok := x["BoardId"].(uint64); ok {
+		identifiers.BoardId = int(board)
+	}
+	if chip, ok := x["ChipID"].(uint64); ok {
+		identifiers.ChipID = int(chip)
+	}
+	if secDom, ok := x["SecurityDomain"].(uint64); ok {
+		identifiers.SecurityDomain = int(secDom)
+	}
+
+	return identifiers, nil
 }

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -42,6 +42,10 @@ func NewPersonalizedDeveloperDiskImageMounter(entry ios.DeviceEntry, version *se
 	}, nil
 }
 
+func (p personalizedDeveloperDiskImageMounter) Close() error {
+	return p.deviceConn.Close()
+}
+
 func (p personalizedDeveloperDiskImageMounter) ListImages() ([][]byte, error) {
 	return listImages(p.plistRw, "Personalized", p.version)
 }

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -104,9 +104,7 @@ func (p personalizedDeveloperDiskImageMounter) MountImage(imagePath string) erro
 		return err
 	}
 
-	//return conn.hangUp() // TODO
-
-	panic("implement me")
+	return hangUp(p.plistRw)
 }
 
 func (p personalizedDeveloperDiskImageMounter) queryPersonalizedImageNonce() ([]byte, error) {

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/danielpaulus/go-ios/ios"
 	log "github.com/sirupsen/logrus"
+	"path"
 )
 
 type personalizedDeveloperDiskImageMounter struct {
@@ -17,6 +18,7 @@ func (p personalizedDeveloperDiskImageMounter) ListImages() ([][]byte, error) {
 }
 
 func (p personalizedDeveloperDiskImageMounter) MountImage(imagePath string) error {
+	manifest, err := loadBuildManifest(path.Join(imagePath, "BuildManifest.plist"))
 	//TODO implement me
 	panic("implement me")
 }

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -10,7 +10,7 @@ import (
 	"path"
 )
 
-type personalizedDeveloperDiskImageMounter struct {
+type PersonalizedDeveloperDiskImageMounter struct {
 	deviceConn ios.DeviceConnectionInterface
 	plistRw    ios.PlistCodecReadWriter
 	version    *semver.Version
@@ -18,22 +18,22 @@ type personalizedDeveloperDiskImageMounter struct {
 	ecid       uint64
 }
 
-func NewPersonalizedDeveloperDiskImageMounter(entry ios.DeviceEntry, version *semver.Version) (personalizedDeveloperDiskImageMounter, error) {
+func NewPersonalizedDeveloperDiskImageMounter(entry ios.DeviceEntry, version *semver.Version) (PersonalizedDeveloperDiskImageMounter, error) {
 	values, err := ios.GetValuesPlist(entry)
 	if err != nil {
-		return personalizedDeveloperDiskImageMounter{}, nil
+		return PersonalizedDeveloperDiskImageMounter{}, nil
 	}
 	var ecid uint64
 	if e, ok := values["UniqueChipID"].(uint64); ok {
 		ecid = e
 	} else {
-		return personalizedDeveloperDiskImageMounter{}, fmt.Errorf("could not get ECID from device")
+		return PersonalizedDeveloperDiskImageMounter{}, fmt.Errorf("could not get ECID from device")
 	}
 	deviceConn, err := ios.ConnectToService(entry, serviceName)
 	if err != nil {
-		return personalizedDeveloperDiskImageMounter{}, err
+		return PersonalizedDeveloperDiskImageMounter{}, err
 	}
-	return personalizedDeveloperDiskImageMounter{
+	return PersonalizedDeveloperDiskImageMounter{
 		deviceConn: deviceConn,
 		plistRw:    ios.NewPlistCodecReadWriter(deviceConn.Reader(), deviceConn.Writer()),
 		version:    version,
@@ -42,15 +42,15 @@ func NewPersonalizedDeveloperDiskImageMounter(entry ios.DeviceEntry, version *se
 	}, nil
 }
 
-func (p personalizedDeveloperDiskImageMounter) Close() error {
+func (p PersonalizedDeveloperDiskImageMounter) Close() error {
 	return p.deviceConn.Close()
 }
 
-func (p personalizedDeveloperDiskImageMounter) ListImages() ([][]byte, error) {
+func (p PersonalizedDeveloperDiskImageMounter) ListImages() ([][]byte, error) {
 	return listImages(p.plistRw, "Personalized", p.version)
 }
 
-func (p personalizedDeveloperDiskImageMounter) MountImage(imagePath string) error {
+func (p PersonalizedDeveloperDiskImageMounter) MountImage(imagePath string) error {
 	manifest, err := loadBuildManifest(path.Join(imagePath, "BuildManifest.plist"))
 	if err != nil {
 		return fmt.Errorf("failed to load build manifest. %w", err)
@@ -111,7 +111,7 @@ func (p personalizedDeveloperDiskImageMounter) MountImage(imagePath string) erro
 	return hangUp(p.plistRw)
 }
 
-func (p personalizedDeveloperDiskImageMounter) queryPersonalizedImageNonce() ([]byte, error) {
+func (p PersonalizedDeveloperDiskImageMounter) queryPersonalizedImageNonce() ([]byte, error) {
 	err := p.plistRw.Write(map[string]interface{}{
 		"Command":               "QueryNonce",
 		"HostProcessName":       "CoreDeviceService",
@@ -133,7 +133,7 @@ func (p personalizedDeveloperDiskImageMounter) queryPersonalizedImageNonce() ([]
 	return nil, nil
 }
 
-func (p personalizedDeveloperDiskImageMounter) queryIdentifiers() (personalizationIdentifiers, error) {
+func (p PersonalizedDeveloperDiskImageMounter) queryIdentifiers() (personalizationIdentifiers, error) {
 	err := p.plistRw.Write(map[string]interface{}{
 		"Command":               "QueryPersonalizationIdentifiers",
 		"PersonalizedImageType": "DeveloperDiskImage",
@@ -163,7 +163,7 @@ func (p personalizedDeveloperDiskImageMounter) queryIdentifiers() (personalizati
 	return identifiers, nil
 }
 
-func (p personalizedDeveloperDiskImageMounter) mountPersonalizedImage(signatureBytes []byte, trustCache []byte) error {
+func (p PersonalizedDeveloperDiskImageMounter) mountPersonalizedImage(signatureBytes []byte, trustCache []byte) error {
 	err := p.plistRw.Write(map[string]interface{}{
 		"Command":         "MountImage",
 		"ImageSignature":  signatureBytes,

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -11,6 +11,7 @@ type personalizedDeveloperDiskImageMounter struct {
 	deviceConn ios.DeviceConnectionInterface
 	plistRw    ios.PlistCodecReadWriter
 	version    *semver.Version
+	tss        tssClient
 }
 
 func (p personalizedDeveloperDiskImageMounter) ListImages() ([][]byte, error) {

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -3,6 +3,7 @@ package imagemounter
 import (
 	"github.com/Masterminds/semver"
 	"github.com/danielpaulus/go-ios/ios"
+	log "github.com/sirupsen/logrus"
 )
 
 type personalizedDeveloperDiskImageMounter struct {
@@ -18,4 +19,26 @@ func (p personalizedDeveloperDiskImageMounter) ListImages() ([][]byte, error) {
 func (p personalizedDeveloperDiskImageMounter) MountImage(imagePath string) error {
 	//TODO implement me
 	panic("implement me")
+}
+
+func (p personalizedDeveloperDiskImageMounter) queryPersonalizedImageNonce() ([]byte, error) {
+	err := p.plistRw.Write(map[string]interface{}{
+		"Command":               "QueryNonce",
+		"HostProcessName":       "CoreDeviceService",
+		"PersonalizedImageType": "DeveloperDiskImage",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var resp map[string]interface{}
+	err = p.plistRw.Read(&resp)
+	if err != nil {
+		return nil, err
+	}
+	log.WithField("response", resp).Info("got response")
+	if nonce, ok := resp["PersonalizationNonce"].([]byte); ok {
+		return nonce, nil
+	}
+	return nil, nil
 }

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -1,0 +1,21 @@
+package imagemounter
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/danielpaulus/go-ios/ios"
+)
+
+type personalizedDeveloperDiskImageMounter struct {
+	deviceConn ios.DeviceConnectionInterface
+	plistRw    ios.PlistCodecReadWriter
+	version    *semver.Version
+}
+
+func (p personalizedDeveloperDiskImageMounter) ListImages() ([][]byte, error) {
+	return listImages(p.plistRw, "Personalized", p.version)
+}
+
+func (p personalizedDeveloperDiskImageMounter) MountImage(imagePath string) error {
+	//TODO implement me
+	panic("implement me")
+}

--- a/ios/imagemounter/tss.go
+++ b/ios/imagemounter/tss.go
@@ -1,0 +1,156 @@
+package imagemounter
+
+import (
+	"bytes"
+	"fmt"
+	"howett.net/plist"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// tssClient is used to talk to https://gs.apple.com/TSS for getting the personalized developer disk image signatures
+type tssClient struct {
+	h *http.Client
+}
+
+func newTssClient() tssClient {
+	c := &http.Client{
+		Timeout: 1 * time.Minute,
+	}
+
+	return tssClient{
+		h: c,
+	}
+}
+
+func (t tssClient) getSignature(identity buildIdentity, identifiers personalizationIdentifiers, nonce []byte, ecid uint64) ([]byte, error) {
+	params := map[string]interface{}{
+		"@ApImg4Ticket":     true,
+		"@BBTicket":         true,
+		"@HostPlatformInfo": "mac",
+		"@VersionInfo":      "libauthinstall-973.40.2",
+		"ApBoardID":         identifiers.BoardId,
+		"ApChipID":          identifiers.ChipID,
+		"ApECID":            ecid,
+		"ApNonce":           nonce,
+		"ApProductionMode":  true,
+		"ApSecurityDomain":  identifiers.SecurityDomain,
+		"ApSecurityMode":    true,
+		"LoadableTrustCache": map[string]interface{}{
+			"Digest":  identity.Manifest.LoadableTrustCache.Digest,
+			"EPRO":    true,
+			"ESEC":    true,
+			"Trusted": true,
+		},
+
+		"PersonalizedDMG": map[string]interface{}{
+			"Digest":  identity.Manifest.PersonalizedDmg.Digest,
+			"EPRO":    true,
+			"ESEC":    true,
+			"Name":    "DeveloperDiskImage",
+			"Trusted": true,
+		},
+
+		"SepNonce": make([]byte, 20),
+		"UID_MODE": false,
+	}
+
+	buf := bytes.NewBuffer(nil)
+	enc := plist.NewEncoderForFormat(buf, plist.XMLFormat)
+	err := enc.Encode(params)
+	if err != nil {
+		return nil, err
+	}
+	h := http.Client{}
+	req, err := http.NewRequest("POST", "https://gs.apple.com/TSS/controller?action=2", buf)
+	if err != nil {
+		return nil, err
+	}
+	res, err := h.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusOK {
+		resp, err := parseResponse(res.Body)
+		if err != nil {
+			return nil, err
+		}
+		if resp.status != 0 {
+			return nil, fmt.Errorf("unexpected status in response %d", resp.status)
+		}
+		var ticket map[string]interface{}
+		_, err = plist.Unmarshal([]byte(resp.requestString), &ticket)
+		if err != nil {
+			return nil, err
+		}
+		if ticket, ok := ticket["ApImg4Ticket"].([]byte); ok {
+			return ticket, nil
+		} else {
+			return nil, fmt.Errorf("could not get 'ApImg4Ticket' value from response")
+		}
+	}
+	return nil, fmt.Errorf("unexpected response status %d", res.StatusCode)
+}
+
+type response struct {
+	status        int
+	message       string
+	requestString string
+}
+
+func parseResponse(r io.Reader) (response, error) {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return response{}, fmt.Errorf("could not read content. %w", err)
+	}
+	s := string(b)
+	end := func(s string) int {
+		idx := strings.Index(s, "&")
+		if idx < 0 {
+			return len(s)
+		} else {
+			return idx
+		}
+	}
+
+	var res response
+
+	statusIdx := strings.Index(s, "STATUS=")
+	if statusIdx >= 0 {
+		statusStart := statusIdx + len("STATUS=")
+		status := s[statusStart:]
+		statusEnd := end(status)
+		status = status[:statusEnd]
+		stat, err := strconv.ParseInt(status, 10, 64)
+		if err != nil {
+			return response{}, fmt.Errorf("could not parse status '%s'. %w", status, err)
+		}
+		res.status = int(stat)
+	}
+	messageIdx := strings.Index(s, "MESSAGE=")
+	if messageIdx >= 0 {
+		messageStart := messageIdx + len("MESSAGE=")
+		message := s[messageStart:]
+		messageEnd := end(message)
+		message = message[:messageEnd]
+		res.message = message
+	}
+
+	requestStringIdx := strings.Index(s, "REQUEST_STRING=")
+	if requestStringIdx >= 0 {
+		if requestStringIdx <= messageIdx || requestStringIdx <= statusIdx {
+			return response{}, fmt.Errorf("REQUEST_STRING value must come last")
+		}
+		requestStringStart := requestStringIdx + len("REQUEST_STRING=")
+		requestString := s[requestStringStart:]
+		requestStringEnd := end(requestString)
+		requestString = requestString[:requestStringEnd]
+		res.requestString = requestString
+	}
+
+	return res, nil
+}

--- a/ios/imagemounter/tss_test.go
+++ b/ios/imagemounter/tss_test.go
@@ -1,0 +1,57 @@
+package imagemounter
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestParseResponse(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  response
+	}{
+		{
+			name:  "success without request message",
+			input: "STATUS=0&MESSAGE=SUCCESS",
+			want: response{
+				status:  0,
+				message: "SUCCESS",
+			},
+		},
+		{
+			name:  "response with multiword status",
+			input: "STATUS=69&MESSAGE=This device isn't eligible for the requested build.",
+			want: response{
+				status:  69,
+				message: "This device isn't eligible for the requested build.",
+			},
+		},
+		{
+			name:  "response with request string",
+			input: "STATUS=0&MESSAGE=SUCCESS&REQUEST_STRING=<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>",
+			want: response{
+				status:        0,
+				message:       "SUCCESS",
+				requestString: "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := strings.NewReader(tt.input)
+			r, err := parseResponse(reader)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, r)
+		})
+	}
+}
+
+// TODO: It looks like `REQUEST_STRING` always comes last, but if that's not the case we are not sure what to do
+// as it could also contain the '&' separator character
+func TestParseResponseRequiresRequestStringLast(t *testing.T) {
+	_, err := parseResponse(strings.NewReader("REQUEST_STRING=abc&STATUS=0"))
+	assert.Error(t, err)
+}

--- a/main.go
+++ b/main.go
@@ -142,6 +142,7 @@ The commands work as following:
    ios info [options]                                                 Prints a dump of Lockdown getValues.
    ios image list [options]                                           List currently mounted developers images' signatures
    ios image mount [--path=<imagepath>] [options]                     Mount a image from <imagepath>
+   >                                                                  For iOS 17+ (personalized deverloper disk images) <imagepath> must point to the "Restore" directory inside the developer disk 
    ios image auto [--basedir=<where_dev_images_are_stored>] [options] Automatically download correct dev image from the internets and mount it.
    >                                                                  You can specify a dir where images should be cached.
    >                                                                  The default is the current dir.

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ The commands work as following:
    ios info [options]                                                 Prints a dump of Lockdown getValues.
    ios image list [options]                                           List currently mounted developers images' signatures
    ios image mount [--path=<imagepath>] [options]                     Mount a image from <imagepath>
-   >                                                                  For iOS 17+ (personalized deverloper disk images) <imagepath> must point to the "Restore" directory inside the developer disk 
+   >                                                                  For iOS 17+ (personalized developer disk images) <imagepath> must point to the "Restore" directory inside the developer disk 
    ios image auto [--basedir=<where_dev_images_are_stored>] [options] Automatically download correct dev image from the internets and mount it.
    >                                                                  You can specify a dir where images should be cached.
    >                                                                  The default is the current dir.

--- a/main.go
+++ b/main.go
@@ -1121,7 +1121,7 @@ func outputPrettyStateList(types []instruments.ProfileType) {
 }
 
 func listMountedImages(device ios.DeviceEntry) {
-	conn, err := imagemounter.New(device)
+	conn, err := imagemounter.NewImageMounter(device)
 	exitIfError("failed connecting to image mounter", err)
 	signatures, err := conn.ListImages()
 	exitIfError("failed getting image list", err)

--- a/restapi/api/device_endpoints.go
+++ b/restapi/api/device_endpoints.go
@@ -40,7 +40,7 @@ func Activate(c *gin.Context) {
 
 func GetImages(c *gin.Context) {
 	device := c.MustGet(IOS_KEY).(ios.DeviceEntry)
-	conn, err := imagemounter.New(device)
+	conn, err := imagemounter.NewImageMounter(device)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, err)
 		return


### PR DESCRIPTION
With iOS 17 we don't have developer disks per minor version that we can simply mount, we get "personalized" images where we have to ask apple for a signature first.

The cli command itself hasn't changed much, only the path to the image is now different. You need to mount the image at `~/Library/Developer/DeveloperDiskImages/iOS_DDI.dmg`, and then the path to `go-ios` should be like `/Volumes/Xcode_iOS_DDI_Personalized/Restore`. Pointing directly to `~/Library/Developer/DeveloperDiskImages/iOS_DDI.dmg` was not implemented as `dmg` files are not supported by the go std lib, and therefore to keep the implementation simpler.