### PR TITLE
Draft: Disable memory limit for pid

### DIFF
--- a/ios/instruments/processcontrol.go
+++ b/ios/instruments/processcontrol.go
@@ -23,8 +23,8 @@ func (p *ProcessControl) LaunchApp(bundleID string, my_opts map[string]any) (uin
 	}
 	maps.Copy(opts, my_opts)
 	// Xcode sends all these, no idea if we need them for sth. later.
-	//"CA_ASSERT_MAIN_THREAD_TRANSACTIONS": "0", "CA_DEBUG_TRANSACTIONS": "0", "LLVM_PROFILE_FILE": "/dev/null", "METAL_DEBUG_ERROR_MODE": "0", "METAL_DEVICE_WRAPPER_TYPE": "1",
-	//"OS_ACTIVITY_DT_MODE": "YES", "SQLITE_ENABLE_THREAD_ASSERTIONS": "1", "__XPC_LLVM_PROFILE_FILE": "/dev/null"
+	// "CA_ASSERT_MAIN_THREAD_TRANSACTIONS": "0", "CA_DEBUG_TRANSACTIONS": "0", "LLVM_PROFILE_FILE": "/dev/null", "METAL_DEBUG_ERROR_MODE": "0", "METAL_DEVICE_WRAPPER_TYPE": "1",
+	// "OS_ACTIVITY_DT_MODE": "YES", "SQLITE_ENABLE_THREAD_ASSERTIONS": "1", "__XPC_LLVM_PROFILE_FILE": "/dev/null"
 	// NSUnbufferedIO seems to make the app send its logs via instruments using the outputReceived:fromProcess:atTime: selector
 	// We'll supply per default to get logs
 	env := map[string]interface{}{"NSUnbufferedIO": "YES"}
@@ -40,8 +40,8 @@ func (p *ProcessControl) LaunchAppWithArgs(bundleID string, my_args []interface{
 	}
 	maps.Copy(opts, my_opts)
 	// Xcode sends all these, no idea if we need them for sth. later.
-	//"CA_ASSERT_MAIN_THREAD_TRANSACTIONS": "0", "CA_DEBUG_TRANSACTIONS": "0", "LLVM_PROFILE_FILE": "/dev/null", "METAL_DEBUG_ERROR_MODE": "0", "METAL_DEVICE_WRAPPER_TYPE": "1",
-	//"OS_ACTIVITY_DT_MODE": "YES", "SQLITE_ENABLE_THREAD_ASSERTIONS": "1", "__XPC_LLVM_PROFILE_FILE": "/dev/null"
+	// "CA_ASSERT_MAIN_THREAD_TRANSACTIONS": "0", "CA_DEBUG_TRANSACTIONS": "0", "LLVM_PROFILE_FILE": "/dev/null", "METAL_DEBUG_ERROR_MODE": "0", "METAL_DEVICE_WRAPPER_TYPE": "1",
+	// "OS_ACTIVITY_DT_MODE": "YES", "SQLITE_ENABLE_THREAD_ASSERTIONS": "1", "__XPC_LLVM_PROFILE_FILE": "/dev/null"
 	// NSUnbufferedIO seems to make the app send its logs via instruments using the outputReceived:fromProcess:atTime: selector
 	// We'll supply per default to get logs
 	env := map[string]interface{}{"NSUnbufferedIO": "YES"}
@@ -60,6 +60,18 @@ func NewProcessControl(device ios.DeviceEntry) (*ProcessControl, error) {
 	}
 	processControlChannel := dtxConn.RequestChannelIdentifier(procControlChannel, loggingDispatcher{dtxConn})
 	return &ProcessControl{processControlChannel: processControlChannel, conn: dtxConn}, nil
+}
+
+// DisableMemoryLimit disables the memory limit of a process.
+func (p ProcessControl) DisableMemoryLimit(pid uint64) (bool, error) {
+	msg, err := p.processControlChannel.MethodCall("requestDisableMemoryLimitsForPid:", pid)
+	if err != nil {
+		return false, err
+	}
+	if disabled, ok := msg.Payload[0].(bool); ok {
+		return disabled, nil
+	}
+	return false, fmt.Errorf("expected int 0 or 1 as payload of msg: %v", msg)
 }
 
 // KillProcess kills the process on the device.

