### PR TITLE
Support installation for arm64 architecture

### DIFF
--- a/npm_publish/postinstall.js
+++ b/npm_publish/postinstall.js
@@ -12,7 +12,8 @@ var path = require('path'),
 var ARCH_MAPPING = {
     "ia32": "386",
     "x64": "amd64",
-    "arm": "arm"
+    "arm": "arm",
+    "arm64": "arm64"
 };
 
 // Mapping between Node's `process.platform` to Golang's
@@ -86,11 +87,9 @@ function validateConfiguration(packageJson) {
 }
 
 function parsePackageJson() {
-    if (process.arch !== "arm64" && process.platform !== "darwin") {
-        if (!(process.arch in ARCH_MAPPING)) {
-            console.error("Installation is not supported for this architecture: " + process.arch);
-            return;
-        }
+    if (!(process.arch in ARCH_MAPPING)) {
+        console.error("Installation is not supported for this architecture: " + process.arch);
+        return;
     }
 
     if (!(process.platform in PLATFORM_MAPPING)) {
@@ -146,10 +145,6 @@ async function install(callback) {
     mkdirp.sync(opts.binPath);
     console.info(`Copying the relevant binary for your platform ${process.platform}`);
     let src = `./dist/go-ios-${PLATFORM_MAPPING[process.platform]}-${ARCH_MAPPING[process.arch]}_${PLATFORM_MAPPING[process.platform]}_${ARCH_MAPPING[process.arch]}/${opts.binName}`;
-    if (process.arch === "arm64" && process.platform === "darwin") {
-        console.log("using amd64 build on M1 mac")
-        src = `./dist/go-ios-${process.platform}-amd64_${process.platform}_amd64/${opts.binName}`;
-    }
 
     if (process.arch === "ia32" && process.platform === "w32") {
         src = `./dist/go-ios-${PLATFORM_MAPPING[process.platform]}-amd64_${PLATFORM_MAPPING[process.platform]}_amd64/${opts.binName}`;


### PR DESCRIPTION
This patch supports installation for arm64 architecture.
Since go-ios supports arm64 in #399, 
we can use arm64 instead of amd64 for installation.