### PR TITLE
builds: add linux-arm64 binary to the npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build
         run: |
-          ((Get-Content -path main.go -Raw) -replace "local-build","${{ steps.create_release.outputs.current_tag }}") | Set-Content -Path main.go  
+          ((Get-Content -path main.go -Raw) -replace "local-build","${{ steps.create_release.outputs.current_tag }}") | Set-Content -Path main.go
           mkdir bin
           go build -ldflags="-s -w" -o bin/ios.exe
           "${{ steps.create_release.outputs.current_tag }}" | Out-File -Encoding utf8NoBOM release_tag -NoNewline
@@ -122,9 +122,14 @@ jobs:
 
       - name: Build
         run: |
+          go install github.com/konoui/lipo@v0.9.2
+
           sed -i 's/version \= \"local-build\"/version = \"${{ env.release_tag }}\"/' main.go
           mkdir bin
-          go build -ldflags="-s -w" -o bin/ios
+          GOARCH=arm64 go build -ldflags="-s -w" -o bin/ios-arm64
+          GOARCH=amd64 go build -ldflags="-s -w" -o bin/ios-amd64
+          lipo bin/ios-amd64 bin/ios-arm64 -create -output bin/ios
+
           cp ./mac-bin/go-ios-mac.zip .
           cp ./win-bin/go-ios-win.zip .
           zip -j go-ios-linux.zip bin/ios
@@ -143,11 +148,13 @@ jobs:
           mkdir ./npm_publish/dist/go-ios-darwin-amd64_darwin_amd64
           mkdir ./npm_publish/dist/go-ios-darwin-arm64_darwin_arm64
           mkdir ./npm_publish/dist/go-ios-linux-amd64_linux_amd64
+          mkdir ./npm_publish/dist/go-ios-linux-arm64_linux_arm64
           mkdir ./npm_publish/dist/go-ios-windows-amd64_windows_amd64
           cp ./mac-bin/ios ./npm_publish/dist/go-ios-darwin-amd64_darwin_amd64/ios
           cp ./mac-bin/ios ./npm_publish/dist/go-ios-darwin-arm64_darwin_arm64/ios
           cp ./win-bin/ios.exe ./npm_publish/dist/go-ios-windows-amd64_windows_amd64/ios.exe
           cp ./bin/ios ./npm_publish/dist/go-ios-linux-amd64_linux_amd64/ios
+          cp ./bin/ios ./npm_publish/dist/go-ios-linux-arm64_linux_arm64/ios
           echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
           cd npm_publish
           sed -i 's/\"local-build\"/\"${{ env.release_tag }}\"/' package.json


### PR DESCRIPTION
Mostly replicating what is done for macOS arm64 build; build with GOARCH flag and use `lipo` to build a fat binary. Needs a run in GH actions to confirm it's all working.

Fixes https://github.com/danielpaulus/go-ios/issues/318