### PR TITLE
Fix creating a new device pairing

### DIFF
--- a/ios/http/http.go
+++ b/ios/http/http.go
@@ -3,10 +3,11 @@ package http
 import (
 	"bytes"
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/http2"
 	"io"
 	"sync/atomic"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/http2"
 )
 
 type StreamId uint32
@@ -148,6 +149,9 @@ func (r *HttpConnection) readDataFrame() error {
 					return fmt.Errorf("readDataFrame: could not write settings ack. %w", err)
 				}
 			}
+		case http2.FrameRSTStream:
+			r := f.(*http2.RSTStreamFrame)
+			return fmt.Errorf("readDataFrame: got RST frame with error code: %s", r.ErrCode.String())
 		default:
 			break
 		}

--- a/ios/tunnel/untrusted.go
+++ b/ios/tunnel/untrusted.go
@@ -272,6 +272,10 @@ func (t *tunnelService) verifyPair() error {
 		return err
 	}
 
+	if devicePublicKeyBytes == nil {
+		_ = t.controlChannel.writeEvent(pairVerifyFailed{})
+		return fmt.Errorf("verifyPair: did not get public key from device. Can not verify pairing")
+	}
 	devicePublicKey, err := ecdh.X25519().NewPublicKey(devicePublicKeyBytes)
 	if err != nil {
 		return err


### PR DESCRIPTION
This changed in some minor version upgrade recently. Initially we always got back a public key from the device when we tried to verify the pairing. When this happened we skipped sending a pair-verify-failed message to the device. This case is now covered as well, and we a new pairing will be initiated.

Also, the http2 connection was hanging in this scenario because the device sent a `RST` frame to which we didn't react.