### PR TITLE
Check for non-empty 'Error' string in 'StartSessionResponse'

### DIFF
--- a/ios/startsession.go
+++ b/ios/startsession.go
@@ -2,6 +2,7 @@ package ios
 
 import (
 	"bytes"
+	"errors"
 
 	plist "howett.net/plist"
 )
@@ -29,6 +30,7 @@ type StartSessionResponse struct {
 	EnableSessionSSL bool
 	Request          string
 	SessionID        string
+	Error            string
 }
 
 func startSessionResponsefromBytes(plistBytes []byte) StartSessionResponse {
@@ -52,6 +54,9 @@ func (lockDownConn *LockDownConnection) StartSession(pairRecord PairRecord) (Sta
 		return StartSessionResponse{}, err
 	}
 	response := startSessionResponsefromBytes(resp)
+	if response.Error != "" {
+		return StartSessionResponse{}, errors.New(response.Error)
+	}
 	lockDownConn.sessionID = response.SessionID
 	if response.EnableSessionSSL {
 		err = lockDownConn.deviceConnection.EnableSessionSsl(pairRecord)

--- a/ios/startsession.go
+++ b/ios/startsession.go
@@ -2,7 +2,7 @@ package ios
 
 import (
 	"bytes"
-	"errors"
+	"fmt"
 
 	plist "howett.net/plist"
 )

--- a/ios/startsession.go
+++ b/ios/startsession.go
@@ -55,7 +55,7 @@ func (lockDownConn *LockDownConnection) StartSession(pairRecord PairRecord) (Sta
 	}
 	response := startSessionResponsefromBytes(resp)
 	if response.Error != "" {
-		return StartSessionResponse{}, errors.New(response.Error)
+		return StartSessionResponse{}, fmt.Errorf("failed to start new lockdown session: %s", response.Error)
 	}
 	lockDownConn.sessionID = response.SessionID
 	if response.EnableSessionSSL {


### PR DESCRIPTION
Issue: When sending a `StartSession` request, we just check if there was an error reading the response message. However, we don't check if the response object itself contains an `Error` field.

Fix: Start checking for the `Error` field, and if present return an error accordingly.