### PR TITLE
Support tests to run and tests to skip configuration in test config

### DIFF
--- a/ios/nskeyedarchiver/archiver_test.go
+++ b/ios/nskeyedarchiver/archiver_test.go
@@ -36,7 +36,7 @@ func TestArchiveSlice(t *testing.T) {
 // TODO currently only partially decoding XCTestConfig is supported, fix later
 func TestXCTestconfig(t *testing.T) {
 	uuid := uuid.New()
-	config := nskeyedarchiver.NewXCTestConfiguration("productmodulename", uuid, "targetAppBundle", "targetAppPath", "testBundleUrl")
+	config := nskeyedarchiver.NewXCTestConfiguration("productmodulename", uuid, "targetAppBundle", "targetAppPath", "testBundleUrl", nil, nil)
 	result, err := nskeyedarchiver.ArchiveXML(config)
 	if err != nil {
 		log.Error(err)

--- a/ios/testmanagerd/xcuitestrunner_11.go
+++ b/ios/testmanagerd/xcuitestrunner_11.go
@@ -19,10 +19,12 @@ func runXCUIWithBundleIdsXcode11Ctx(
 	device ios.DeviceEntry,
 	args []string,
 	env []string,
+	testsToRun []string,
+	testsToSkip []string,
 	testListener *TestListener,
 ) (TestSuite, error) {
 	log.Debugf("set up xcuitest")
-	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName)
+	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName, testsToRun, testsToSkip)
 	if err != nil {
 		return TestSuite{}, fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create test config: %w", err)
 	}

--- a/ios/testmanagerd/xcuitestrunner_12.go
+++ b/ios/testmanagerd/xcuitestrunner_12.go
@@ -14,14 +14,14 @@ import (
 )
 
 func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, testRunnerBundleID string, xctestConfigFileName string,
-	device ios.DeviceEntry, args []string, env []string, testListener *TestListener,
+	device ios.DeviceEntry, args []string, env []string, testsToRun []string, testsToSkip []string, testListener *TestListener,
 ) (TestSuite, error) {
 	conn, err := dtx.NewUsbmuxdConnection(device, testmanagerdiOS14)
 	if err != nil {
 		return TestSuite{}, fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}
 
-	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName)
+	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName, testsToRun, testsToSkip)
 	if err != nil {
 		return TestSuite{}, fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot setup test config: %w", err)
 	}


### PR DESCRIPTION
Adds support for test filters in xcuitests. It is now possible to select or skip them by providing `--test-to-run=TARGET.CLASS.TESTMETHOD` or `--test-to-skip=TARGET.CLASS.TESTMETHOD`. You can pass as many filters you need, i.e

```
ios runtest --test-to-run MyApp.Foo.bar1 --test-to-run MyApp.Foo.bar2 --test-to-skip MyApp.Foo.bar3 ...
```