### PR TITLE
ensure that the test listener channel gets closed only once

### DIFF
--- a/ios/testmanagerd/testlistener_test.go
+++ b/ios/testmanagerd/testlistener_test.go
@@ -21,7 +21,7 @@ func TestFinishExecutingTestPlan(t *testing.T) {
 			testListener.didFinishExecutingTestPlan()
 		}()
 
-		<-testListener.executionFinished
+		<-testListener.finished
 	})
 
 	t.Run("Wait for test finish with multiple waiters", func(t *testing.T) {


### PR DESCRIPTION
the close call happens in multiple places and we can not be sure that only one of those methods is getting called during an execution