### PR TITLE
Use the shim service over the tunnel interface for zipconduit and syslog

### DIFF
--- a/ios/connect.go
+++ b/ios/connect.go
@@ -104,6 +104,22 @@ func ConnectToService(device DeviceEntry, serviceName string) (DeviceConnectionI
 	return muxConn.ReleaseDeviceConnection(), nil
 }
 
+// ConnectToShimService opens a new connection of the tunnel interface of the provided device
+// to the provided service.
+// The 'RSDCheckin' required by shim services is also executed before returning the connection to the caller
+func ConnectToShimService(device DeviceEntry, service string) (DeviceConnectionInterface, error) {
+	port := device.Rsd.GetPort(service)
+	conn, err := connectToTunnel(device, port)
+	if err != nil {
+		return nil, err
+	}
+	err = RsdCheckin(conn)
+	if err != nil {
+		return nil, err
+	}
+	return NewDeviceConnectionWithConn(conn), nil
+}
+
 // ConnectToServiceTunnelIface connects to a service on an iOS17+ device using a XPC over HTTP2 connection
 // It returns a new xpc.Connection
 func ConnectToXpcServiceTunnelIface(device DeviceEntry, serviceName string) (*xpc.Connection, error) {

--- a/ios/deviceconnection.go
+++ b/ios/deviceconnection.go
@@ -23,6 +23,7 @@ type DeviceConnectionInterface interface {
 	EnableSessionSslServerModeHandshakeOnly(pairRecord PairRecord) error
 	DisableSessionSSL()
 	Conn() net.Conn
+	io.ReadWriteCloser
 }
 
 // DeviceConnection wraps the net.Conn to the ios Device and has support for
@@ -30,6 +31,16 @@ type DeviceConnectionInterface interface {
 type DeviceConnection struct {
 	c               net.Conn
 	unencryptedConn net.Conn
+}
+
+// Read reads incoming data from the connection to the device
+func (conn *DeviceConnection) Read(p []byte) (n int, err error) {
+	return conn.c.Read(p)
+}
+
+// Write writes data on the connection to the device
+func (conn *DeviceConnection) Write(p []byte) (n int, err error) {
+	return conn.c.Write(p)
 }
 
 // NewDeviceConnection creates a new DeviceConnection pointing to the given socket waiting for a call to Connect()

--- a/ios/syslog/syslog.go
+++ b/ios/syslog/syslog.go
@@ -2,63 +2,67 @@ package syslog
 
 import (
 	"bufio"
-	"errors"
 	"io"
 
 	"github.com/danielpaulus/go-ios/ios"
 )
 
-const serviceName string = "com.apple.syslog_relay"
+const (
+	usbmuxdServiceName string = "com.apple.syslog_relay"
+	shimServiceName           = "com.apple.syslog_relay.shim.remote"
+)
 
 // Connection exposes the LogReader channel which send the LogMessages as strings.
 type Connection struct {
-	deviceConn     ios.DeviceConnectionInterface
+	closer         io.Closer
 	bufferedReader *bufio.Reader
 }
 
 // New returns a new SysLog Connection for the given DeviceID and Udid
 // It will create LogReader as a buffered Channel because Syslog is very verbose.
 func New(device ios.DeviceEntry) (*Connection, error) {
-	deviceConn, err := ios.ConnectToService(device, serviceName)
+	if device.Rsd == nil {
+		return NewWithUsbmuxdConnection(device)
+	}
+	return NewWithShimConnection(device)
+}
+
+// NewWithUsbmuxdConnection connects to the syslog_relay service on the device over the usbmuxd socket
+func NewWithUsbmuxdConnection(device ios.DeviceEntry) (*Connection, error) {
+	deviceConn, err := ios.ConnectToService(device, usbmuxdServiceName)
 	if err != nil {
 		return &Connection{}, err
 	}
-	return &Connection{deviceConn: deviceConn}, nil
+	return &Connection{
+		closer:         deviceConn,
+		bufferedReader: bufio.NewReader(deviceConn),
+	}, nil
+}
+
+// NewWithShimConnection connects to the syslog_relay service over a tunnel interface and the service port
+// is obtained from remote service discovery
+func NewWithShimConnection(device ios.DeviceEntry) (*Connection, error) {
+	deviceConn, err := ios.ConnectToShimService(device, shimServiceName)
+	if err != nil {
+		return nil, err
+	}
+	return &Connection{
+		closer:         deviceConn,
+		bufferedReader: bufio.NewReader(deviceConn),
+	}, nil
 }
 
 // ReadLogMessage this is a blocking function that will return individual log messages received from syslog.
 // Call it in an endless for loop in a separate go routine.
 func (sysLogConn *Connection) ReadLogMessage() (string, error) {
-	reader := sysLogConn.deviceConn.Reader()
-	logmsg, err := sysLogConn.Decode(reader)
+	logmsg, err := sysLogConn.bufferedReader.ReadString(0)
 	if err != nil {
 		return "", err
 	}
 	return logmsg, nil
 }
 
-// Encode returns only and error because syslog is read only.
-func (sysLogConn *Connection) Encode(message interface{}) ([]byte, error) {
-	return nil, errors.New("Syslog is readonly")
-}
-
-// Decode wraps the reader into a buffered reader and reads nullterminated strings from it
-// syslog is very verbose, so the decoder sends the decoded strings to a bufferedChannel
-// in a non blocking style.
-// Do not call this manually, it is used by the underlying DeviceConnection.
-func (sysLogConn *Connection) Decode(r io.Reader) (string, error) {
-	if sysLogConn.bufferedReader == nil {
-		sysLogConn.bufferedReader = bufio.NewReader(r)
-	}
-
-	stringmessage, err := sysLogConn.bufferedReader.ReadString(0)
-	if err != nil {
-		return "", err
-	}
-	return stringmessage, nil
-}
-
 // Close closes the underlying UsbMuxConnection
-func (sysLogConn *Connection) Close() {
-	sysLogConn.deviceConn.Close()
+func (sysLogConn *Connection) Close() error {
+	return sysLogConn.closer.Close()
 }

--- a/ios/usbmuxconnection_test.go
+++ b/ios/usbmuxconnection_test.go
@@ -96,6 +96,16 @@ type DeviceConnectionMock struct {
 	mock.Mock
 }
 
+func (mock *DeviceConnectionMock) Read(p []byte) (n int, err error) {
+	args := mock.Called(p)
+	return args.Int(0), args.Error(1)
+}
+
+func (mock *DeviceConnectionMock) Write(p []byte) (n int, err error) {
+	args := mock.Called(p)
+	return args.Int(0), args.Error(1)
+}
+
 func (mock *DeviceConnectionMock) Close() error {
 	mock.Called()
 	return nil


### PR DESCRIPTION
Services that still work over usbmuxd on iOS 17 are also exposed as 'shim' services via RSD over the tunnel interface. With this change we transparently switch to using those services if available.