### PR TITLE
Allow unmounting disk images

### DIFF
--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -129,6 +129,19 @@ func (p PersonalizedDeveloperDiskImageMounter) MountImage(imagePath string) erro
 	return nil
 }
 
+func (p PersonalizedDeveloperDiskImageMounter) UnmountImage() error {
+	req := map[string]interface{}{
+		"Command":   "UnmountImage",
+		"MountPath": "/System/Developer",
+	}
+	log.Debugf("sending: %+v", req)
+	err := p.plistRw.Write(req)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (p PersonalizedDeveloperDiskImageMounter) queryPersonalizedImageNonce() ([]byte, error) {
 	err := p.plistRw.Write(map[string]interface{}{
 		"Command":               "QueryNonce",

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ Usage:
   ios info [display | lockdown] [options]
   ios image list [options]
   ios image mount [--path=<imagepath>] [options]
+  ios image unmount [options]
   ios image auto [--basedir=<where_dev_images_are_stored>] [options]
   ios syslog [options]
   ios screenshot [options] [--output=<outfile>] [--stream] [--port=<port>]
@@ -162,6 +163,7 @@ The commands work as following:
    ios image list [options]                                           List currently mounted developers images' signatures
    ios image mount [--path=<imagepath>] [options]                     Mount a image from <imagepath>
    >                                                                  For iOS 17+ (personalized developer disk images) <imagepath> must point to the "Restore" directory inside the developer disk
+   ios image unmount [options]                                        Unmount developer disk image
    ios image auto [--basedir=<where_dev_images_are_stored>] [options] Automatically download correct dev image from the internets and mount it.
    >                                                                  You can specify a dir where images should be cached.
    >                                                                  The default is the current dir.
@@ -1147,6 +1149,17 @@ func imageCommand1(device ios.DeviceEntry, arguments docopt.Opts) bool {
 				return true
 			}
 			log.WithFields(log.Fields{"image": path, "udid": device.Properties.SerialNumber}).Info("success mounting image")
+		}
+
+		unmount, _ := arguments.Bool("unmount")
+		if unmount {
+			err := imagemounter.UnmountImage(device)
+			if err != nil {
+				log.WithFields(log.Fields{"udid": device.Properties.SerialNumber, "err": err}).
+					Error("error unmounting image")
+				return true
+			}
+			log.WithFields(log.Fields{"udid": device.Properties.SerialNumber}).Info("success unmounting image")
 		}
 	}
 	return b


### PR DESCRIPTION
This PR adds an `unmount` sub-command to the `image` command for doing just that : unmounting currently mounted developer disk images, be them "standard" ones (iOS < 17) or personalized ones (iOS >= 17).

This PR is heavily inspired by [pymobiledevice3's implementation](https://github.com/doronz88/pymobiledevice3/blob/6351c9527e79a453228ce5969998d9e357b499f3/pymobiledevice3/services/mobile_image_mounter.py#L66-L80).

I wasn't sure whether I should include a `Hangup` command or not, like it's done with the mounting commands [here](https://github.com/danielpaulus/go-ios/blob/5403671c371d0d28e91997bf29f22c101368a423/ios/imagemounter/imagemounter.go#L95) and [here](https://github.com/danielpaulus/go-ios/blob/5403671c371d0d28e91997bf29f22c101368a423/ios/imagemounter/personalized_image_mounter.go#L125). I tried both (adding one and not adding one) and didn't see any difference : I was able to mount, unmount, and mount again an image with both approaches. The only difference I saw was a warning in the `go-ncm` logs with the hangup command added :
```
handle_events: error: libusb: interrupted [code -10]
```
But since `pymobiledevice3` doesn't seem to include hangup commands, neither during unmounting, nor during mounting, I didn't include one. Please feel free to explain what this command is and whether I should include one or not 🤓 

I tested with an iPhone SE (2022) running iOS 17.5.1 :
```
# go-ios image list
{"level":"info","msg":"no udid specified using first device in list","time":"2024-08-10T15:25:16Z","udid":"ABCDEF"}
{"level":"info","msg":"no udid specified using first device in list","time":"2024-08-10T15:25:16Z","udid":"ABCDEF"}
{"level":"info","msg":"abcdef","time":"2024-08-10T15:25:16Z"}
```
```
# go-ios image unmount
{"level":"info","msg":"no udid specified using first device in list","time":"2024-08-10T15:25:59Z","udid":"ABCDEF"}
{"level":"info","msg":"no udid specified using first device in list","time":"2024-08-10T15:26:00Z","udid":"ABCDEF"}
{"level":"info","msg":"success unmounting image","time":"2024-08-10T15:26:00Z","udid":"ABCDEF"}
```
```
# go-ios image list
{"level":"info","msg":"no udid specified using first device in list","time":"2024-08-10T15:26:17Z","udid":"ABCDEF"}
{"level":"info","msg":"no udid specified using first device in list","time":"2024-08-10T15:26:18Z","udid":"ABCDEF"}
{"level":"info","msg":"none","time":"2024-08-10T15:26:18Z"}
```
```
# go-ios image auto
{"level":"info","msg":"no udid specified using first device in list","time":"2024-08-10T15:26:34Z","udid":"ABCDEF"}
{"level":"info","msg":"no udid specified using first device in list","time":"2024-08-10T15:26:35Z","udid":"ABCDEF"}
{"level":"info","msg":"device iOS version: 17.5.1, getting developer image: https://deviceboxhq.com/ddi-15F31d.zip","time":"2024-08-10T15:26:35Z"}
{"level":"info","msg":"downloading 'https://deviceboxhq.com/ddi-15F31d.zip' to path 'devimages/ddi-15F31d.zip'","time":"2024-08-10T15:26:35Z"}
{"basedir":"./devimages","level":"info","msg":"success downloaded image","time":"2024-08-10T15:26:36Z","udid":"ABCDEF"}
{"image":"devimages/ddi-15F31d/Restore","level":"info","msg":"success mounting image","time":"2024-08-10T15:26:37Z","udid":"ABCDEF"}
```
```
# go-ios image list
{"level":"info","msg":"no udid specified using first device in list","time":"2024-08-10T15:26:44Z","udid":"ABCDEF"}
{"level":"info","msg":"no udid specified using first device in list","time":"2024-08-10T15:26:45Z","udid":"ABCDEF"}
{"level":"info","msg":"abcdef","time":"2024-08-10T15:26:45Z"}
```
