### PR TITLE
Allow removing tunnels from the tunnel manager

### DIFF
--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -302,6 +302,17 @@ func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 	return nil
 }
 
+func (m *TunnelManager) RemoveTunnel(ctx context.Context, serialNumber string) error {
+	for udid, tun := range m.tunnels {
+		if udid == serialNumber {
+			err := m.stopTunnel(tun)
+			return err
+		}
+	}
+
+	return errors.New("tunnel not found")
+}
+
 func (m *TunnelManager) stopTunnel(t Tunnel) error {
 	m.mux.Lock()
 	defer m.mux.Unlock()


### PR DESCRIPTION
This PR adds a public method for removing a tunnel based on the serial number, basically bringing the recent `/tunnel` `DELETE` HTTP endpoint addition for use directly from go code importing `go-iOS`.