### PR TITLE
make AppInfo a map to allow reading all values

### DIFF
--- a/ios/debugserver/debugserver.go
+++ b/ios/debugserver/debugserver.go
@@ -176,8 +176,8 @@ func Start(device ios.DeviceEntry, appPath string, stopAtEntry bool) error {
 	}
 	var container string
 	for _, ai := range appinfo {
-		if ai.CFBundleIdentifier == bundleId {
-			container = ai.Path
+		if ai.CFBundleIdentifier() == bundleId {
+			container = ai.Path()
 			break
 		}
 	}

--- a/ios/installationproxy/installationproxy.go
+++ b/ios/installationproxy/installationproxy.go
@@ -134,30 +134,7 @@ func plistFromBytes(plistBytes []byte) (BrowseResponse, error) {
 }
 
 func browseApps(applicationType string, showLaunchProhibitedApps bool) map[string]interface{} {
-	returnAttributes := []string{
-		"ApplicationDSID",
-		"ApplicationType",
-		"CFBundleDisplayName",
-		"CFBundleExecutable",
-		"CFBundleIdentifier",
-		"CFBundleName",
-		"CFBundleShortVersionString",
-		"CFBundleVersion",
-		"Container",
-		"Entitlements",
-		"EnvironmentVariables",
-		"MinimumOSVersion",
-		"Path",
-		"ProfileValidated",
-		"SBAppTags",
-		"SignerIdentity",
-		"UIDeviceFamily",
-		"UIRequiredDeviceCapabilities",
-		"UIFileSharingEnabled",
-	}
-	clientOptions := map[string]interface{}{
-		"ReturnAttributes": returnAttributes,
-	}
+	clientOptions := map[string]any{}
 	if applicationType != "" && applicationType != "Filesharing" {
 		clientOptions["ApplicationType"] = applicationType
 	}
@@ -173,24 +150,53 @@ type BrowseResponse struct {
 	Status        string
 	CurrentList   []AppInfo
 }
-type AppInfo struct {
-	ApplicationDSID              int
-	ApplicationType              string
-	CFBundleDisplayName          string
-	CFBundleExecutable           string
-	CFBundleIdentifier           string
-	CFBundleName                 string
-	CFBundleShortVersionString   string
-	CFBundleVersion              string
-	Container                    string
-	Entitlements                 map[string]interface{}
-	EnvironmentVariables         map[string]interface{}
-	MinimumOSVersion             string
-	Path                         string
-	ProfileValidated             bool
-	SBAppTags                    []string
-	SignerIdentity               string
-	UIDeviceFamily               []int
-	UIRequiredDeviceCapabilities []string
-	UIFileSharingEnabled         bool
+type AppInfo map[string]any
+
+func (a AppInfo) CFBundleIdentifier() string {
+	if bundleId, ok := a["CFBundleIdentifier"].(string); ok {
+		return bundleId
+	}
+	return ""
+}
+
+func (a AppInfo) Path() string {
+	if path, ok := a["Path"].(string); ok {
+		return path
+	}
+	return ""
+}
+
+func (a AppInfo) CFBundleName() string {
+	if bundleName, ok := a["CFBundleName"].(string); ok {
+		return bundleName
+	}
+	return ""
+}
+
+func (a AppInfo) EnvironmentVariables() map[string]any {
+	if envVars, ok := a["EnvironmentVariables"].(map[string]any); ok {
+		return envVars
+	}
+	return make(map[string]any)
+}
+
+func (a AppInfo) CFBundleExecutable() string {
+	if executable, ok := a["CFBundleExecutable"].(string); ok {
+		return executable
+	}
+	return ""
+}
+
+func (a AppInfo) CFBundleShortVersionString() string {
+	if shortVersion, ok := a["CFBundleShortVersionString"].(string); ok {
+		return shortVersion
+	}
+	return ""
+}
+
+func (a AppInfo) UIFileSharingEnabled() bool {
+	if fileSharingEnabled, ok := a["UIFileSharingEnabled"].(bool); ok {
+		return fileSharingEnabled
+	}
+	return false
 }

--- a/ios/testmanagerd/xctestrunutils.go
+++ b/ios/testmanagerd/xctestrunutils.go
@@ -3,14 +3,15 @@ package testmanagerd
 import (
 	"bytes"
 	"fmt"
-	"github.com/danielpaulus/go-ios/ios"
-	"github.com/danielpaulus/go-ios/ios/installationproxy"
-	"howett.net/plist"
 	"io"
 	"maps"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/installationproxy"
+	"howett.net/plist"
 )
 
 // xctestrunutils provides utilities for parsing `.xctestrun` files.
@@ -198,8 +199,8 @@ func getBundleId(installedApps []installationproxy.AppInfo, uiTargetAppPath stri
 	var appNameWithSuffix = filepath.Base(uiTargetAppPath)
 	var uiTargetAppName = strings.TrimSuffix(appNameWithSuffix, ".app")
 	for _, app := range installedApps {
-		if app.CFBundleName == uiTargetAppName {
-			return app.CFBundleIdentifier
+		if app.CFBundleName() == uiTargetAppName {
+			return app.CFBundleIdentifier()
 		}
 	}
 	return ""

--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -603,13 +603,13 @@ type appInfo struct {
 
 func getappInfo(bundleID string, apps []installationproxy.AppInfo) (appInfo, error) {
 	for _, app := range apps {
-		if app.CFBundleIdentifier == bundleID {
+		if app.CFBundleIdentifier() == bundleID {
 			info := appInfo{
-				path:       app.Path,
-				bundleName: app.CFBundleName,
-				bundleID:   app.CFBundleIdentifier,
+				path:       app.Path(),
+				bundleName: app.CFBundleName(),
+				bundleID:   app.CFBundleIdentifier(),
 			}
-			if home, ok := app.EnvironmentVariables["HOME"].(string); ok {
+			if home, ok := app.EnvironmentVariables()["HOME"].(string); ok {
 				info.homePath = home
 			}
 			return info, nil

--- a/main.go
+++ b/main.go
@@ -906,8 +906,8 @@ The commands work as following:
 			exitIfError("browsing apps failed", err)
 
 			for _, app := range response {
-				if app.CFBundleIdentifier == bundleID {
-					processName = app.CFBundleExecutable
+				if app.CFBundleIdentifier() == bundleID {
+					processName = app.CFBundleExecutable()
 					break
 				}
 			}
@@ -1978,14 +1978,14 @@ func printInstalledApps(device ios.DeviceEntry, system bool, all bool, list bool
 
 	if list {
 		for _, v := range response {
-			fmt.Printf("%s %s %s\n", v.CFBundleIdentifier, v.CFBundleName, v.CFBundleShortVersionString)
+			fmt.Printf("%s %s %s\n", v.CFBundleIdentifier, v.CFBundleName, v.CFBundleShortVersionString())
 		}
 		return
 	}
 	if filesharing {
 		for _, v := range response {
-			if v.UIFileSharingEnabled {
-				fmt.Printf("%s %s %s\n", v.CFBundleIdentifier, v.CFBundleName, v.CFBundleShortVersionString)
+			if v.UIFileSharingEnabled() {
+				fmt.Printf("%s %s %s\n", v.CFBundleIdentifier, v.CFBundleName, v.CFBundleShortVersionString())
 			}
 		}
 		return
@@ -2157,7 +2157,7 @@ func outputProcessListNoJSON(device ios.DeviceEntry, processes []instruments.Pro
 		log.Error("browsing installed apps failed. bundleID will not be included in output")
 	} else {
 		for _, app := range response {
-			appInfoByExecutableName[app.CFBundleExecutable] = app
+			appInfoByExecutableName[app.CFBundleExecutable()] = app
 		}
 	}
 
@@ -2179,7 +2179,7 @@ func outputProcessListNoJSON(device ios.DeviceEntry, processes []instruments.Pro
 		bundleID := ""
 		appInfo, exists := appInfoByExecutableName[processInfo.Name]
 		if exists {
-			bundleID = appInfo.CFBundleIdentifier
+			bundleID = appInfo.CFBundleIdentifier()
 		}
 		fmt.Printf("%*d %-*s %s  %s\n", maxPidLength, processInfo.Pid, maxNameLength, processInfo.Name, processInfo.StartDate.Format("2006-01-02 15:04:05"), bundleID)
 	}


### PR DESCRIPTION
Currently we are explicitly requesting a set of attributes with `returnAttributes` when we list apps. There are more attributes available and if we don't specify the ones that we want to have, we get all of them.

With this change we put them into a map instead of having a struct with the limited set, and for the ones that we already use in the codebase helper methods were added