### PR TITLE
Skip TLS certificate verification for getting the developer disk signature

### DIFF
--- a/ios/imagemounter/tss.go
+++ b/ios/imagemounter/tss.go
@@ -2,13 +2,15 @@ package imagemounter
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
-	"howett.net/plist"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"howett.net/plist"
 )
 
 // tssClient is used to talk to https://gs.apple.com/TSS for getting the personalized developer disk image signatures
@@ -64,7 +66,13 @@ func (t tssClient) getSignature(identity buildIdentity, identifiers personalizat
 	if err != nil {
 		return nil, fmt.Errorf("getSignature: failed to encode request body: %w", err)
 	}
-	h := http.Client{}
+	h := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
 	req, err := http.NewRequest("POST", "https://gs.apple.com/TSS/controller?action=2", buf)
 	if err != nil {
 		return nil, err

--- a/ios/imagemounter/tss.go
+++ b/ios/imagemounter/tss.go
@@ -72,6 +72,7 @@ func (t tssClient) getSignature(identity buildIdentity, identifiers personalizat
 				InsecureSkipVerify: true,
 			},
 		},
+		Timeout: 1 * time.Minute,
 	}
 	req, err := http.NewRequest("POST", "https://gs.apple.com/TSS/controller?action=2", buf)
 	if err != nil {


### PR DESCRIPTION
On linux hosts this fails with `Post "https://gs.apple.com/TSS/controller?action=2": tls: failed to verify certificate: x509: certificate signed by unknown authority` otherwise