### PR TITLE
Include missing personalization identifiers

### DIFF
--- a/ios/imagemounter/personalized_image.go
+++ b/ios/imagemounter/personalized_image.go
@@ -2,10 +2,11 @@ package imagemounter
 
 import (
 	"fmt"
-	"howett.net/plist"
 	"os"
 	"strconv"
 	"strings"
+
+	"howett.net/plist"
 )
 
 type buildManifest struct {
@@ -64,9 +65,10 @@ func (b buildIdentity) ApChipID() int {
 }
 
 type personalizationIdentifiers struct {
-	BoardId        int
-	ChipID         int
-	SecurityDomain int
+	BoardId               int
+	ChipID                int
+	SecurityDomain        int
+	AdditionalIdentifiers map[string]interface{}
 }
 
 func hexToInt(s string) int {

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -2,12 +2,14 @@ package imagemounter
 
 import (
 	"fmt"
-	"github.com/Masterminds/semver"
-	"github.com/danielpaulus/go-ios/ios"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"github.com/danielpaulus/go-ios/ios"
+	log "github.com/sirupsen/logrus"
 )
 
 // PersonalizedDeveloperDiskImageMounter allows mounting personalized developer disk images
@@ -163,17 +165,25 @@ func (p PersonalizedDeveloperDiskImageMounter) queryIdentifiers() (personalizati
 		return personalizationIdentifiers{}, fmt.Errorf("queryIdentifiers: failed to read response for 'QueryPersonalizationIdentifiers': %w", err)
 	}
 
-	x := resp["PersonalizationIdentifiers"].(map[string]interface{})
+	persIdentifiers := resp["PersonalizationIdentifiers"].(map[string]interface{})
 
-	var identifiers personalizationIdentifiers
+	identifiers := personalizationIdentifiers{
+		AdditionalIdentifiers: map[string]interface{}{},
+	}
 
-	if board, ok := x["BoardId"].(uint64); ok {
+	for k, v := range persIdentifiers {
+		if strings.HasPrefix(k, "Ap,") {
+			identifiers.AdditionalIdentifiers[k] = v
+		}
+	}
+
+	if board, ok := persIdentifiers["BoardId"].(uint64); ok {
 		identifiers.BoardId = int(board)
 	}
-	if chip, ok := x["ChipID"].(uint64); ok {
+	if chip, ok := persIdentifiers["ChipID"].(uint64); ok {
 		identifiers.ChipID = int(chip)
 	}
-	if secDom, ok := x["SecurityDomain"].(uint64); ok {
+	if secDom, ok := persIdentifiers["SecurityDomain"].(uint64); ok {
 		identifiers.SecurityDomain = int(secDom)
 	}
 

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -165,7 +165,11 @@ func (p PersonalizedDeveloperDiskImageMounter) queryIdentifiers() (personalizati
 		return personalizationIdentifiers{}, fmt.Errorf("queryIdentifiers: failed to read response for 'QueryPersonalizationIdentifiers': %w", err)
 	}
 
-	persIdentifiers := resp["PersonalizationIdentifiers"].(map[string]interface{})
+	var persIdentifiers map[string]interface{}
+	var ok bool
+	if persIdentifiers, ok = resp["PersonalizationIdentifiers"].(map[string]interface{}); !ok {
+		return personalizationIdentifiers{}, fmt.Errorf("queryIdentifiers: response has no 'PersonalizationIdentifiers' entry: %+v", resp)
+	}
 
 	identifiers := personalizationIdentifiers{
 		AdditionalIdentifiers: map[string]interface{}{},

--- a/ios/imagemounter/tss.go
+++ b/ios/imagemounter/tss.go
@@ -60,6 +60,10 @@ func (t tssClient) getSignature(identity buildIdentity, identifiers personalizat
 		"UID_MODE": false,
 	}
 
+	for k, v := range identifiers.AdditionalIdentifiers {
+		params[k] = v
+	}
+
 	buf := bytes.NewBuffer(nil)
 	enc := plist.NewEncoderForFormat(buf, plist.XMLFormat)
 	err := enc.Encode(params)


### PR DESCRIPTION
Sometimes the devices includes identifiers starting with 'Ap,' in the response from mobile_image_mounter. We need to copy those to the request to get the signature for the personalized developer disk image