### PR TITLE
Allow closing listener in port forwarding

### DIFF
--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -38,6 +38,7 @@ func Forward(device ios.DeviceEntry, hostPort uint16, phonePort uint16) (*ConnLi
 	return cl, nil
 }
 
+// Close stops listening on the host port for the forwarded connection
 func (cl *ConnListener) Close() error {
 	close(cl.quit)
 

--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -16,28 +16,54 @@ type iosproxy struct {
 	deviceConn ios.DeviceConnectionInterface
 }
 
+type ConnListener struct {
+	listener net.Listener
+	quit     chan interface{}
+}
+
 // Forward forwards every connection made to the hostPort to whatever service runs inside an app on the device on phonePort.
-func Forward(device ios.DeviceEntry, hostPort uint16, phonePort uint16) error {
+func Forward(device ios.DeviceEntry, hostPort uint16, phonePort uint16) (*ConnListener, error) {
 	log.Infof("Start listening on port %d forwarding to port %d on device", hostPort, phonePort)
 	l, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", hostPort))
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("forward: failed listener with err: %w", err)
+	}
+	cl := &ConnListener{
+		listener: l,
+		quit:     make(chan interface{}),
 	}
 
-	go connectionAccept(l, device.DeviceID, phonePort)
+	go connectionAccept(cl, device.DeviceID, phonePort)
+
+	return cl, nil
+}
+
+func (cl *ConnListener) Close() error {
+	close(cl.quit)
+
+	err := cl.listener.Close()
+	if err != nil {
+		return fmt.Errorf("forward: failed closing listener with err: %w", err)
+	}
 
 	return nil
 }
 
-func connectionAccept(l net.Listener, deviceID int, phonePort uint16) {
+func connectionAccept(cl *ConnListener, deviceID int, phonePort uint16) {
 	for {
-		clientConn, err := l.Accept()
-		if err != nil {
-			log.Errorf("Error accepting new connection %v", err)
-			continue
+		select {
+		case <-cl.quit:
+			log.WithFields(log.Fields{"phonePort": phonePort}).Info("closed listener successfully")
+			return
+		default:
+			clientConn, err := cl.listener.Accept()
+			if err != nil {
+				log.Errorf("Error accepting new connection %v", err)
+				continue
+			}
+			log.WithFields(log.Fields{"conn": fmt.Sprintf("%#v", cl)}).Info("new client connected")
+			go StartNewProxyConnection(context.TODO(), clientConn, deviceID, phonePort)
 		}
-		log.WithFields(log.Fields{"conn": fmt.Sprintf("%#v", clientConn)}).Info("new client connected")
-		go StartNewProxyConnection(context.TODO(), clientConn, deviceID, phonePort)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1481,11 +1481,19 @@ func handleProfileList(device ios.DeviceEntry) {
 }
 
 func startForwarding(device ios.DeviceEntry, hostPort int, targetPort int) {
-	err := forward.Forward(device, uint16(hostPort), uint16(targetPort))
+	cl, err := forward.Forward(device, uint16(hostPort), uint16(targetPort))
 	exitIfError("failed to forward port", err)
+	defer stopForwarding(cl)
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	<-c
+}
+
+func stopForwarding(cl *forward.ConnListener) {
+	err := cl.Close()
+	if err != nil {
+		exitIfError("failed to close forwarded port", err)
+	}
 }
 
 func printDiagnostics(device ios.DeviceEntry) {


### PR DESCRIPTION
### Why
Whenever the `go-ios` is used as a dependency package in any go project, it would be nice to use port forwarding feature with the possibility to free the listening port when the forwarding is stopped

### How
- wrap the `net.Listener` in a dedicated struct
- provide the `Close()` function to free the listening port
- allow the eternal for loop in `connectionAccept` to break when `Close()` is called
- wrap any errors occurred