### PR TITLE
allow setting custom tunnel host

### DIFF
--- a/ios/connect.go
+++ b/ios/connect.go
@@ -282,7 +282,7 @@ func ConnectTUNDevice(remoteIp string, port int, d DeviceEntry) (*net.TCPConn, e
 		return connectTUN(remoteIp, port)
 	}
 
-	addr, _ := net.ResolveTCPAddr("tcp4", fmt.Sprintf("localhost:%d", d.UserspaceTUNPort))
+	addr, _ := net.ResolveTCPAddr("tcp4", fmt.Sprintf("%s:%d", d.UserspaceTUNHost, d.UserspaceTUNPort))
 	conn, err := net.DialTCP("tcp", nil, addr)
 	if err != nil {
 		return nil, fmt.Errorf("ConnectUserSpaceTunnel: failed to dial: %w", err)
@@ -328,6 +328,9 @@ func connectTUN(address string, port int) (*net.TCPConn, error) {
 // 60-105 is leetspeek for go-ios :-D
 const defaultHttpApiPort = 60105
 
+// defaultHttpApiHost is the host on which the HTTP-Server runs, by default it is 127.0.0.1
+const defaultHttpApiHost = "127.0.0.1"
+
 // DefaultHttpApiPort is the port on which we start the HTTP-Server for exposing started tunnels
 // if GO_IOS_AGENT_PORT is set, we use that port. Otherwise we use the default port 60106.
 // 60-105 is leetspeek for go-ios :-D
@@ -337,4 +340,14 @@ func HttpApiPort() int {
 		return defaultHttpApiPort
 	}
 	return port
+}
+
+// DefaultHttpApiHost is the host on which the HTTP-Server runs, by default it is 127.0.0.1
+// if GO_IOS_AGENT_HOST is set, we use that host. Otherwise we use the default host
+func HttpApiHost() string {
+	host := os.Getenv("GO_IOS_AGENT_HOST")
+	if host == "" {
+		return defaultHttpApiHost
+	}
+	return host
 }

--- a/ios/listdevices.go
+++ b/ios/listdevices.go
@@ -59,6 +59,7 @@ type DeviceEntry struct {
 	Address          string
 	Rsd              RsdPortProvider
 	UserspaceTUN     bool
+	UserspaceTUNHost string
 	UserspaceTUNPort int
 }
 

--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -177,11 +177,11 @@ func TunnelInfoForDevice(udid string, tunnelInfoHost string, tunnelInfoPort int)
 	return info, nil
 }
 
