### PR TITLE
move initializing the buffered reader out of the loop

### DIFF
--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -167,8 +167,8 @@ func (dtxConn *Connection) Send(message []byte) error {
 
 // reader reads messages from the byte stream and dispatches them to the right channel when they are decoded.
 func reader(dtxConn *Connection) {
+	reader := bufio.NewReader(dtxConn.deviceConnection.Reader())
 	for {
-		reader := bufio.NewReader(dtxConn.deviceConnection.Reader())
 		msg, err := ReadMessage(reader)
 		if err != nil {
 			defer dtxConn.close(err)


### PR DESCRIPTION
having it inside the loop destroys the reader after every iteration and it may contain bytes at that point