### PR TITLE
Make starting a tunnel a non-blocking operation

### DIFF
--- a/ios/tunnel/tunnel.go
+++ b/ios/tunnel/tunnel.go
@@ -62,11 +62,11 @@ func ManualPairAndConnectToTunnel(ctx context.Context, device ios.DeviceEntry, p
 	}
 	ts := NewTunnelServiceWithXpc(xpcConn, h, p)
 
-	err = ts.Pair()
+	err = ts.ManualPair()
 	if err != nil {
 		return Tunnel{}, fmt.Errorf("ManualPairAndConnectToTunnel: failed to pair device: %w", err)
 	}
-	tunnelInfo, err := ts.CreateTunnelListener()
+	tunnelInfo, err := ts.createTunnelListener()
 	if err != nil {
 		return Tunnel{}, fmt.Errorf("ManualPairAndConnectToTunnel: failed to create tunnel listener: %w", err)
 	}

--- a/ios/tunnel/untrusted.go
+++ b/ios/tunnel/untrusted.go
@@ -21,13 +21,13 @@ import (
 
 const UntrustedTunnelServiceName = "com.apple.internal.dt.coredevice.untrusted.tunnelservice"
 
-func NewTunnelServiceWithXpc(xpcConn *xpc.Connection, c io.Closer, pairRecords PairRecordManager) (*TunnelService, error) {
+func NewTunnelServiceWithXpc(xpcConn *xpc.Connection, c io.Closer, pairRecords PairRecordManager) *TunnelService {
 	return &TunnelService{
 		xpcConn:        xpcConn,
 		c:              c,
 		controlChannel: newControlChannelReadWriter(xpcConn),
 		pairRecords:    pairRecords,
-	}, nil
+	}
 }
 
 type TunnelService struct {

--- a/ios/tunnel/untrusted.go
+++ b/ios/tunnel/untrusted.go
@@ -44,7 +44,11 @@ func (t *TunnelService) Close() error {
 	return t.c.Close()
 }
 
-func (t *TunnelService) Pair() error {
+// ManualPair triggers a device pairing that requires the user to press the 'Trust' button on the device that appears
+// when this operation is triggered
+// If there is already an active pairing with the credentials stored in PairRecordManager this call does not trigger
+// anything on the device and returns with an error
+func (t *TunnelService) ManualPair() error {
 	err := t.controlChannel.writeRequest(map[string]interface{}{
 		"handshake": map[string]interface{}{
 			"_0": map[string]interface{}{
@@ -99,7 +103,7 @@ func (t *TunnelService) Pair() error {
 	return nil
 }
 
-func (t *TunnelService) CreateTunnelListener() (TunnelListener, error) {
+func (t *TunnelService) createTunnelListener() (TunnelListener, error) {
 	log.Info("create tunnel listener")
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 

--- a/main.go
+++ b/main.go
@@ -1986,8 +1986,15 @@ func startTunnel(device ios.DeviceEntry) {
 	exitIfError("", err)
 	tunnelInfo, err := ts.CreateTunnelListener()
 	exitIfError("", err)
-	err = tunnel.ConnectToTunnel(ctx, tunnelInfo, addr)
+	t, err := tunnel.ConnectToTunnel(ctx, tunnelInfo, addr)
 	exitIfError("", err)
+	log.WithField("address", t.Address).
+		WithField("rsd-port", t.RsdPort).
+		WithField("cli-args", fmt.Sprintf("--address=%s --rsd-port=%d", t.Address, t.RsdPort)).
+		Info("tunnel started")
+	<-ctx.Done()
+	log.Info("closing tunnel")
+	t.Close()
 }
 
 func deviceWithRsdProvider(device ios.DeviceEntry, udid string, address string, rsdPort int) ios.DeviceEntry {

--- a/main.go
+++ b/main.go
@@ -1014,7 +1014,7 @@ The commands work as following:
 
 	b, _ = arguments.Bool("start-tunnel")
 	if b {
-		startTunnel(device)
+		startTunnel(context.TODO(), device)
 	}
 
 	b, _ = arguments.Bool("deviceinfo")
@@ -1957,36 +1957,11 @@ func pairDevice(device ios.DeviceEntry, orgIdentityP12File string, p12Password s
 	log.Infof("Successfully paired %s", device.Properties.SerialNumber)
 }
 
-func startTunnel(device ios.DeviceEntry) {
+func startTunnel(ctx context.Context, device ios.DeviceEntry) {
 	pm, err := tunnel.NewPairRecordManager("/var/db/lockdown/RemotePairing/user_501")
 	exitIfError("could not creat pair record manager", err)
-	ctx := context.Background()
-	findCtx, _ := context.WithTimeout(ctx, 10*time.Second)
-	addr, err := ios.FindDeviceInterfaceAddress(findCtx, device)
-	exitIfError("could not find device address", err)
-
-	rsdService, err := ios.NewWithAddr(addr)
-	exitIfError("could not connect to RSD", err)
-	defer rsdService.Close()
-	handshakeResponse, err := rsdService.Handshake()
-	exitIfError("could not execute RSD handshake", err)
-
-	port := handshakeResponse.GetPort(tunnel.UntrustedTunnelServiceName)
-	if port == 0 {
-		log.Fatal("could net get port for untrusted tunnel service")
-	}
-	h, err := ios.ConnectToHttp2WithAddr(addr, port)
-	exitIfError("failed to connect to device", err)
-
-	xpcConn, err := ios.CreateXpcConnection(h)
-	exitIfError("", err)
-	ts, err := tunnel.NewTunnelServiceWithXpc(xpcConn, h, pm)
-
-	err = ts.Pair()
-	exitIfError("", err)
-	tunnelInfo, err := ts.CreateTunnelListener()
-	exitIfError("", err)
-	t, err := tunnel.ConnectToTunnel(ctx, tunnelInfo, addr)
+	startTunnelCtx, _ := context.WithTimeout(ctx, 10*time.Second)
+	t, err := tunnel.ManualPairAndConnectToTunnel(startTunnelCtx, device, pm)
 	exitIfError("", err)
 	log.WithField("address", t.Address).
 		WithField("rsd-port", t.RsdPort).


### PR DESCRIPTION
With the blocking operation we could get the tunnel information only through logs.

Now we get back a `Tunnel` struct that has all relevant infos and it can be used to tear down the tunnel as well.