### PR TITLE
Additional Battery IORegistry values

### DIFF
--- a/ios/diagnostics/request.go
+++ b/ios/diagnostics/request.go
@@ -44,6 +44,12 @@ type IORegistry struct {
 	Voltage         int
 	IsCharging      bool
 	CurrentCapacity int
+
+	DesignCapacity        uint64
+	NominalChargeCapacity uint64
+	CycleCount            uint64
+	AtCriticalLevel       bool
+	AtWarnLevel           bool
 }
 
 type WiFi struct {


### PR DESCRIPTION
I added some IORegistry values to the `batteryregistry` command, useful to parse the device battery conditions