-func ListRunningTunnels(tunnelInfoPort int) ([]Tunnel, error) {
+func ListRunningTunnels(tunnelInfoHost string, tunnelInfoPort int) ([]Tunnel, error) {
 	c := http.Client{
 		Timeout: 5 * time.Second,
 	}
-	res, err := c.Get(fmt.Sprintf("http://127.0.0.1:%d/tunnels", tunnelInfoPort))
+	res, err := c.Get(fmt.Sprintf("http://%s:%d/tunnels", tunnelInfoHost, tunnelInfoPort))
 	if err != nil {
 		return nil, fmt.Errorf("TunnelInfoForDevice: failed to get tunnel info: %w", err)
 	}

--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -26,7 +26,7 @@ var netClient = &http.Client{
 }
 
 func CloseAgent() error {
-	_, err := netClient.Get(fmt.Sprintf("http://%s:%d/shutdown", "127.0.0.1", ios.HttpApiPort()))
+	_, err := netClient.Get(fmt.Sprintf("http://%s:%d/shutdown", ios.HttpApiHost(), ios.HttpApiPort()))
 	if err != nil {
 		return fmt.Errorf("CloseAgent: failed to send shutdown request: %w", err)
 	}
@@ -34,7 +34,7 @@ func CloseAgent() error {
 }
 
 func IsAgentRunning() bool {
-	resp, err := netClient.Get(fmt.Sprintf("http://%s:%d/health", "127.0.0.1", ios.HttpApiPort()))
+	resp, err := netClient.Get(fmt.Sprintf("http://%s:%d/health", ios.HttpApiHost(), ios.HttpApiPort()))
 	if err != nil {
 		return false
 	}
@@ -43,7 +43,7 @@ func IsAgentRunning() bool {
 func WaitUntilAgentReady() bool {
 	for {
 		slog.Info("Waiting for go-ios agent to be ready...")
-		resp, err := netClient.Get(fmt.Sprintf("http://%s:%d/ready", "127.0.0.1", ios.HttpApiPort()))
+		resp, err := netClient.Get(fmt.Sprintf("http://%s:%d/ready", ios.HttpApiHost(), ios.HttpApiPort()))
 		if err != nil {
 			return false
 		}
@@ -155,11 +155,11 @@ func ServeTunnelInfo(tm *TunnelManager, port int) error {
 	return nil
 }
 
-func TunnelInfoForDevice(udid string, tunnelInfoPort int) (Tunnel, error) {
+func TunnelInfoForDevice(udid string, tunnelInfoHost string, tunnelInfoPort int) (Tunnel, error) {
 	c := http.Client{
 		Timeout: 5 * time.Second,
 	}
-	res, err := c.Get(fmt.Sprintf("http://127.0.0.1:%d/tunnel/%s", tunnelInfoPort, udid))
+	res, err := c.Get(fmt.Sprintf("http://%s:%d/tunnel/%s", tunnelInfoHost, tunnelInfoPort, udid))
 	if err != nil {
 		return Tunnel{}, fmt.Errorf("TunnelInfoForDevice: failed to get tunnel info: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -1118,7 +1118,7 @@ The commands work as following:
 			}
 			startTunnel(context.TODO(), pairRecordsPath, tunnelInfoPort, useUserspaceNetworking)
 		} else if listCommand {
-			tunnels, err := tunnel.ListRunningTunnels(tunnelInfoPort)
+			tunnels, err := tunnel.ListRunningTunnels(tunnelInfoHost, tunnelInfoPort)
 			if err != nil {
 				exitIfError("failed to get tunnel infos", err)
 			}
@@ -2276,6 +2276,7 @@ func deviceWithRsdProvider(device ios.DeviceEntry, udid string, address string, 
 	rsdProvider, err := rsdService.Handshake()
 	device1, err := ios.GetDeviceWithAddress(udid, address, rsdProvider)
 	device1.UserspaceTUN = device.UserspaceTUN
+	device1.UserspaceTUNHost = device.UserspaceTUNHost
 	device1.UserspaceTUNPort = device.UserspaceTUNPort
 	exitIfError("error getting devicelist", err)
 

--- a/main.go
+++ b/main.go
@@ -323,6 +323,11 @@ The commands work as following:
 		return
 	}
 
+	tunnelInfoHost, err := arguments.String("--tunnel-info-host")
+	if err != nil {
+		tunnelInfoHost = ios.HttpApiHost()
+	}
+
 	tunnelInfoPort, err := arguments.Int("--tunnel-info-port")
 	if err != nil {
 		tunnelInfoPort = ios.HttpApiPort()
@@ -333,6 +338,11 @@ The commands work as following:
 	udid, _ := arguments.String("--udid")
 	address, addressErr := arguments.String("--address")
 	rsdPort, rsdErr := arguments.Int("--rsd-port")
+	userspaceTunnelHost, userspaceTunnelHostErr := arguments.String("--userspace-host")
+	if userspaceTunnelHostErr != nil {
+		userspaceTunnelHost = ios.HttpApiHost()
+	}
+
 	userspaceTunnelPort, userspaceTunnelErr := arguments.Int("--userspace-port")
 
 	device, err := ios.GetDevice(udid)
@@ -342,13 +352,15 @@ The commands work as following:
 		if addressErr == nil && rsdErr == nil {
 			if userspaceTunnelErr == nil {
 				device.UserspaceTUN = true
+				device.UserspaceTUNHost = userspaceTunnelHost
 				device.UserspaceTUNPort = userspaceTunnelPort
 			}
 			device = deviceWithRsdProvider(device, udid, address, rsdPort)
 		} else {
-			info, err := tunnel.TunnelInfoForDevice(device.Properties.SerialNumber, tunnelInfoPort)
+			info, err := tunnel.TunnelInfoForDevice(device.Properties.SerialNumber, tunnelInfoHost, tunnelInfoPort)
 			if err == nil {
 				device.UserspaceTUNPort = info.UserspaceTUNPort
+				device.UserspaceTUNHost = userspaceTunnelHost
 				device.UserspaceTUN = info.UserspaceTUN
 				device = deviceWithRsdProvider(device, udid, info.Address, info.RsdPort)
 			} else {

--- a/restapi/api/middleware.go
+++ b/restapi/api/middleware.go
@@ -33,7 +33,7 @@ func DeviceMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		info, err := tunnel.TunnelInfoForDevice(device.Properties.SerialNumber, ios.HttpApiPort())
+		info, err := tunnel.TunnelInfoForDevice(device.Properties.SerialNumber, ios.HttpApiHost(), ios.HttpApiPort())
 		if err == nil {
 			log.WithField("udid", device.Properties.SerialNumber).Printf("Received tunnel info %v", info)
 


### PR DESCRIPTION
by setting the host for tunnel info http api and tunnel sockets the go-ios client can run remotely. Main use case for me is using the devices connected to my mac inside docker desktop 