### PR TITLE
Allow ResponseWithReturnValueInPayload to be passed into dtxConnection.Dispatch

### DIFF
--- a/ios/dtx_codec/connection.go
+++ b/ios/dtx_codec/connection.go
@@ -131,7 +131,7 @@ func (g GlobalDispatcher) Dispatch(msg Message) {
 	if msg.HasError() {
 		log.Error(msg.Payload[0])
 	}
-	if msg.PayloadHeader.MessageType == UnknownTypeOne {
+	if msg.PayloadHeader.MessageType == UnknownTypeOne || msg.PayloadHeader.MessageType == ResponseWithReturnValueInPayload {
 		g.dtxConnection.Dispatch(msg)
 	}
 }


### PR DESCRIPTION
**DESCRIPTION**

When using a custom dispatcher for channel graphics messages, it appears that the `ResponseWithReturnValueInPayload` message type is returned periodically. However, the `func (g GlobalDispatcher) Dispatch(msg Message)` function currently only handles `UnknownTypeOne`. To properly receive GPU statistics, I had to modify the dispatcher to handle the `ResponseWithReturnValueInPayload` type as well, ensuring it is correctly passed into the Dispatch function.

Here's pseudocode for reference:
```Go
type mDispatcher struct {
}

func (md*mDispatcher ) Dispatch(msg dtx.Message) {
}

func (mp* mProvider)  InitializeWithDispatcher(device ios.DeviceEntry, msgDispatcher dtx.Dispatcher) error {
	conn, err := connectInstruments(device)
	conn.MessageDispatcher = msgDispatcher
	channel := mp.dtxConn.RequestChannelIdentifier(graphicsChannelName, nil)
	_, err := channel.MethodCall("startSamplingAtTimeInterval:", 0)
	conn.MessageDispatcher = msgDispatcher
	mp.dtxConn = conn
	return nil
}
```