### PR TITLE
postinstall: add arm64 as valid arch

### DIFF
--- a/npm_publish/postinstall.js
+++ b/npm_publish/postinstall.js
@@ -12,7 +12,8 @@ var path = require('path'),
 var ARCH_MAPPING = {
     "ia32": "386",
     "x64": "amd64",
-    "arm": "arm"
+    "arm": "arm",
+    "arm64": "arm64"
 };
 
 // Mapping between Node's `process.platform` to Golang's


### PR DESCRIPTION
https://github.com/danielpaulus/go-ios/pull/529 now publishes binaries for both `linux/amd64` and `linux/arm64` but turns out the postinstallation scripts had two different architecture maps and one was missing `arm64`