### PR TITLE
Use same pair record structor as MacOS for remote pairing

### DIFF
--- a/ios/tunnel/pairrecord_test.go
+++ b/ios/tunnel/pairrecord_test.go
@@ -1,0 +1,37 @@
+package tunnel
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ed25519"
+	"howett.net/plist"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestPairRecordManager(t *testing.T) {
+	tmp := t.TempDir()
+
+	pm, err := NewPairRecordManager(tmp)
+
+	require.NoError(t, err)
+
+	t.Run("self identity is created", func(t *testing.T) {
+		_, err := os.Stat(path.Join(tmp, "selfIdentity.plist"))
+		assert.NoError(t, err)
+	})
+	t.Run("read key equals the stored one", func(t *testing.T) {
+		siPath := path.Join(tmp, "selfIdentity.plist")
+		b, err := os.ReadFile(siPath)
+		require.NoError(t, err)
+
+		var si selfIdentityInternal
+		_, err = plist.Unmarshal(b, &si)
+		require.NoError(t, err)
+
+		private := ed25519.NewKeyFromSeed(si.PrivateKey)
+
+		assert.True(t, private.Equal(pm.SelfId.PrivateKey))
+	})
+}

--- a/main.go
+++ b/main.go
@@ -1936,6 +1936,8 @@ func pairDevice(device ios.DeviceEntry, orgIdentityP12File string, p12Password s
 }
 
 func startTunnel(device ios.DeviceEntry) {
+	pm, err := tunnel.NewPairRecordManager("/var/db/lockdown/RemotePairing/user_501")
+	exitIfError("could not creat pair record manager", err)
 	ctx := context.Background()
 	findCtx, _ := context.WithTimeout(ctx, 10*time.Second)
 	addr, err := ios.FindDeviceInterfaceAddress(findCtx, device)
@@ -1947,13 +1949,6 @@ func startTunnel(device ios.DeviceEntry) {
 	handshakeResponse, err := rsdService.Handshake()
 	exitIfError("could not execute RSD handshake", err)
 
-	home, err := os.UserHomeDir()
-	exitIfError("", err)
-	pairRecordsDir := path.Join(home, ".go-ios")
-	pairRecords := tunnel.NewPairRecordStore(pairRecordsDir)
-	err = os.MkdirAll(pairRecordsDir, os.ModePerm)
-	exitIfError("could not create go-ios dir", err)
-
 	port := handshakeResponse.GetPort(tunnel.UntrustedTunnelServiceName)
 	if port == 0 {
 		log.Fatal("could net get port for untrusted tunnel service")
@@ -1963,17 +1958,10 @@ func startTunnel(device ios.DeviceEntry) {
 
 	xpcConn, err := ios.CreateXpcConnection(h)
 	exitIfError("", err)
-	ts, err := tunnel.NewTunnelServiceWithXpc(xpcConn, h)
+	ts, err := tunnel.NewTunnelServiceWithXpc(xpcConn, h, pm)
 
-	pr, err := pairRecords.LoadOrCreate(device.Properties.SerialNumber)
+	err = ts.Pair()
 	exitIfError("", err)
-	if err != nil {
-		log.WithError(err).Warn("could not store pair record")
-	}
-
-	err = ts.Pair(pr)
-	exitIfError("", err)
-	_ = pairRecords.Store(device.Properties.SerialNumber, pr)
 	tunnelInfo, err := ts.CreateTunnelListener()
 	exitIfError("", err)
 	err = tunnel.ConnectToTunnel(ctx, tunnelInfo, addr)


### PR DESCRIPTION
Remote pair records (the ones that are used in tunnel creation) are stored in the `/var/db/lockdown/RemotePairing/user_501` directory on MacOS. We now use the same structure as MacOS does so that we can reuse an already existing pairing created by MacOS.