### PR TITLE
fix 'automationFrameworkPath' for iOS 17+

### DIFF
--- a/ios/nskeyedarchiver/archiver_test.go
+++ b/ios/nskeyedarchiver/archiver_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Masterminds/semver"
 	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
 	archiver "github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
 	"github.com/google/uuid"
@@ -36,7 +37,7 @@ func TestArchiveSlice(t *testing.T) {
 // TODO currently only partially decoding XCTestConfig is supported, fix later
 func TestXCTestconfig(t *testing.T) {
 	uuid := uuid.New()
-	config := nskeyedarchiver.NewXCTestConfiguration("productmodulename", uuid, "targetAppBundle", "targetAppPath", "testBundleUrl", nil, nil, false)
+	config := nskeyedarchiver.NewXCTestConfiguration("productmodulename", uuid, "targetAppBundle", "targetAppPath", "testBundleUrl", nil, nil, false, semver.MustParse("17.0.0"))
 	result, err := nskeyedarchiver.ArchiveXML(config)
 	if err != nil {
 		log.Error(err)

--- a/ios/nskeyedarchiver/objectivec_classes.go
+++ b/ios/nskeyedarchiver/objectivec_classes.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/google/uuid"
 	"howett.net/plist"
 )
@@ -84,6 +85,7 @@ func NewXCTestConfiguration(
 	testsToRun []string,
 	testsToSkip []string,
 	isXCTest bool,
+	version *semver.Version,
 ) XCTestConfiguration {
 	contents := map[string]interface{}{}
 
@@ -119,7 +121,11 @@ func NewXCTestConfiguration(
 	}
 
 	contents["aggregateStatisticsBeforeCrash"] = map[string]interface{}{"XCSuiteRecordsKey": map[string]interface{}{}}
-	contents["automationFrameworkPath"] = "/Developer/Library/PrivateFrameworks/XCTAutomationSupport.framework"
+	if version.Major() >= 17 {
+		contents["automationFrameworkPath"] = "/System/Developer/Library/PrivateFrameworks/XCTAutomationSupport.framework"
+	} else {
+		contents["automationFrameworkPath"] = "/Developer/Library/PrivateFrameworks/XCTAutomationSupport.framework"
+	}
 	contents["baselineFileRelativePath"] = plist.UID(0)
 	contents["baselineFileURL"] = plist.UID(0)
 	contents["defaultTestExecutionTimeAllowance"] = plist.UID(0)

--- a/ios/testmanagerd/xcuitestrunner_11.go
+++ b/ios/testmanagerd/xcuitestrunner_11.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 
+	"github.com/Masterminds/semver"
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
 	"github.com/danielpaulus/go-ios/ios/instruments"
@@ -23,9 +24,10 @@ func runXCUIWithBundleIdsXcode11Ctx(
 	testsToSkip []string,
 	testListener *TestListener,
 	isXCTest bool,
+	version *semver.Version,
 ) ([]TestSuite, error) {
 	log.Debugf("set up xcuitest")
-	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName, testsToRun, testsToSkip, isXCTest)
+	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName, testsToRun, testsToSkip, isXCTest, version)
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("RunXCUIWithBundleIdsXcode11Ctx: cannot create test config: %w", err)
 	}

--- a/ios/testmanagerd/xcuitestrunner_12.go
+++ b/ios/testmanagerd/xcuitestrunner_12.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
 	"github.com/danielpaulus/go-ios/ios/instruments"
@@ -14,14 +15,14 @@ import (
 )
 
 func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, bundleID string, testRunnerBundleID string, xctestConfigFileName string,
-	device ios.DeviceEntry, args []string, env map[string]interface{}, testsToRun []string, testsToSkip []string, testListener *TestListener, isXCTest bool,
+	device ios.DeviceEntry, args []string, env map[string]interface{}, testsToRun []string, testsToSkip []string, testListener *TestListener, isXCTest bool, version *semver.Version,
 ) ([]TestSuite, error) {
 	conn, err := dtx.NewUsbmuxdConnection(device, testmanagerdiOS14)
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}
 
-	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName, testsToRun, testsToSkip, isXCTest)
+	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(device, bundleID, testRunnerBundleID, xctestConfigFileName, testsToRun, testsToSkip, isXCTest, version)
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot setup test config: %w", err)
 	}


### PR DESCRIPTION
this value has changed with iOS 17. While this did not cause problems in most cases, UI interruption handlers were broken because of that. They simply stopped firing with that value pointing to the old path