### PR TITLE
Allow ResponseWithReturnValueInPayload messages to be passed to dtxConnection.Dispatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cziter15/go-ios
+module github.com/danielpaulus/go-ios
 
 go 1.22.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/danielpaulus/go-ios
+module github.com/cziter15/go-ios
 
 go 1.22.0
 

--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -131,7 +131,7 @@ func (g GlobalDispatcher) Dispatch(msg Message) {
 	if msg.HasError() {
 		log.Error(msg.Payload[0])
 	}
-	if msg.PayloadHeader.MessageType == UnknownTypeOne {
+	if msg.PayloadHeader.MessageType == UnknownTypeOne || msg.PayloadHeader.MessageType == ResponseWithReturnValueInPayload {
 		g.dtxConnection.Dispatch(msg)
 	}
 }


### PR DESCRIPTION
Allow ResponseWithReturnValueInPayload messages to be passed to dtxConnection.Dispatch.
That makes them to be able to reach the Message Dispatcher and this is useful in some cases (instruments).