### PR TITLE
fix: quit runwda when wda dies

### DIFF
--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -1,7 +1,7 @@
 package dtx
 
 import (
-	"context"
+	"errors"
 	"io"
 	"math"
 	"strings"
@@ -16,6 +16,8 @@ import (
 
 type MethodWithResponse func(msg Message) (interface{}, error)
 
+var ErrConnectionClosed = errors.New("Connection closed")
+
 // Connection manages channels, including the GlobalChannel, for a DtxConnection and dispatches received messages
 // to the right channel.
 type Connection struct {
@@ -27,8 +29,9 @@ type Connection struct {
 	mutex                  sync.Mutex
 	requestChannelMessages chan Message
 
-	Ctx       context.Context
-	cancelCtx context.CancelCauseFunc
+	closed    chan struct{}
+	err       error
+	closeOnce sync.Once
 }
 
 // Dispatcher is a simple interface containing a Dispatch func to receive dtx.Messages
@@ -45,14 +48,24 @@ type GlobalDispatcher struct {
 
 const requestChannel = "_requestChannelWithCode:identifier:"
 
+// Closed is closed when the underlying DTX connection was closed for any reason (either initiated by calling Close() or due to an error)
+func (dtxConn *Connection) Closed() <-chan struct{} {
+	return dtxConn.closed
+}
+
+// Err is non-nil when the connection was closed (when Close was called this will be ErrConnectionClosed)
+func (dtxConn *Connection) Err() error {
+	return dtxConn.err
+}
+
 // Close closes the underlying deviceConnection
 func (dtxConn *Connection) Close() error {
 	if dtxConn.deviceConnection != nil {
 		err := dtxConn.deviceConnection.Close()
-		dtxConn.cancelCtx(err)
+		dtxConn.close(err)
 		return err
 	}
-	dtxConn.cancelCtx(nil)
+	dtxConn.close(ErrConnectionClosed)
 	return nil
 }
 
@@ -128,7 +141,7 @@ func newDtxConnection(conn ios.DeviceConnectionInterface) (*Connection, error) {
 
 	// The global channel has channelCode 0, so we need to start with channelCodeCounter==1
 	dtxConnection := &Connection{deviceConnection: conn, channelCodeCounter: 1, requestChannelMessages: requestChannelMessages}
-	dtxConnection.Ctx, dtxConnection.cancelCtx = context.WithCancelCause(context.Background())
+	dtxConnection.closed = make(chan struct{})
 
 	// The global channel is automatically present and used for requesting other channels and some other methods like notifyPublishedCapabilities
 	globalChannel := Channel{
@@ -157,7 +170,7 @@ func reader(dtxConn *Connection) {
 		reader := dtxConn.deviceConnection.Reader()
 		msg, err := ReadMessage(reader)
 		if err != nil {
-			defer dtxConn.cancelCtx(err)
+			defer dtxConn.close(err)
 			errText := err.Error()
 			if err == io.EOF || strings.Contains(errText, "use of closed network") {
 				log.Debug("DTX Connection with EOF")
@@ -236,4 +249,11 @@ func (dtxConn *Connection) RequestChannelIdentifier(identifier string, messageDi
 	}
 
 	return channel
+}
+
+func (dtxConn *Connection) close(err error) {
+	dtxConn.closeOnce.Do(func() {
+		dtxConn.err = err
+		close(dtxConn.closed)
+	})
 }

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -291,13 +291,14 @@ func runXUITestWithBundleIdsXcode15Ctx(
 	testsToSkip []string,
 	testListener *TestListener,
 ) ([]TestSuite, error) {
-	conn1, err := dtx.NewTunnelConnection(device, testmanagerdiOS17)
+	ctx, cancelCtx := context.WithCancel(ctx)
+	conn1, err := dtx.NewTunnelConnection(device, testmanagerdiOS17, dtx.WithBreakdownCallback(cancelCtx))
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot create a tunnel connection to testmanagerd: %w", err)
 	}
 	defer conn1.Close()
 
-	conn2, err := dtx.NewTunnelConnection(device, testmanagerdiOS17)
+	conn2, err := dtx.NewTunnelConnection(device, testmanagerdiOS17, dtx.WithBreakdownCallback(cancelCtx))
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("runXUITestWithBundleIdsXcode15Ctx: cannot create a tunnel connection to testmanagerd: %w", err)
 	}

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -393,14 +393,16 @@ func runXUITestWithBundleIdsXcode15Ctx(
 	}
 
 	select {
-	case <-conn1.Ctx.Done():
-		if context.Cause(conn1.Ctx) != nil {
-			log.WithError(context.Cause(conn1.Ctx)).Error("conn1 ended unexpectedly")
+	case <-conn1.Closed():
+		log.Debug("conn1 closed")
+		if conn1.Err() != dtx.ErrConnectionClosed {
+			log.WithError(conn1.Err()).Error("conn1 closed unexpectedly")
 		}
 		break
-	case <-conn2.Ctx.Done():
-		if context.Cause(conn2.Ctx) != nil {
-			log.WithError(context.Cause(conn2.Ctx)).Error("conn2 ended unexpectedly")
+	case <-conn2.Closed():
+		log.Debug("conn2 closed")
+		if conn2.Err() != dtx.ErrConnectionClosed {
+			log.WithError(conn2.Err()).Error("conn2 closed unexpectedly")
 		}
 		break
 	case <-testListener.Done():

--- a/ios/testmanagerd/xcuitestrunner_11.go
+++ b/ios/testmanagerd/xcuitestrunner_11.go
@@ -29,7 +29,8 @@ func runXCUIWithBundleIdsXcode11Ctx(
 		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create test config: %w", err)
 	}
 	log.Debugf("test session setup ok")
-	conn, err := dtx.NewUsbmuxdConnection(device, testmanagerd)
+	ctx, cancelCtx := context.WithCancel(ctx)
+	conn, err := dtx.NewUsbmuxdConnection(device, testmanagerd, dtx.WithBreakdownCallback(cancelCtx))
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}
@@ -37,7 +38,7 @@ func runXCUIWithBundleIdsXcode11Ctx(
 
 	ideDaemonProxy := newDtxProxyWithConfig(conn, testConfig, testListener)
 
-	conn2, err := dtx.NewUsbmuxdConnection(device, testmanagerd)
+	conn2, err := dtx.NewUsbmuxdConnection(device, testmanagerd, dtx.WithBreakdownCallback(cancelCtx))
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}

--- a/ios/testmanagerd/xcuitestrunner_11.go
+++ b/ios/testmanagerd/xcuitestrunner_11.go
@@ -78,14 +78,16 @@ func runXCUIWithBundleIdsXcode11Ctx(
 	}
 
 	select {
-	case <-conn.Ctx.Done():
-		if context.Cause(conn.Ctx) != nil {
-			log.WithError(context.Cause(conn.Ctx)).Error("conn ended unexpectedly")
+	case <-conn.Closed():
+		log.Debug("conn closed")
+		if conn.Err() != dtx.ErrConnectionClosed {
+			log.WithError(conn.Err()).Error("conn closed unexpectedly")
 		}
 		break
-	case <-conn2.Ctx.Done():
-		if context.Cause(conn2.Ctx) != nil {
-			log.WithError(context.Cause(conn2.Ctx)).Error("conn2 ended unexpectedly")
+	case <-conn2.Closed():
+		log.Debug("conn2 closed")
+		if conn2.Err() != dtx.ErrConnectionClosed {
+			log.WithError(conn2.Err()).Error("conn2 closed unexpectedly")
 		}
 		break
 	case <-testListener.Done():

--- a/ios/testmanagerd/xcuitestrunner_12.go
+++ b/ios/testmanagerd/xcuitestrunner_12.go
@@ -77,16 +77,16 @@ func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, tes
 	}
 
 	select {
-	case <-conn.Ctx.Done():
-		log.Info("conn.Ctx.Done()")
-		if context.Cause(conn.Ctx) != context.Canceled {
-			log.WithError(context.Cause(conn.Ctx)).Error("conn ended unexpectedly")
+	case <-conn.Closed():
+		log.Debug("conn closed")
+		if conn.Err() != dtx.ErrConnectionClosed {
+			log.WithError(conn.Err()).Error("conn closed unexpectedly")
 		}
 		break
-	case <-conn2.Ctx.Done():
-		log.Info("conn2.Ctx.Done()")
-		if context.Cause(conn2.Ctx) != context.Canceled {
-			log.WithError(context.Cause(conn2.Ctx)).Error("conn2 ended unexpectedly")
+	case <-conn2.Closed():
+		log.Debug("conn2 closed")
+		if conn2.Err() != dtx.ErrConnectionClosed {
+			log.WithError(conn2.Err()).Error("conn2 closed unexpectedly")
 		}
 		break
 	case <-testListener.Done():

--- a/ios/testmanagerd/xcuitestrunner_12.go
+++ b/ios/testmanagerd/xcuitestrunner_12.go
@@ -16,7 +16,8 @@ import (
 func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, testRunnerBundleID string, xctestConfigFileName string,
 	device ios.DeviceEntry, args []string, env []string, testsToRun []string, testsToSkip []string, testListener *TestListener,
 ) ([]TestSuite, error) {
-	conn, err := dtx.NewUsbmuxdConnection(device, testmanagerdiOS14)
+	ctx, cancelCtx := context.WithCancel(ctx)
+	conn, err := dtx.NewUsbmuxdConnection(device, testmanagerdiOS14, dtx.WithBreakdownCallback(cancelCtx))
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}
@@ -29,7 +30,7 @@ func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, tes
 
 	ideDaemonProxy := newDtxProxyWithConfig(conn, testConfig, testListener)
 
-	conn2, err := dtx.NewUsbmuxdConnection(device, testmanagerdiOS14)
+	conn2, err := dtx.NewUsbmuxdConnection(device, testmanagerdiOS14, dtx.WithBreakdownCallback(cancelCtx))
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}


### PR DESCRIPTION
With this changes `ios runwda` will exit with error when WDA app dies (e.g. killed with `ios kill`, killed manually with AppSwitcher, or when iPhone is turned off).
`dtxConnection`'s `BreakdownCallback` is implemented with Functionals Options Pattern, so it's fully optional and shouldn't affect any other `dtxConnection` usages.