### PR TITLE
Fix proxy support

### DIFF
--- a/ios/imagemounter/imagedownloader.go
+++ b/ios/imagemounter/imagedownloader.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/danielpaulus/go-ios/ios"
@@ -247,8 +248,12 @@ func validateBaseDirAndLookForImage(baseDir string, imageToFind string) (string,
 // write as it downloads and not load the whole file into memory.
 // PS: Taken from golangcode.com
 func downloadFile(filepath string, url string) error {
+	c := &http.Client{
+		Timeout:   2 * time.Minute,
+		Transport: http.DefaultTransport,
+	}
 	// Get the data
-	resp, err := http.Get(url)
+	resp, err := c.Get(url)
 	if err != nil {
 		return err
 	}

--- a/ios/imagemounter/tss.go
+++ b/ios/imagemounter/tss.go
@@ -20,7 +20,8 @@ type tssClient struct {
 
 func newTssClient() tssClient {
 	c := &http.Client{
-		Timeout: 1 * time.Minute,
+		Timeout:   1 * time.Minute,
+		Transport: http.DefaultTransport,
 	}
 
 	return tssClient{

--- a/ios/mobileactivation/albert.go
+++ b/ios/mobileactivation/albert.go
@@ -15,7 +15,8 @@ const (
 )
 
 var netClient = &http.Client{
-	Timeout: time.Second * 5,
+	Timeout:   time.Second * 5,
+	Transport: http.DefaultTransport,
 }
 
 func sendHandshakeRequest(body io.Reader) (http.Header, io.ReadCloser, error) {


### PR DESCRIPTION
In Golang only the default http client uses the system wide env var. this led to some weird behavior with half 
of go-ios supporting it and the other half not so much. I changed it to use the default transport always. 