### PR TITLE
Add back the "image unmount" command removed by mistake

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ Usage:
   ios info [display | lockdown] [options]
   ios image list [options]
   ios image mount [--path=<imagepath>] [options]
+  ios image unmount [options]
   ios image auto [--basedir=<where_dev_images_are_stored>] [options]
   ios syslog [options]
   ios screenshot [options] [--output=<outfile>] [--stream] [--port=<port>]


### PR DESCRIPTION
This PR simply adds back the `image unmount` command introduced with #454 and remove by mistake with #464 [here](https://github.com/danielpaulus/go-ios/pull/464#discussion_r1724889745).