### PR TITLE
feat: Simulate location for iOS17

### DIFF
--- a/ios/debugproxy/binforward.go
+++ b/ios/debugproxy/binforward.go
@@ -22,6 +22,7 @@ var serviceConfigurations = map[string]serviceConfig{
 	"com.apple.accessibility.axAuditDaemon.remoteserver":      {NewDtxDecoder, true},
 	"com.apple.testmanagerd.lockdown":                         {NewDtxDecoder, true},
 	"com.apple.debugserver":                                   {NewBinDumpOnly, true},
+	"com.apple.instruments.dtservicehub":                      {NewDtxDecoder, false},
 	"com.apple.instruments.remoteserver.DVTSecureSocketProxy": {NewDtxDecoder, false},
 	"com.apple.testmanagerd.lockdown.secure":                  {NewDtxDecoder, false},
 	"bindumper":                                               {NewBinDumpOnly, false},

--- a/ios/instruments/helper.go
+++ b/ios/instruments/helper.go
@@ -12,6 +12,7 @@ import (
 const (
 	serviceName      string = "com.apple.instruments.remoteserver"
 	serviceNameiOS14 string = "com.apple.instruments.remoteserver.DVTSecureSocketProxy"
+	serviceNameRsd   string = "com.apple.instruments.dtservicehub"
 )
 
 type loggingDispatcher struct {
@@ -24,6 +25,10 @@ func (p loggingDispatcher) Dispatch(m dtx.Message) {
 }
 
 func connectInstruments(device ios.DeviceEntry) (*dtx.Connection, error) {
+	if device.SupportsRsd() {
+		log.Debugf("Connecting to %s", serviceNameRsd)
+		return dtx.NewTunnelConnection(device, serviceNameRsd)
+	}
 	dtxConn, err := dtx.NewUsbmuxdConnection(device, serviceName)
 	if err != nil {
 		log.Debugf("Failed connecting to %s, trying %s", serviceName, serviceNameiOS14)

--- a/ios/instruments/location_simulation.go
+++ b/ios/instruments/location_simulation.go
@@ -1,0 +1,50 @@
+package instruments
+
+import (
+	"github.com/danielpaulus/go-ios/ios"
+	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
+)
+
+const locationSimulationIdentifier = "com.apple.instruments.server.services.LocationSimulation"
+
+// LocationSimulationService gives us access to simulate device geo location
+type LocationSimulationService struct {
+	channel *dtx.Channel
+	conn    *dtx.Connection
+}
+
+// StartSimulateLocation sets geolocation with provided params
+func (d *LocationSimulationService) StartSimulateLocation(lat, lon float64) error {
+	_, err := d.channel.MethodCall("simulateLocationWithLatitude:longitude:", lat, lon)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// StopSimulateLocation clears simulated location
+func (d *LocationSimulationService) StopSimulateLocation() error {
+	_, err := d.channel.MethodCall("stopLocationSimulation")
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	return nil
+}
+
+// NewLocationSimulationService creates a new LocationSimulationService for a given device
+func NewLocationSimulationService(device ios.DeviceEntry) (*LocationSimulationService, error) {
+	dtxConn, err := connectInstruments(device)
+	if err != nil {
+		return nil, err
+	}
+	processControlChannel := dtxConn.RequestChannelIdentifier(locationSimulationIdentifier, loggingDispatcher{dtxConn})
+	return &LocationSimulationService{channel: processControlChannel, conn: dtxConn}, nil
+}
+
+// Close closes up the DTX connection
+func (d *LocationSimulationService) Close() {
+	d.conn.Close()
+}

--- a/ios/listdevices.go
+++ b/ios/listdevices.go
@@ -82,6 +82,12 @@ func NewReadDevices() ReadDevicesType {
 	return data
 }
 
+// SupportsRsd checks if the device supports RSD (Remote Service Discovery).
+// It returns true if the device has RSD capability, otherwise false.
+func (device *DeviceEntry) SupportsRsd() bool {
+	return device.Rsd != nil
+}
+
 // ListDevices returns a DeviceList containing data about all
 // currently connected iOS devices
 func (muxConn *UsbMuxConnection) ListDevices() (DeviceList, error) {


### PR DESCRIPTION
### Why?

The current `setlocation` only works for iOS below 17, the iOS 17 introduces a new instrumentation service `com.apple.instruments.dtservicehub` with the channel id `com.apple.instruments.server.services.LocationSimulation` for the simulated location.

### How?

By using DTX make a channel call:
- `imulateLocationWithLatitude:longitude:` with args to start the location simulation
- `stopLocationSimulation` to stop and clear the location simulation & data
The response payloads for both methods are `<nil>`
