### PR TITLE
fix: ios 11-13 arme64 runwda fix

### DIFF
--- a/ios/testmanagerd/xcuitestrunner_11.go
+++ b/ios/testmanagerd/xcuitestrunner_11.go
@@ -111,14 +111,24 @@ func runXCUIWithBundleIdsXcode11Ctx(
 func startTestRunner11(pControl *instruments.ProcessControl, xctestConfigPath string, bundleID string,
 	sessionIdentifier string, testBundlePath string, wdaargs []string, wdaenv []string,
 ) (uint64, error) {
-	args := []interface{}{}
+	args := []interface{}{
+		"-NSTreatUnknownArgumentsAsOpen", "NO", "-ApplePersistenceIgnoreState", "YES",
+	}
 	for _, arg := range wdaargs {
 		args = append(args, arg)
 	}
 	env := map[string]interface{}{
-		"XCTestBundlePath":            testBundlePath,
-		"XCTestConfigurationFilePath": xctestConfigPath,
-		"XCTestSessionIdentifier":     sessionIdentifier,
+		"CA_ASSERT_MAIN_THREAD_TRANSACTIONS": "0",
+		"CA_DEBUG_TRANSACTIONS":              "0",
+		"DYLD_INSERT_LIBRARIES":              "/Developer/usr/lib/libMainThreadChecker.dylib",
+
+		"MTC_CRASH_ON_REPORT":             "1",
+		"NSUnbufferedIO":                  "YES",
+		"OS_ACTIVITY_DT_MODE":             "YES",
+		"SQLITE_ENABLE_THREAD_ASSERTIONS": "1",
+		"XCTestBundlePath":                testBundlePath,
+		"XCTestConfigurationFilePath":     xctestConfigPath,
+		"XCTestSessionIdentifier":         sessionIdentifier,
 	}
 
 	for _, entrystring := range wdaenv {


### PR DESCRIPTION
So was experiencing a unique issue on certain models running iOS 11-13. This fix resolves the issue


fields.msg="Assertion failed: (this->cputype == CPU_TYPE_ARM64 && this->cpusubtype == CPU_SUBTYPE_ARM64E && \"chainedPointerFormat() called on non-chained binary\"), function chainedPointerFormat, file /BuildRoot/Library/Caches/com.apple.xbs/Sources/dyld/dyld-731.4/dyld3/MachOAnalyzer.cpp, line 3029.\ndyld: Assertion failed: (this->cputype == CPU_TYPE_ARM64 && this->cpusubtype == CPU_SUBTYPE_ARM64E && \"chainedPointerFormat() called on non-chained binary\"), function chainedPointerFormat, file /BuildRoot/Library/Caches/com.apple.xbs/Sources/dyld/dyld-731.4/dyld3/MachOAnalyzer.cpp, line 3029.\n\n" 

could not connect to phone                    conn="&net.TCPConn{conn:net.conn{fd:(*net.netFD)(0xc000348400)}}" err="Failed connecting to service, error code:3" phonePort=8100