--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ Usage:
   ios apps [--system] [--all] [--list] [--filesharing] [options]
   ios launch <bundleID> [--wait] [--kill-existing] [--arg=<a>]... [--env=<e>]... [options]
   ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options]
+  ios memlimitoff (--process=<processName>) [options]
   ios runtest [--bundle-id=<bundleid>] [--test-runner-bundle-id=<testrunnerbundleid>] [--xctest-config=<xctestconfig>] [--log-output=<file>] [--xctest] [--test-to-run=<tests>]... [--test-to-skip=<tests>]... [--env=<e>]... [options]
   ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--log-output=<file>] [--arg=<a>]... [--env=<e>]... [options]
   ios ax [--font=<fontSize>] [options]
@@ -226,6 +227,7 @@ The commands work as following:
    ios apps [--system] [--all] [--list] [--filesharing]               Retrieves a list of installed applications. --system prints out preinstalled system apps. --all prints all apps, including system, user, and hidden apps. --list only prints bundle ID, bundle name and version number. --filesharing only prints apps which enable documents sharing.
    ios launch <bundleID> [--wait] [--kill-existing] [--arg=<a>]... [--env=<e>]... [options] Launch app with the bundleID on the device. Get your bundle ID from the apps command. --wait keeps the connection open if you want logs.
    ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options] Kill app with the specified bundleID, process id, or process name on the device.
+   ios memlimitoff (--process=<processName>) [options]                Waives memory limit set by iOS (For instance a Broadcast Extension limit is 50 MB).
    ios runtest [--bundle-id=<bundleid>] [--test-runner-bundle-id=<testbundleid>] [--xctest-config=<xctestconfig>] [--log-output=<file>] [--xctest] [--test-to-run=<tests>]... [--test-to-skip=<tests>]... [--env=<e>]... [options]                    Run a XCUITest. If you provide only bundle-id go-ios will try to dynamically create test-runner-bundle-id and xctest-config.
    >                                                                  If you provide '-' as log output, it prints resuts to stdout.
    >                                                                  To be able to filter for tests to run or skip, use one argument per test selector. Example: runtest --test-to-run=(TestTarget.)TestClass/testMethod --test-to-run=(TestTarget.)TestClass/testMethod (the value for 'TestTarget' is optional)
@@ -839,6 +841,28 @@ The commands work as following:
 	b, _ = arguments.Bool("sysmontap")
 	if b {
 		printSysmontapStats(device)
+	}
+
+	b, _ = arguments.Bool("memlimitoff")
+	if b {
+		processName, _ := arguments.String("--process")
+
+		pControl, err := instruments.NewProcessControl(device)
+		exitIfError("processcontrol failed", err)
+		defer pControl.Close()
+
+		svc, err := instruments.NewDeviceInfoService(device)
+		exitIfError("failed opening deviceInfoService for getting process list", err)
+		defer svc.Close()
+
+		processList, _ := svc.ProcessList()
+		for _, process := range processList {
+			if process.Pid > 1 && process.Name == processName {
+				disabled, err := pControl.DisableMemoryLimit(process.Pid)
+				exitIfError("DisableMemoryLimit failed", err)
+				log.WithFields(log.Fields{"process": process.Name, "pid": process.Pid}).Info("memory limit is off: ", disabled)
+			}
+		}
 	}
 
 	b, _ = arguments.Bool("kill")


### PR DESCRIPTION
iOS dictates a memory limit for apps and extensions. One of the extension is a Broadcast Extension with a limit of 50 MB. With the call `- (NSNumber *)requestDisableMemoryLimitsForPid:(int)arg1;` we could try to waive this limit as Xcode does this when view debugger is being attached.

<img width="497" alt="Screenshot 2024-11-13 at 3 48 58 PM" src="https://github.com/user-attachments/assets/e9619469-9753-461b-9465-8141a93b0601">

