### PR TITLE
set an error on the test run when we lose DTX connectivity

### DIFF
--- a/ios/testmanagerd/testlistener.go
+++ b/ios/testmanagerd/testlistener.go
@@ -255,6 +255,11 @@ func (t *TestListener) TestRunnerKilled() {
 	t.executionFinished()
 }
 
+func (t *TestListener) FinishWithError(err error) {
+	t.err = err
+	t.executionFinished()
+}
+
 func (t *TestListener) Done() <-chan struct{} {
 	return t.finished
 }

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -396,14 +396,14 @@ func runXUITestWithBundleIdsXcode15Ctx(
 	select {
 	case <-conn1.Closed():
 		log.Debug("conn1 closed")
-		if conn1.Err() != dtx.ErrConnectionClosed {
+		if !errors.Is(conn1.Err(), dtx.ErrConnectionClosed) {
 			log.WithError(conn1.Err()).Error("conn1 closed unexpectedly")
 		}
 		testListener.FinishWithError(errors.New("lost connection to testmanagerd. the test-runner may have been killed"))
 		break
 	case <-conn2.Closed():
 		log.Debug("conn2 closed")
-		if conn2.Err() != dtx.ErrConnectionClosed {
+		if !errors.Is(conn2.Err(), dtx.ErrConnectionClosed) {
 			log.WithError(conn2.Err()).Error("conn2 closed unexpectedly")
 		}
 		testListener.FinishWithError(errors.New("lost connection to testmanagerd. the test-runner may have been killed"))

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -2,6 +2,7 @@ package testmanagerd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -398,12 +399,14 @@ func runXUITestWithBundleIdsXcode15Ctx(
 		if conn1.Err() != dtx.ErrConnectionClosed {
 			log.WithError(conn1.Err()).Error("conn1 closed unexpectedly")
 		}
+		testListener.FinishWithError(errors.New("lost connection to testmanagerd. the test-runner may have been killed"))
 		break
 	case <-conn2.Closed():
 		log.Debug("conn2 closed")
 		if conn2.Err() != dtx.ErrConnectionClosed {
 			log.WithError(conn2.Err()).Error("conn2 closed unexpectedly")
 		}
+		testListener.FinishWithError(errors.New("lost connection to testmanagerd. the test-runner may have been killed"))
 		break
 	case <-testListener.Done():
 		break


### PR DESCRIPTION
in most cases this is due to the test runner crashing (or it can also be closed manually through the UI)