### PR TITLE
Fix: pass primitive pid to memory limit request

### DIFF
--- a/ios/dtx_codec/channel.go
+++ b/ios/dtx_codec/channel.go
@@ -49,19 +49,36 @@ func (d *Channel) ReceiveMethodCall(selector string) Message {
 // MethodCall is the standard DTX style remote method invocation pattern. The ObjectiveC Selector goes as a NSKeyedArchiver.archived NSString into the
 // DTXMessage payload, and the arguments are separately NSKeyArchiver.archived and put into the Auxiliary DTXPrimitiveDictionary. It returns the response message and an error.
 func (d *Channel) MethodCall(selector string, args ...interface{}) (Message, error) {
-	payload, _ := nskeyedarchiver.ArchiveBin(selector)
 	auxiliary := NewPrimitiveDictionary()
 	for _, arg := range args {
 		auxiliary.AddNsKeyedArchivedObject(arg)
 	}
+
+	return d.methodCallWithReply(selector, auxiliary)
+}
+
+// MethodCallPrimitive is a DTX style remote method invocation pattern. The ObjectiveC Selector goes as a NSKeyedArchiver.archived NSString into the
+// DTXMessage payload, and the primitive arguments put into the Auxiliary DTXPrimitiveDictionary. It returns the response message and an error.
+func (d *Channel) MethodCallPrimitive(selector string, args ...int) (Message, error) {
+	auxiliary := NewPrimitiveDictionary()
+	for _, arg := range args {
+		auxiliary.AddInt32(arg)
+	}
+
+	return d.methodCallWithReply(selector, auxiliary)
+}
+
+func (d *Channel) methodCallWithReply(selector string, auxiliary PrimitiveDictionary) (Message, error) {
+	payload, _ := nskeyedarchiver.ArchiveBin(selector)
 	msg, err := d.SendAndAwaitReply(true, Methodinvocation, payload, auxiliary)
 	if err != nil {
 		log.WithFields(log.Fields{"channel_id": d.channelName, "error": err, "methodselector": selector}).Info("failed starting invoking method")
 		return msg, err
 	}
 	if msg.HasError() {
-		return msg, fmt.Errorf("Failed invoking method '%s' with error: %s", selector, msg.Payload[0])
+		return msg, fmt.Errorf("failed invoking method '%s' with error: %s", selector, msg.Payload[0])
 	}
+
 	return msg, nil
 }
 

--- a/ios/instruments/processcontrol.go
+++ b/ios/instruments/processcontrol.go
@@ -64,7 +64,7 @@ func NewProcessControl(device ios.DeviceEntry) (*ProcessControl, error) {
 
 // DisableMemoryLimit disables the memory limit of a process.
 func (p ProcessControl) DisableMemoryLimit(pid uint64) (bool, error) {
-	msg, err := p.processControlChannel.MethodCall("requestDisableMemoryLimitsForPid:", pid)
+	msg, err := p.processControlChannel.MethodCallPrimitive("requestDisableMemoryLimitsForPid:", int(pid))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
The `requestDisableMemoryLimitsForPid` sent by Xcode has a smaller plist:

```
00000230: 00 00 00 0A 00 00 00 06  00 00 00 8A 03 00 00 00  ................
00000240: 00 00 00 62 70 6C 69 73  74 30 30 D4 01 02 03 04  ...bplist00.....
00000250: 05 06 07 0A 58 24 76 65  72 73 69 6F 6E 59 24 61  ....X$versionY$a
00000260: 72 63 68 69 76 65 72 54  24 74 6F 70 58 24 6F 62  rchiverT$topX$ob
00000270: 6A 65 63 74 73 12 00 01  86 A0 5F 10 0F 4E 53 4B  jects....._..NSK
00000280: 65 79 65 64 41 72 63 68  69 76 65 72 D1 08 09 54  eyedArchiver...T
00000290: 72 6F 6F 74 80 01 A2 0B  0C 55 24 6E 75 6C 6C 5F  root.....U$null_
000002A0: 10 21 72 65 71 75 65 73  74 44 69 73 61 62 6C 65  .!requestDisable
000002B0: 4D 65 6D 6F 72 79 4C 69  6D 69 74 73 46 6F 72 50  MemoryLimitsForP
000002C0: 69 64 3A 08 11 1A 24 29  32 37 49 4C 51 53 56 5C  id:...$)27ILQSV\
000002D0: 00 00 00 00 00 00 01 01  00 00 00 00 00 00 00 0D  ................
000002E0: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 80  ................
```

while go-ios with the new method:
```
00000290  00 00 00 00 00 00 00 00  00 00 00 00 00 00 5F 62  .............._b
000002A0  70 6C 69 73 74 30 30 D4  01 02 03 04 05 06 09 0C  plist00.........
000002B0  59 24 61 72 63 68 69 76  65 72 58 24 6F 62 6A 65  Y$archiverX$obje
000002C0  63 74 73 54 24 74 6F 70  58 24 76 65 72 73 69 6F  ctsT$topX$versio
000002D0  6E 5F 10 0F 4E 53 4B 65  79 65 64 41 72 63 68 69  n_..NSKeyedArchi
000002E0  76 65 72 A2 07 08 55 24  6E 75 6C 6C 5F 10 21 72  ver...U$null_.!r
000002F0  65 71 75 65 73 74 44 69  73 61 62 6C 65 4D 65 6D  equestDisableMem
00000300  6F 72 79 4C 69 6D 69 74  73 46 6F 72 50 69 64 3A  oryLimitsForPid:
00000310  D1 0A 0B 54 72 6F 6F 74  80 01 12 00 01 86 A0 08  ...Troot........
00000320  11 1B 24 29 32 44 47 4D  71 74 79 7B 00 00 00 00  ..$)2DGMqty{....
00000330  00 00 01 01 00 00 00 00  00 00 00 0D 00 00 00 00  ................
00000340  00 00 00 00 00 00 00 00  00 00 00 80              ............
```

wrapping the primitive int32 into a plist making the call return `false` (-1 error code) all the time apparently calculated from here: https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/kern/kern_memorystatus.c#L7748