### PR TITLE
fix(Makefile): use native GOOS/GOARCH by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,30 +9,19 @@
 GO_IOS_BINARY_NAME=ios
 NCM_BINARY_NAME=go-ncm
 
+# Define only if compiling for system different than our own
+OS=
+ARCH=
 
-# Detect the system architecture
-UNAME_S := $(shell uname -s)
-UNAME_M := $(shell uname -m)
-
-# Default GOARCH value
-GOARCH := amd64
-
-# Set GOARCH based on the detected architecture
-ifeq ($(UNAME_M),x86_64)
-    GOARCH := amd64
-else ifeq ($(UNAME_M),armv7l)
-    GOARCH := arm
-else ifeq ($(UNAME_M),aarch64)
-    GOARCH := arm64
-# Add more architecture mappings as needed
-endif
+# Prepend each non-empty OS/ARCH definition to "go" command
+GOEXEC=$(strip $(foreach v,OS ARCH,$(and $($v),GO$v=$($v) )) go)
 
 # Build the Go program
 build:
-	@go work use .
-	@GOARCH=$(GOARCH) go build -o $(GO_IOS_BINARY_NAME) ./main.go
-	@go work use ./ncm
-	@CGO_ENABLED=1 GOARCH=$(GOARCH) go build -o $(NCM_BINARY_NAME) ./cmd/cdc-ncm/main.go
+	@$(GOEXEC) work use .
+	@$(GOEXEC) build -o $(GO_IOS_BINARY_NAME) ./main.go
+	@$(GOEXEC) work use ./ncm
+	@CGO_ENABLED=1 $(GOEXEC) build -o $(NCM_BINARY_NAME) ./cmd/cdc-ncm/main.go
 
 # Run the Go program with sudo
 run: build


### PR DESCRIPTION
The Makefile attempts to determine the target OS/arch so that it can specify `GOOS`/`GOARCH` explicitly when calling `go`.

This doesn't really achieve anything as it ends up competing with the same default behavior of `go` as well as the user's own configured environment.

Furthermore, [it causes the build to fail](https://github.com/user-attachments/files/17181175/go-ios.make.txt) on newer Apple silicon Macs, where `uname -m` reports `arm64` (not `aarch64` expected by the Makefile).

This change removes the behavior that always-overrides `GOARCH`. The user can either specify `GOOS` and `GOARCH` in the Makefile where commented, or they can simply export the variables through their environment and the Makefile will respect them.

Otherwise, do not override `GOARCH` or `GOOS` within the Makefile. Let the `go` toolchain figure it out as intended.