### PR TITLE
fix memory leaks

### DIFF
--- a/ios/dtx_codec/channel.go
+++ b/ios/dtx_codec/channel.go
@@ -164,16 +164,19 @@ func (d *Channel) Dispatch(msg Message) {
 						d.messageDispatcher.Dispatch(msg)
 					}
 					delete(d.responseWaiters, msg.Identifier)
+					delete(d.defragmenters, msg.Identifier)
 				}
 				return
 			}
 			log.Warn("Received message fragment without first message, dropping it")
 			delete(d.responseWaiters, msg.Identifier)
+			delete(d.defragmenters, msg.Identifier)
 			return
 		}
 
 		d.responseWaiters[msg.Identifier] <- msg
 		delete(d.responseWaiters, msg.Identifier)
+		delete(d.defragmenters, msg.Identifier)
 		return
 	}
 	d.messageDispatcher.Dispatch(msg)

--- a/ios/testmanagerd/testlistener.go
+++ b/ios/testmanagerd/testlistener.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -133,12 +134,12 @@ func (t *TestListener) testCaseFinished(testClass string, testMethod string, xcA
 
 		file.Write(attachment.Payload)
 		testCase.Attachments = append(testCase.Attachments, TestAttachment{
-			Name:                  attachment.Name,
+			Name:                  strings.Clone(attachment.Name),
 			Timestamp:             attachment.Timestamp,
-			Activity:              xcActivityRecord.Title,
+			Activity:              strings.Clone(xcActivityRecord.Title),
 			Path:                  attachmentsPath,
-			Type:                  xcActivityRecord.ActivityType,
-			UniformTypeIdentifier: attachment.UniformTypeIdentifier,
+			Type:                  strings.Clone(xcActivityRecord.ActivityType),
+			UniformTypeIdentifier: strings.Clone(attachment.UniformTypeIdentifier),
 		})
 	}
 }


### PR DESCRIPTION
There was a memory leak when we handle fragmented DTX messages. The fragments were not completely cleaned up.

And in XCUITests the attachments were also retained completely, even though we were only using the string values of those attachments. Cloning those strings resolves this