### PR TITLE
Add missing proxydispatcher cases + fix productModuleName for iOS <17

### DIFF
--- a/ios/testmanagerd/proxydispatcher.go
+++ b/ios/testmanagerd/proxydispatcher.go
@@ -288,6 +288,32 @@ func (p proxyDispatcher) Dispatch(m dtx.Message) {
 			}
 
 			p.testListener.testCaseDidStartForClass(testClass, testMethod)
+		case "_XCT_testCaseDidStartWithIdentifier:iteration:":
+			argumentLengthErr := assertArgumentsLengthEqual(m, 2)
+			if argumentLengthErr != nil {
+				decoderErr = argumentLengthErr
+				break
+			}
+
+			testIdentifier, decoderErr := extractTestIdentifierArg(m, 0)
+			if decoderErr != nil {
+				break
+			}
+
+			p.testListener.testCaseDidStartForClass(testIdentifier.C[0], testIdentifier.C[1])
+		case "_XCT_testCaseDidStartWithIdentifier:":
+			argumentLengthErr := assertArgumentsLengthEqual(m, 1)
+			if argumentLengthErr != nil {
+				decoderErr = argumentLengthErr
+				break
+			}
+
+			testIdentifier, decoderErr := extractTestIdentifierArg(m, 0)
+			if decoderErr != nil {
+				break
+			}
+
+			p.testListener.testCaseDidStartForClass(testIdentifier.C[0], testIdentifier.C[1])
 		case "_XCT_testCaseDidStartWithIdentifier:testCaseRunConfiguration:":
 			argumentLengthErr := assertArgumentsLengthEqual(m, 2)
 			if argumentLengthErr != nil {

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -554,7 +554,8 @@ func createTestConfigOnDevice(testSessionID uuid.UUID, info testInfo, houseArres
 
 	testBundleURL := path.Join(info.testApp.path, "PlugIns", xctestConfigFileName)
 
-	config := nskeyedarchiver.NewXCTestConfiguration(info.targetApp.bundleName, testSessionID, info.targetApp.bundleID, info.targetApp.path, testBundleURL, testsToRun, testsToSkip, isXCTest, version)
+	productModuleName := strings.ReplaceAll(xctestConfigFileName, ".xctest", "")
+	config := nskeyedarchiver.NewXCTestConfiguration(productModuleName, testSessionID, info.targetApp.bundleID, info.targetApp.path, testBundleURL, testsToRun, testsToSkip, isXCTest, version)
 	result, err := nskeyedarchiver.ArchiveXML(config)
 	if err != nil {
 		return "", nskeyedarchiver.XCTestConfiguration{}, err
@@ -564,7 +565,7 @@ func createTestConfigOnDevice(testSessionID uuid.UUID, info testInfo, houseArres
 	if err != nil {
 		return "", nskeyedarchiver.XCTestConfiguration{}, err
 	}
-	return xctestConfigPath, nskeyedarchiver.NewXCTestConfiguration(info.targetApp.bundleName, testSessionID, info.targetApp.bundleID, info.targetApp.path, testBundleURL, testsToRun, testsToSkip, isXCTest, version), nil
+	return xctestConfigPath, nskeyedarchiver.NewXCTestConfiguration(productModuleName, testSessionID, info.targetApp.bundleID, info.targetApp.path, testBundleURL, testsToRun, testsToSkip, isXCTest, version), nil
 }
 
 func createTestConfig(info testInfo, testSessionID uuid.UUID, xctestConfigFileName string, testsToRun []string, testsToSkip []string, isXCTest bool, version *semver.Version) nskeyedarchiver.XCTestConfiguration {


### PR DESCRIPTION
The `method` switch in proxydispatcher::Dispatch was missing a few cases, which led to missing XCUITest results when using go-ios on iOS <17 devices.

Additionally, the `productModuleName` field in the XCTestConfiguration appeared to be wrong (also for iOS <17 devices), leading to the same issue of missing test results. It has been changed to match the iOS 17 config, which seems to work better for the test cases I've tried.