### PR TITLE
Tunnel mode selection feature for agent mode.

### DIFF
--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -54,7 +54,7 @@ func WaitUntilAgentReady() bool {
 	}
 }
 
-func RunAgent(args ...string) error {
+func RunAgent(mode string, args ...string) error {
 	if IsAgentRunning() {
 		return nil
 	}
@@ -64,8 +64,18 @@ func RunAgent(args ...string) error {
 		return fmt.Errorf("RunAgent: failed to get executable path: %w", err)
 	}
 
-	cmd := exec.Command(ex, append([]string{"tunnel", "start"}, args...)...)
+	var cmd *exec.Cmd
+
+	if mode == "kernel" {
+		cmd = exec.Command(ex, append([]string{"tunnel", "start"}, args...)...)
+	}
+
+	if mode == "user" {
+		cmd = exec.Command(ex, append([]string{"tunnel", "start", "--userspace"}, args...)...)
+	}
+
 	err = cmd.Start()
+
 	if err != nil {
 		return fmt.Errorf("RunAgent: failed to start agent: %w", err)
 	}

--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -65,13 +65,13 @@ func RunAgent(mode string, args ...string) error {
 	}
 
 	var cmd *exec.Cmd
-
-	if mode == "kernel" {
+	switch mode {
+	case "kernel":
 		cmd = exec.Command(ex, append([]string{"tunnel", "start"}, args...)...)
-	}
-
-	if mode == "user" {
+	case "user":
 		cmd = exec.Command(ex, append([]string{"tunnel", "start", "--userspace"}, args...)...)
+	default:
+		return fmt.Errorf("RunAgent: unknown mode: %s. Only 'kernel' and 'user' are supported", mode)
 	}
 
 	err = cmd.Start()

--- a/main.go
+++ b/main.go
@@ -295,11 +295,12 @@ The commands work as following:
 	log.Debug(arguments)
 
 	skipAgent, _ := os.LookupEnv("ENABLE_GO_IOS_AGENT")
-	if skipAgent == "yes" {
-		tunnel.RunAgent()
+	if skipAgent == "user" || skipAgent == "kernel" {
+		tunnel.RunAgent(skipAgent)
 	}
+
 	if !tunnel.IsAgentRunning() {
-		log.Warn("go-ios agent is not running. You might need to start it with 'ios tunnel start' for ios17+. Use ENABLE_GO_IOS_AGENT=yes for experimental daemon mode.")
+		log.Warn("go-ios agent is not running. You might need to start it with 'ios tunnel start' for ios17+. Use ENABLE_GO_IOS_AGENT=user for userspace tunnel or ENABLE_GO_IOS_AGENT=kernel for kernel tunnel for the experimental daemon mode.")
 	}
 	shouldPrintVersionNoDashes, _ := arguments.Bool("version")
 	shouldPrintVersion, _ := arguments.Bool("--version")


### PR DESCRIPTION
With this change ENABLE_GO_IOS_AGENT can be set to "user" or "kernel" to start selective mode tunnel.