### PR TITLE
Set keepaliveidle time more aggressive against connection drops

### DIFF
--- a/ios/tunnel/userspace_tunnel.go
+++ b/ios/tunnel/userspace_tunnel.go
@@ -46,9 +46,15 @@ func (iface *UserSpaceTUNInterface) TunnelRWCThroughInterface(localPort uint16, 
 	if err != nil {
 		return fmt.Errorf("TunnelRWCThroughInterface: NewEndpoint failed: %+v", err)
 	}
+
 	ep.SocketOptions().SetKeepAlive(true)
+	// Set keep alive idle value more aggresive than the gVisor's 2 hours. NAT and Firewalls can drop the idle connections more aggresive.
+	p := tcpip.KeepaliveIdleOption(30 * time.Second)
+	ep.SetSockOpt(&p)
+
 	o := tcpip.KeepaliveIntervalOption(1 * time.Second)
 	ep.SetSockOpt(&o)
+
 	// Bind if a port is specified.
 	if localPort != 0 {
 		if err := ep.Bind(tcpip.FullAddress{Port: localPort}); err != nil {


### PR DESCRIPTION
Keepaliveidle time should be set more aggresive than the gVisor's 2 hours default idle time. Many NAT and firewalls drop the idle connections more aggressively (30-60 secs apparently).

Keepaliveinterval option doesn't take affect as the keep alive probe doesn't start before the idle time reaches. It is 2 hours by default and before it reaches NAT/Firewall close the connection unlike kernel mode TUN device,

With this change the idle time will be more aggressive and according to several tests this fix connection drops. Long running test more than 24 hours achieved with this fix.