### PR TITLE
Kill apps and reboot devices through appservice

### DIFF
--- a/ios/appservice/appservice.go
+++ b/ios/appservice/appservice.go
@@ -35,8 +35,8 @@ type Process struct {
 	Path string
 }
 
-func (c *Connection) LaunchApp(deviceId string, bundleId string, args []interface{}, env map[string]interface{}) (AppLaunch, error) {
-	msg := buildAppLaunchPayload(c.deviceId, bundleId, args, env)
+func (c *Connection) LaunchApp(deviceId string, bundleId string, args []interface{}, env map[string]interface{}, options map[string]interface{}) (AppLaunch, error) {
+	msg := buildAppLaunchPayload(c.deviceId, bundleId, args, env, options)
 	err := c.conn.Send(msg, xpc.HeartbeatRequestFlag)
 	m, err := c.conn.ReceiveOnServerClientStream()
 	if err != nil {
@@ -111,10 +111,10 @@ func (c *Connection) KillProcess(pid int) error {
 	return nil
 }
 
-func buildAppLaunchPayload(deviceId string, bundleId string, args []interface{}, env map[string]interface{}) map[string]interface{} {
+func buildAppLaunchPayload(deviceId string, bundleId string, args []interface{}, env map[string]interface{}, options map[string]interface{}) map[string]interface{} {
 	platformSpecificOptions := bytes.NewBuffer(nil)
 	plistEncoder := plist.NewBinaryEncoder(platformSpecificOptions)
-	err := plistEncoder.Encode(map[string]interface{}{})
+	err := plistEncoder.Encode(options)
 	if err != nil {
 		panic(err)
 	}

--- a/ios/appservice/appservice.go
+++ b/ios/appservice/appservice.go
@@ -2,17 +2,19 @@ package appservice
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
-	"strings"
-
 	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/xpc"
 	"github.com/google/uuid"
 	"howett.net/plist"
+	"path"
+	"syscall"
 )
 
 type Connection struct {
-	conn *xpc.Connection
+	conn     *xpc.Connection
+	deviceId string
 }
 
 func New(deviceEntry ios.DeviceEntry) (*Connection, error) {
@@ -21,15 +23,20 @@ func New(deviceEntry ios.DeviceEntry) (*Connection, error) {
 		return nil, err
 	}
 
-	return &Connection{conn: xpcConn}, nil
+	return &Connection{conn: xpcConn, deviceId: uuid.New().String()}, nil
 }
 
 type AppLaunch struct {
 	Pid int64
 }
 
-func (c *Connection) LaunchApp(deviceId string, bundleId string, args []interface{}, env map[string]interface{}, opt map[string]interface{}) (AppLaunch, error) {
-	msg := buildAppLaunchPayload(deviceId, bundleId, args, env, opt)
+type Process struct {
+	Pid  int
+	Path string
+}
+
+func (c *Connection) LaunchApp(deviceId string, bundleId string, args []interface{}, env map[string]interface{}) (AppLaunch, error) {
+	msg := buildAppLaunchPayload(c.deviceId, bundleId, args, env)
 	err := c.conn.Send(msg, xpc.HeartbeatRequestFlag)
 	m, err := c.conn.ReceiveOnServerClientStream()
 	if err != nil {
@@ -46,15 +53,73 @@ func (c *Connection) Close() error {
 	return c.conn.Close()
 }
 
-func buildAppLaunchPayload(deviceId string, bundleId string, args []interface{}, env map[string]interface{}, opt map[string]interface{}) map[string]interface{} {
+func (c *Connection) ListProcesses() ([]Process, error) {
+	req := buildListProcessesPayload(c.deviceId)
+	err := c.conn.Send(req, xpc.HeartbeatRequestFlag)
+	if err != nil {
+		return nil, err
+	}
+	res, err := c.conn.ReceiveOnServerClientStream()
+	if err != nil {
+		return nil, err
+	}
+
+	if output, ok := res["CoreDevice.output"].(map[string]interface{}); ok {
+		if tokens, ok := output["processTokens"].([]interface{}); ok {
+			processes := make([]Process, len(tokens), len(tokens))
+			for i, t := range tokens {
+				var p Process
+
+				if processMap, ok := t.(map[string]interface{}); ok {
+					if pid, ok := processMap["processIdentifier"].(int64); ok {
+						p.Pid = int(pid)
+					} else {
+						return nil, fmt.Errorf("could not parse pid (type: %T)", processMap["processIdentifier"])
+					}
+					if processPath, ok := processMap["executableURL"].(map[string]interface{})["relative"].(string); ok {
+						p.Path = processPath
+					} else {
+						return nil, fmt.Errorf("could not parse process path (type: %T)", processMap["executableURL"])
+					}
+				} else {
+					return nil, errors.New("could not get process info")
+				}
+
+				processes[i] = p
+			}
+			return processes, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not parse response")
+}
+
+func (c *Connection) KillProcess(pid int) error {
+	req := buildSendSignalPayload(c.deviceId, pid, syscall.SIGKILL)
+	err := c.conn.Send(req, xpc.HeartbeatRequestFlag)
+	if err != nil {
+		return err
+	}
+	m, err := c.conn.ReceiveOnServerClientStream()
+	if err != nil {
+		return err
+	}
+	err = getError(m)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func buildAppLaunchPayload(deviceId string, bundleId string, args []interface{}, env map[string]interface{}) map[string]interface{} {
 	platformSpecificOptions := bytes.NewBuffer(nil)
 	plistEncoder := plist.NewBinaryEncoder(platformSpecificOptions)
-	err := plistEncoder.Encode(opt)
+	err := plistEncoder.Encode(map[string]interface{}{})
 	if err != nil {
 		panic(err)
 	}
 
-	return buildCoreDevicePayload(deviceId, "com.apple.coredevice.feature.launchapplication", map[string]interface{}{
+	return buildRequest(deviceId, "com.apple.coredevice.feature.launchapplication", map[string]interface{}{
 		"applicationSpecifier": map[string]interface{}{
 			"bundleIdentifier": map[string]interface{}{
 				"_0": bundleId,
@@ -66,7 +131,7 @@ func buildAppLaunchPayload(deviceId string, bundleId string, args []interface{},
 			"platformSpecificOptions":       platformSpecificOptions.Bytes(),
 			"standardIOUsesPseudoterminals": true,
 			"startStopped":                  false,
-			"terminateExisting":             true,
+			"terminateExisting":             false,
 			"user": map[string]interface{}{
 				"active": true,
 			},
@@ -76,20 +141,17 @@ func buildAppLaunchPayload(deviceId string, bundleId string, args []interface{},
 	})
 }
 
-func buildCoreDevicePayload(deviceId string, feature string, input map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{
-		"CoreDevice.CoreDeviceDDIProtocolVersion": int64(0),
-		"CoreDevice.action":                       map[string]interface{}{},
-		"CoreDevice.coreDeviceVersion": map[string]interface{}{
-			"components":              []interface{}{uint64(0x15c), uint64(0x1), uint64(0x0), uint64(0x0), uint64(0x0)},
-			"originalComponentsCount": int64(2),
-			"stringValue":             "348.1",
+func buildListProcessesPayload(deviceId string) map[string]interface{} {
+	return buildRequest(deviceId, "com.apple.coredevice.feature.listprocesses", nil)
+}
+
+func buildSendSignalPayload(deviceId string, pid int, signal syscall.Signal) map[string]interface{} {
+	return buildRequest(deviceId, "com.apple.coredevice.feature.sendsignaltoprocess", map[string]interface{}{
+		"process": map[string]interface{}{
+			"processIdentifier": int64(pid),
 		},
-		"CoreDevice.deviceIdentifier":     deviceId,
-		"CoreDevice.featureIdentifier":    feature,
-		"CoreDevice.input":                input,
-		"CoreDevice.invocationIdentifier": strings.ToUpper(uuid.New().String()),
-	}
+		"signal": int64(signal),
+	})
 }
 
 func pidFromResponse(response map[string]interface{}) (int64, error) {
@@ -103,12 +165,31 @@ func pidFromResponse(response map[string]interface{}) (int64, error) {
 	return 0, fmt.Errorf("could not get pid from response")
 }
 
-func (c *Connection) ListProcesses(deviceId string) (map[string]interface{}, error) {
-	msg := buildCoreDevicePayload(deviceId, "com.apple.coredevice.feature.listprocesses", map[string]interface{}{})
-	err := c.conn.Send(msg, xpc.HeartbeatRequestFlag)
-	if err != nil {
-		return nil, err
+func buildRequest(deviceId, feature string, input map[string]interface{}) map[string]interface{} {
+	u := uuid.New()
+	return map[string]interface{}{
+		"CoreDevice.CoreDeviceDDIProtocolVersion": int64(0),
+		"CoreDevice.action":                       map[string]interface{}{},
+		"CoreDevice.coreDeviceVersion": map[string]interface{}{
+			"components":              []interface{}{uint64(0x15c), uint64(0x1), uint64(0x0), uint64(0x0), uint64(0x0)},
+			"originalComponentsCount": int64(2),
+			"stringValue":             "348.1",
+		},
+		"CoreDevice.deviceIdentifier":     deviceId,
+		"CoreDevice.featureIdentifier":    feature,
+		"CoreDevice.input":                input,
+		"CoreDevice.invocationIdentifier": u.String(),
 	}
+}
 
-	return c.conn.ReceiveOnServerClientStream()
+func getError(response map[string]interface{}) error {
+	if e, ok := response["CoreDevice.error"].(map[string]interface{}); ok {
+		return fmt.Errorf("device returned error: %+v", e)
+	}
+	return nil
+}
+
+func (p Process) ExecutableName() string {
+	_, file := path.Split(p.Path)
+	return file
 }

--- a/ios/appservice/appservice_integration_test.go
+++ b/ios/appservice/appservice_integration_test.go
@@ -50,7 +50,7 @@ func testLaunchAndKillApp(t *testing.T, device ios.DeviceEntry) {
 	require.NoError(t, err)
 	defer as.Close()
 
-	_, err = as.LaunchApp(uuid.New().String(), "com.apple.mobilesafari", nil, nil)
+	_, err = as.LaunchApp(uuid.New().String(), "com.apple.mobilesafari", nil, nil, nil)
 	require.NoError(t, err)
 
 	processes, err := as.ListProcesses()
@@ -72,7 +72,7 @@ func testKillInvalidPidReturnsError(t *testing.T, device ios.DeviceEntry) {
 	require.NoError(t, err)
 	defer as.Close()
 
-	launched, err := as.LaunchApp(uuid.New().String(), "com.apple.mobilesafari", nil, nil)
+	launched, err := as.LaunchApp(uuid.New().String(), "com.apple.mobilesafari", nil, nil, nil)
 	require.NoError(t, err)
 
 	err = as.KillProcess(int(launched.Pid))

--- a/ios/appservice/appservice_integration_test.go
+++ b/ios/appservice/appservice_integration_test.go
@@ -1,0 +1,83 @@
+//go:build !fast
+
+package appservice_test
+
+import (
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/appservice"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"slices"
+	"testing"
+)
+
+func TestLaunchAndKillApps(t *testing.T) {
+	rsdPath := os.Getenv("GO_IOS_RSD")
+	if len(rsdPath) == 0 {
+		t.Skipf("GO_IOS_RSD missing")
+	}
+	address := os.Getenv("GO_IOS_ADDRESS")
+	if len(address) == 0 {
+		t.Skipf("GO_IOS_ADDRESS missing")
+	}
+
+	f, err := os.Open(rsdPath)
+	require.NoError(t, err)
+	defer f.Close()
+	rsd, err := ios.NewRsdPortProvider(f)
+	require.NoError(t, err)
+
+	device, err := ios.GetDeviceWithAddress("", address, rsd)
+	require.NoError(t, err)
+	version, err := ios.GetProductVersion(device)
+	require.NoError(t, err)
+	if version.Major() < 17 {
+		t.Skipf("Device has version %s. Skipping test on devices lower than iOS 17", version.String())
+	}
+
+	t.Run("launch and kill app", func(t *testing.T) {
+		testLaunchAndKillApp(t, device)
+	})
+	t.Run("kill invalid pid", func(t *testing.T) {
+		testKillInvalidPidReturnsError(t, device)
+	})
+}
+
+func testLaunchAndKillApp(t *testing.T, device ios.DeviceEntry) {
+	as, err := appservice.New(device)
+	require.NoError(t, err)
+	defer as.Close()
+
+	_, err = as.LaunchApp(uuid.New().String(), "com.apple.mobilesafari", nil, nil)
+	require.NoError(t, err)
+
+	processes, err := as.ListProcesses()
+	require.NoError(t, err)
+
+	idx := slices.IndexFunc(processes, func(e appservice.Process) bool {
+		return e.ExecutableName() == "MobileSafari"
+	})
+	assert.NotEqual(t, -1, idx)
+
+	process := processes[idx]
+
+	err = as.KillProcess(process.Pid)
+	assert.NoError(t, err)
+}
+
+func testKillInvalidPidReturnsError(t *testing.T, device ios.DeviceEntry) {
+	as, err := appservice.New(device)
+	require.NoError(t, err)
+	defer as.Close()
+
+	launched, err := as.LaunchApp(uuid.New().String(), "com.apple.mobilesafari", nil, nil)
+	require.NoError(t, err)
+
+	err = as.KillProcess(int(launched.Pid))
+	require.NoError(t, err)
+
+	err = as.KillProcess(int(launched.Pid))
+	assert.Error(t, err)
+}

--- a/ios/xpc/connection.go
+++ b/ios/xpc/connection.go
@@ -58,7 +58,6 @@ func (c *Connection) Send(data map[string]interface{}, flags ...uint32) error {
 		Body:  data,
 		Id:    c.msgId,
 	}
-	c.msgId++
 	return EncodeMessage(c.clientServer, msg)
 }
 

--- a/main.go
+++ b/main.go
@@ -890,11 +890,21 @@ The commands work as following:
 
 	b, _ = arguments.Bool("reboot")
 	if b {
-		err := diagnostics.Reboot(device)
-		if err != nil {
-			log.Error(err)
+		v, err := ios.GetProductVersion(device)
+		exitIfError("could not get device version", err)
+		if v.Major() < 17 {
+			err := diagnostics.Reboot(device)
+			if err != nil {
+				log.Error(err)
+			} else {
+				log.Info("ok")
+			}
 		} else {
-			log.Info("ok")
+			app, err := appservice.New(device)
+			exitIfError("could not connect to appservice", err)
+			defer app.Close()
+			err = app.Reboot()
+			exitIfError("could not execute reboot", err)
 		}
 		return
 	}


### PR DESCRIPTION
There is no more process control service on iOS 17. The tasks of listing/killing processes is done via `com.apple.coredevice.appservice` now, as well as rebooting a device