### PR TITLE
Support for multiple test suite results for xcuitests

### DIFF
--- a/ios/testmanagerd/testlistener.go
+++ b/ios/testmanagerd/testlistener.go
@@ -106,17 +106,17 @@ func (t *TestListener) testCaseStalled(testClass string, method string, file str
 }
 
 func (t *TestListener) testCaseFinished(testClass string, testMethod string, xcActivityRecord nskeyedarchiver.XCActivityRecord) {
-	for _, attachment := range xcActivityRecord.Attachments {
-		ts := t.findTestSuite(testClass)
-		testCase := t.findTestCase(testClass, testMethod)
-		if ts == nil || testCase == nil || testClass == "none" || testMethod == "none" {
-			// Attachments of activity records are reported under a special test class named "none"
-			// That's unfortunately the default behavior defined by Apple.
-			// This if block is a safe guard to auto correct the test case information
-			ts = t.runningTestSuite
-			testCase = &ts.TestCases[len(ts.TestCases)-1]
-		}
+	ts := t.findTestSuite(testClass)
+	testCase := t.findTestCase(testClass, testMethod)
+	if ts == nil || testCase == nil || testClass == "none" || testMethod == "none" {
+		// Attachments of activity records are reported under a special test class named "none"
+		// That's unfortunately the default behavior defined by Apple.
+		// This if block is a safe guard to auto correct the test case information
+		ts = t.runningTestSuite
+		testCase = &ts.TestCases[len(ts.TestCases)-1]
+	}
 
+	for _, attachment := range xcActivityRecord.Attachments {
 		attachmentsPath := filepath.Join(t.attachmentsDirectory, uuid.New().String())
 		file, err := os.Create(attachmentsPath)
 		if err != nil {

--- a/ios/testmanagerd/testlistener.go
+++ b/ios/testmanagerd/testlistener.go
@@ -269,7 +269,10 @@ func (t *TestListener) findTestCase(className string, methodName string) *TestCa
 func (t *TestListener) findTestSuite(className string) *TestSuite {
 	for i, _ := range t.TestSuites {
 		ts := &t.TestSuites[i]
-		return ts
+		if ts.Name == className {
+			return ts
+		}
+
 	}
 
 	return nil

--- a/ios/testmanagerd/testlistener.go
+++ b/ios/testmanagerd/testlistener.go
@@ -251,12 +251,10 @@ func (t *TestListener) Done() <-chan struct{} {
 func (t *TestListener) findTestCase(className string, methodName string) *TestCase {
 	ts := t.findTestSuite(className)
 
-	if ts != nil {
-		for j, _ := range ts.TestCases {
-			tc := &ts.TestCases[j]
-			if tc.ClassName == className && tc.MethodName == methodName {
-				return tc
-			}
+	if ts != nil && len(ts.TestCases) > 0 {
+		tc := &ts.TestCases[len(ts.TestCases)-1]
+		if tc.ClassName == className && tc.MethodName == methodName {
+			return tc
 		}
 	}
 
@@ -266,14 +264,6 @@ func (t *TestListener) findTestCase(className string, methodName string) *TestCa
 func (t *TestListener) findTestSuite(className string) *TestSuite {
 	if t.runningTestSuite != nil && t.runningTestSuite.Name == className {
 		return t.runningTestSuite
-	}
-
-	for i, _ := range t.TestSuites {
-		ts := &t.TestSuites[i]
-		if ts.Name == className {
-			return ts
-		}
-
 	}
 
 	return nil

--- a/ios/testmanagerd/testlistener.go
+++ b/ios/testmanagerd/testlistener.go
@@ -113,6 +113,10 @@ func (t *TestListener) testCaseFinished(testClass string, testMethod string, xcA
 		// That's unfortunately the default behavior defined by Apple.
 		// This if block is a safe guard to auto correct the test case information
 		ts = t.runningTestSuite
+		if len(ts.TestCases) == 0 {
+			log.Warn(fmt.Sprintf("Received testCaseFinished for %s:%s without initialization", testClass, testMethod))
+			return
+		}
 		testCase = &ts.TestCases[len(ts.TestCases)-1]
 	}
 

--- a/ios/testmanagerd/testlistener_test.go
+++ b/ios/testmanagerd/testlistener_test.go
@@ -139,8 +139,8 @@ func TestFinishExecutingTestPlan(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 
 		testListener.testSuiteDidStart("mysuite", "2024-01-16 15:36:43 +0000")
-		testListener.testCaseDidStartForClass("myclass", "mymethod")
-		testListener.testCaseDidFinishForTest("myclass", "mymethod", "passed", 1.0)
+		testListener.testCaseDidStartForClass("mysuite", "mymethod")
+		testListener.testCaseDidFinishForTest("mysuite", "mymethod", "passed", 1.0)
 
 		assert.Equal(t, 1, len(testListener.findTestSuite("mysuite").TestCases), "TestCase must be appended to list of test cases")
 		assert.Equal(t, TestCaseStatus("passed"), testListener.findTestSuite("mysuite").TestCases[0].Status)
@@ -151,11 +151,11 @@ func TestFinishExecutingTestPlan(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 
 		testListener.testSuiteDidStart("mysuite", "2024-01-16 15:36:43 +0000")
-		testListener.testCaseDidStartForClass("myclass", "mymethod1")
-		testListener.testCaseDidFinishForTest("myclass", "mymethod1", "passed", 1.0)
-		testListener.testCaseDidStartForClass("myclass", "mymethod2")
-		testListener.testCaseDidFinishForTest("myclass", "mymethod2", "passed", 1.0)
-		testListener.testSuiteFinished("myclass", "2024-01-16 15:36:44 +0000", 2, 0, 0, 0, 0, 0, 1.0, 2.0)
+		testListener.testCaseDidStartForClass("mysuite", "mymethod1")
+		testListener.testCaseDidFinishForTest("mysuite", "mymethod1", "passed", 1.0)
+		testListener.testCaseDidStartForClass("mysuite", "mymethod2")
+		testListener.testCaseDidFinishForTest("mysuite", "mymethod2", "passed", 1.0)
+		testListener.testSuiteFinished("mysuite", "2024-01-16 15:36:44 +0000", 2, 0, 0, 0, 0, 0, 1.0, 2.0)
 
 		assert.Equal(t, 2, len(testListener.findTestSuite("mysuite").TestCases), "TestCase must be appended to list of test cases")
 		assert.Equal(t, TestCaseStatus("passed"), testListener.findTestSuite("mysuite").TestCases[0].Status)
@@ -168,9 +168,9 @@ func TestFinishExecutingTestPlan(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 
 		testListener.testSuiteDidStart("mysuite", "2024-01-16 15:36:43 +0000")
-		testListener.testCaseDidStartForClass("myclass", "mymethod1")
-		testListener.testCaseStalled("myclass", "mymethod1", "file://app.swift", 123)
-		testListener.testCaseDidFinishForTest("myclass", "mymethod1", "failed", 1.0)
+		testListener.testCaseDidStartForClass("mysuite", "mymethod1")
+		testListener.testCaseStalled("mysuite", "mymethod1", "file://app.swift", 123)
+		testListener.testCaseDidFinishForTest("mysuite", "mymethod1", "failed", 1.0)
 
 		assert.Equal(t, 1, len(testListener.findTestSuite("mysuite").TestCases), "TestCase must be appended to list of test cases")
 		assert.Equal(t, TestCaseStatus("stalled"), testListener.findTestSuite("mysuite").TestCases[0].Status)
@@ -193,10 +193,10 @@ func TestFinishExecutingTestPlan(t *testing.T) {
 			Attachments:  attachments,
 		})
 
-		assert.Equal(t, 1, len(testListener.findTestSuite("mysuite").TestCases), "TestCase must be appended to list of test cases")
-		assert.Equal(t, 1, len(testListener.findTestSuite("mysuite").TestCases[0].Attachments), "Test must have 1 attachment")
+		assert.Equal(t, 1, len(testListener.findTestSuite("none").TestCases), "TestCase must be appended to list of test cases")
+		assert.Equal(t, 1, len(testListener.findTestSuite("none").TestCases[0].Attachments), "Test must have 1 attachment")
 
-		path := testListener.findTestSuite("mysuite").TestCases[0].Attachments[0].Path
+		path := testListener.findTestSuite("none").TestCases[0].Attachments[0].Path
 		attachment, err := os.ReadFile(path)
 		assert.NoError(t, err)
 		defer os.RemoveAll(path)

--- a/ios/testmanagerd/testlistener_test.go
+++ b/ios/testmanagerd/testlistener_test.go
@@ -82,13 +82,19 @@ func TestFinishExecutingTestPlan(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 
 		testListener.testSuiteDidStart("mysuite", "2024-01-16 15:36:43 +0000")
-		testListener.testSuiteDidStart("mysuite2", "2024-01-16 15:36:43 +0000")
+		testListener.testSuiteDidStart("mysuite2", "2024-01-17 16:36:43 +0000")
 
 		assert.Equal(t, 2, len(testListener.TestSuites))
 		assert.Equal(t, 2024, testListener.findTestSuite("mysuite").StartDate.Year())
 		assert.Equal(t, time.Month(1), testListener.findTestSuite("mysuite").StartDate.Month())
 		assert.Equal(t, 16, testListener.findTestSuite("mysuite").StartDate.Day())
 		assert.Equal(t, "mysuite", testListener.findTestSuite("mysuite").Name)
+
+		assert.Equal(t, 2, len(testListener.TestSuites))
+		assert.Equal(t, 2024, testListener.findTestSuite("mysuite2").StartDate.Year())
+		assert.Equal(t, time.Month(1), testListener.findTestSuite("mysuite2").StartDate.Month())
+		assert.Equal(t, 17, testListener.findTestSuite("mysuite2").StartDate.Day())
+		assert.Equal(t, "mysuite2", testListener.findTestSuite("mysuite2").Name)
 	})
 
 	t.Run("Check test case creation", func(t *testing.T) {

--- a/ios/testmanagerd/testlistener_test.go
+++ b/ios/testmanagerd/testlistener_test.go
@@ -124,9 +124,9 @@ func TestFinishExecutingTestPlan(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 
 		testListener.testSuiteDidStart("mysuite", "2024-01-16 15:36:43 +0000")
-		testListener.testCaseDidStartForClass("myclass", "mymethod")
+		testListener.testCaseDidStartForClass("mysuite", "mymethod")
 
-		testListener.testCaseFailedForClass("myclass", "mymethod", "error", "file://app.swift", 123)
+		testListener.testCaseFailedForClass("mysuite", "mymethod", "error", "file://app.swift", 123)
 
 		assert.Equal(t, 1, len(testListener.findTestSuite("mysuite").TestCases), "TestCase must be appended to list of test cases")
 		assert.Equal(t, TestCaseStatus("failed"), testListener.findTestSuite("mysuite").TestCases[0].Status)

--- a/ios/testmanagerd/testlistener_test.go
+++ b/ios/testmanagerd/testlistener_test.go
@@ -101,11 +101,11 @@ func TestFinishExecutingTestPlan(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 
 		testListener.testSuiteDidStart("mysuite", "2024-01-16 15:36:43 +0000")
-		testListener.testCaseDidStartForClass("myclass", "mymethod")
+		testListener.testCaseDidStartForClass("mysuite", "mymethod")
 
 		assert.Equal(t, 1, len(testListener.findTestSuite("mysuite").TestCases), "TestCase must be appended to list of test cases")
 		assert.Equal(t, TestCase{
-			ClassName:  "myclass",
+			ClassName:  "mysuite",
 			MethodName: "mymethod",
 		}, testListener.findTestSuite("mysuite").TestCases[0])
 	})

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -217,12 +217,12 @@ const (
 
 const testBundleSuffix = "UITests.xctrunner"
 
-func RunXCUITest(bundleID string, testRunnerBundleID string, xctestConfigName string, device ios.DeviceEntry, env []string, testListener *TestListener) (TestSuite, error) {
+func RunXCUITest(bundleID string, testRunnerBundleID string, xctestConfigName string, device ios.DeviceEntry, env []string, testListener *TestListener) ([]TestSuite, error) {
 	// FIXME: this is redundant code, getting the app list twice and creating the appinfos twice
 	// just to generate the xctestConfigFileName. Should be cleaned up at some point.
 	installationProxy, err := installationproxy.New(device)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUITest: cannot connect to installation proxy: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUITest: cannot connect to installation proxy: %w", err)
 	}
 	defer installationProxy.Close()
 
@@ -232,11 +232,11 @@ func RunXCUITest(bundleID string, testRunnerBundleID string, xctestConfigName st
 
 	apps, err := installationProxy.BrowseUserApps()
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUITest: cannot browse user apps: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUITest: cannot browse user apps: %w", err)
 	}
 	info, err := getAppInfos(bundleID, testRunnerBundleID, apps)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUITest: cannot get app information: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUITest: cannot get app information: %w", err)
 	}
 
 	if xctestConfigName == "" {
@@ -255,10 +255,10 @@ func RunXCUIWithBundleIdsCtx(
 	args []string,
 	env []string,
 	testListener *TestListener,
-) (TestSuite, error) {
+) ([]TestSuite, error) {
 	version, err := ios.GetProductVersion(device)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUIWithBundleIdsCtx: cannot determine iOS version: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsCtx: cannot determine iOS version: %w", err)
 	}
 
 	if version.LessThan(ios.IOS14()) {
@@ -284,32 +284,32 @@ func runXUITestWithBundleIdsXcode15Ctx(
 	args []string,
 	env []string,
 	testListener *TestListener,
-) (TestSuite, error) {
+) ([]TestSuite, error) {
 	conn1, err := dtx.NewTunnelConnection(device, testmanagerdiOS17)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot create a tunnel connection to testmanagerd: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot create a tunnel connection to testmanagerd: %w", err)
 	}
 	defer conn1.Close()
 
 	conn2, err := dtx.NewTunnelConnection(device, testmanagerdiOS17)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot create a tunnel connection to testmanagerd: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot create a tunnel connection to testmanagerd: %w", err)
 	}
 	defer conn2.Close()
 
 	installationProxy, err := installationproxy.New(device)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot connect to installation proxy: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot connect to installation proxy: %w", err)
 	}
 	defer installationProxy.Close()
 	apps, err := installationProxy.BrowseUserApps()
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot browse user apps: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot browse user apps: %w", err)
 	}
 
 	info, err := getAppInfos(bundleID, testRunnerBundleID, apps)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot get app information: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot get app information: %w", err)
 	}
 
 	testSessionID := uuid.New()
@@ -330,30 +330,30 @@ func runXUITestWithBundleIdsXcode15Ctx(
 	}}
 	receivedCaps, err := ideDaemonProxy1.daemonConnection.initiateSessionWithIdentifierAndCaps(testSessionID, localCaps)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot initiate a IDE session: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot initiate a IDE session: %w", err)
 	}
 	log.WithField("receivedCaps", receivedCaps).Info("got capabilities")
 
 	appserviceConn, err := appservice.New(device)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot connect to app service: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot connect to app service: %w", err)
 	}
 	defer appserviceConn.Close()
 
 	pid, err := startTestRunner17(device, appserviceConn, "", testRunnerBundleID, strings.ToUpper(testSessionID.String()), info.testrunnerAppPath+"/PlugIns/"+xctestConfigFileName, args, env)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot start test runner: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot start test runner: %w", err)
 	}
 
 	ideDaemonProxy2 := newDtxProxyWithConfig(conn2, testconfig, testListener)
 	caps, err := ideDaemonProxy2.daemonConnection.initiateControlSessionWithCapabilities(nskeyedarchiver.XCTCapabilities{CapabilitiesDictionary: map[string]interface{}{}})
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot initiate a control session with capabilities: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot initiate a control session with capabilities: %w", err)
 	}
 	log.WithField("caps", caps).Info("got capabilities")
 	authorized, err := ideDaemonProxy2.daemonConnection.authorizeTestSessionWithProcessID(uint64(pid))
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot authorize test session: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot authorize test session: %w", err)
 	}
 	log.WithField("authorized", authorized).Info("authorized")
 
@@ -362,7 +362,7 @@ func runXUITestWithBundleIdsXcode15Ctx(
 	proto := uint64(36)
 	err = ideDaemonProxy1.daemonConnection.startExecutingTestPlanWithProtocolVersion(ideInterfaceChannel, proto)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot start executing test plan: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot start executing test plan: %w", err)
 	}
 
 	select {
@@ -380,7 +380,7 @@ func runXUITestWithBundleIdsXcode15Ctx(
 
 	log.Debugf("Done running test")
 
-	return *testListener.TestSuite, testListener.err
+	return testListener.TestSuites, testListener.err
 }
 
 type processKiller interface {

--- a/ios/testmanagerd/xcuitestrunner_11.go
+++ b/ios/testmanagerd/xcuitestrunner_11.go
@@ -20,16 +20,16 @@ func runXCUIWithBundleIdsXcode11Ctx(
 	args []string,
 	env []string,
 	testListener *TestListener,
-) (TestSuite, error) {
+) ([]TestSuite, error) {
 	log.Debugf("set up xcuitest")
 	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create test config: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create test config: %w", err)
 	}
 	log.Debugf("test session setup ok")
 	conn, err := dtx.NewUsbmuxdConnection(device, testmanagerd)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}
 	defer conn.Close()
 
@@ -37,7 +37,7 @@ func runXCUIWithBundleIdsXcode11Ctx(
 
 	conn2, err := dtx.NewUsbmuxdConnection(device, testmanagerd)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}
 	defer conn2.Close()
 	log.Debug("connections ready")
@@ -47,24 +47,24 @@ func runXCUIWithBundleIdsXcode11Ctx(
 	protocolVersion := uint64(25)
 	_, err = ideDaemonProxy.daemonConnection.initiateSessionWithIdentifier(testSessionId, protocolVersion)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot initiate a test session: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot initiate a test session: %w", err)
 	}
 
 	pControl, err := instruments.NewProcessControl(device)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot connect to process control: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot connect to process control: %w", err)
 	}
 	defer pControl.Close()
 
 	pid, err := startTestRunner11(pControl, xctestConfigPath, testRunnerBundleID, testSessionId.String(), testInfo.testrunnerAppPath+"/PlugIns/"+xctestConfigFileName, args, env)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot start the test runner: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot start the test runner: %w", err)
 	}
 	log.Debugf("Runner started with pid:%d, waiting for testBundleReady", pid)
 
 	err = ideDaemonProxy2.daemonConnection.initiateControlSession(pid, protocolVersion)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot initiate a control session with capabilities: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot initiate a control session with capabilities: %w", err)
 	}
 	log.Debugf("control session initiated")
 	ideInterfaceChannel := ideDaemonProxy.dtxConnection.ForChannelRequest(proxyDispatcher{id: "emty"})
@@ -72,7 +72,7 @@ func runXCUIWithBundleIdsXcode11Ctx(
 	log.Debug("start executing testplan")
 	err = ideDaemonProxy2.daemonConnection.startExecutingTestPlanWithProtocolVersion(ideInterfaceChannel, 25)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot start executing test plan: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot start executing test plan: %w", err)
 	}
 
 	select {
@@ -90,7 +90,7 @@ func runXCUIWithBundleIdsXcode11Ctx(
 
 	log.Debugf("Done running test")
 
-	return *testListener.TestSuite, testListener.err
+	return testListener.TestSuites, testListener.err
 }
 
 func startTestRunner11(pControl *instruments.ProcessControl, xctestConfigPath string, bundleID string,

--- a/ios/testmanagerd/xcuitestrunner_12.go
+++ b/ios/testmanagerd/xcuitestrunner_12.go
@@ -15,15 +15,15 @@ import (
 
 func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, testRunnerBundleID string, xctestConfigFileName string,
 	device ios.DeviceEntry, args []string, env []string, testListener *TestListener,
-) (TestSuite, error) {
+) ([]TestSuite, error) {
 	conn, err := dtx.NewUsbmuxdConnection(device, testmanagerdiOS14)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}
 
 	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot setup test config: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot setup test config: %w", err)
 	}
 	defer conn.Close()
 
@@ -31,7 +31,7 @@ func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, tes
 
 	conn2, err := dtx.NewUsbmuxdConnection(device, testmanagerdiOS14)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}
 	defer conn2.Close()
 	log.Debug("connections ready")
@@ -39,7 +39,7 @@ func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, tes
 	ideDaemonProxy2.ideInterface.testConfig = testConfig
 	caps, err := ideDaemonProxy.daemonConnection.initiateControlSessionWithCapabilities(nskeyedarchiver.XCTCapabilities{})
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot initiate a control session with capabilities: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot initiate a control session with capabilities: %w", err)
 	}
 	log.Debug(caps)
 	localCaps := nskeyedarchiver.XCTCapabilities{CapabilitiesDictionary: map[string]interface{}{
@@ -50,18 +50,18 @@ func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, tes
 
 	caps2, err := ideDaemonProxy2.daemonConnection.initiateSessionWithIdentifierAndCaps(testSessionId, localCaps)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot initiate a session with identifier and capabilities: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot initiate a session with identifier and capabilities: %w", err)
 	}
 	log.Debug(caps2)
 	pControl, err := instruments.NewProcessControl(device)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot connect to process control: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot connect to process control: %w", err)
 	}
 	defer pControl.Close()
 
 	pid, err := startTestRunner12(pControl, xctestConfigPath, testRunnerBundleID, testSessionId.String(), testInfo.testrunnerAppPath+"/PlugIns/"+xctestConfigFileName, args, env)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot start test runner: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot start test runner: %w", err)
 	}
 	log.Debugf("Runner started with pid:%d, waiting for testBundleReady", pid)
 
@@ -73,7 +73,7 @@ func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, tes
 	log.Debugf("authorizing test session for pid %d successful %t", pid, success)
 	err = ideDaemonProxy2.daemonConnection.startExecutingTestPlanWithProtocolVersion(ideInterfaceChannel, 36)
 	if err != nil {
-		return TestSuite{}, fmt.Errorf("runXUITestWithBundleIdsXcode12Ctx: cannot start executing test plan: %w", err)
+		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode12Ctx: cannot start executing test plan: %w", err)
 	}
 
 	select {
@@ -91,7 +91,7 @@ func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, tes
 
 	log.Debugf("Done running test")
 
-	return *testListener.TestSuite, testListener.err
+	return testListener.TestSuites, testListener.err
 }
 
 func startTestRunner12(pControl *instruments.ProcessControl, xctestConfigPath string, bundleID string,


### PR DESCRIPTION
Renamed `TestListener.TestSuite` to `TestListener.TestSuites` and changed its type from `TestSuite` to `[]TestSuite`.