### PR TITLE
Fix stuck XCUITest runner when a popup is shown on the screen

### DIFF
--- a/ios/nskeyedarchiver/objectivec_classes.go
+++ b/ios/nskeyedarchiver/objectivec_classes.go
@@ -586,7 +586,11 @@ func NewNSError(object map[string]interface{}, objects []interface{}) interface{
 }
 
 func (err NSError) Error() string {
-	return fmt.Sprintf("Error code: %d, Domain: %s, User info: %v", err.ErrorCode, err.Domain, err.UserInfo)
+	var description any = "no description available"
+	if d, ok := err.UserInfo["NSLocalizedDescription"]; ok {
+		description = d
+	}
+	return fmt.Sprintf("%v (Error code: %d, Domain: %s)", description, err.ErrorCode, err.Domain)
 }
 
 // Apples Reference Date is Jan 1st 2001 00:00

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -483,8 +483,9 @@ func startTestRunner17(device ios.DeviceEntry, appserviceConn *appservice.Connec
 	}
 
 	opts := map[string]interface{}{
-		"ActivateSuspended": uint64(1),
-		"StartSuspendedKey": uint64(0),
+		"ActivateSuspended":   uint64(1),
+		"StartSuspendedKey":   uint64(0),
+		"__ActivateSuspended": uint64(1),
 	}
 
 	appLaunch, err := appserviceConn.LaunchAppWithStdIo(


### PR DESCRIPTION
When a popup (like a permission popup for the camera, notifications, etc) is shown before the XCUITest is started, the XCUITest runner will hang and after 30s we get the error `Failed to background test runner within 30.0s.`

By adding the option `"__ActivateSuspended": uint64(1),` when we launch the XCUITest (like Xcode does), this is not happening anymore.

Also, the `Error()` method of `NSError` was a bit too verbose. In the error that we got here, there is a entry `screenshot-data` in the `userInfo` dictionary, and we shouldn't include that in the error message (it's still stored in the error if someone really needs that)