### PR TITLE
Fix unsaved in progress reports

### DIFF
--- a/ios/testmanagerd/testlistener.go
+++ b/ios/testmanagerd/testlistener.go
@@ -280,6 +280,10 @@ func (t *TestListener) TestRunnerKilled() {
 }
 
 func (t *TestListener) FinishWithError(err error) {
+	if t.runningTestSuite != nil {
+		t.TestSuites = append(t.TestSuites, *t.runningTestSuite)
+		t.runningTestSuite = nil
+	}
 	t.err = err
 	t.executionFinished()
 }

--- a/ios/testmanagerd/testlistener_test.go
+++ b/ios/testmanagerd/testlistener_test.go
@@ -1,6 +1,7 @@
 package testmanagerd
 
 import (
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -147,6 +148,18 @@ func TestFinishExecutingTestPlan(t *testing.T) {
 		testListener.testSuiteDidStart("mysuite", "2024-01-16 15:36:43 +0000")
 		testListener.testCaseDidStartForClass("mysuite", "mymethod")
 		testListener.testCaseDidFinishForTest("mysuite", "mymethod", "passed", 1.0)
+
+		t.Run("Check running test suite is saved on FinishWithError", func(t *testing.T) {
+			testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
+
+			testListener.testSuiteDidStart("mysuite", "2024-01-16 15:36:43 +0000")
+			testListener.testCaseDidStartForClass("mysuite", "mymethod")
+			testListener.FinishWithError(errors.New("test error"))
+
+			assert.Equal(t, 1, len(testListener.TestSuites))
+			assert.Equal(t, "mysuite", testListener.TestSuites[0].Name)
+			assert.Equal(t, 1, len(testListener.TestSuites[0].TestCases))
+		})
 
 		assert.Equal(t, 1, len(testListener.runningTestSuite.TestCases), "TestCase must be appended to list of test cases")
 		assert.Equal(t, TestCaseStatus("passed"), testListener.runningTestSuite.TestCases[0].Status)

--- a/ios/testmanagerd/xcuitestrunner_test.go
+++ b/ios/testmanagerd/xcuitestrunner_test.go
@@ -123,7 +123,7 @@ func signAndInstall(device ios.DeviceEntry) error {
 	svc, _ := installationproxy.New(device)
 	response, err := svc.BrowseUserApps()
 	for _, info := range response {
-		if bundleId == info.CFBundleIdentifier {
+		if bundleId == info.CFBundleIdentifier() {
 			log.Info("wda installed, skipping installation")
 			return nil
 		}


### PR DESCRIPTION
The PR fixes saving of in-progress tests reports that are interrupted when test runner is killed due to numerous reasons such as misuse of assertions in the unit test code.
With this PR, the report will preserver the important information about the test suite test results and provide an error line where the issue happens.

Before the fix

```
{"level":"info","msg":"Killing test runner with pid 948 ...","time":"2025-06-18T13:25:39+02:00"}
{"level":"info","msg":"Killing test runner with pid 948 ...","time":"2025-06-18T13:25:39+02:00"}
{"level":"info","msg":"Nothing to kill, process with pid 948 is already dead","time":"2025-06-18T13:25:39+02:00"}
{"level":"debug","msg":"Done running test","time":"2025-06-18T13:25:39+02:00"}
{"level":"debug","msg":"DTX Connection with EOF","time":"2025-06-18T13:25:39+02:00"}
{"error":"lost connection to testmanagerd. the test-runner may have been killed","level":"info","msg":"Failed running Xcuitest","time":"2025-06-18T13:25:39+02:00"}
[]{"level":"info","msg":"2 \u003cnil\u003e","time":"2025-06-18T13:25:39+02:00"}
Exiting.
2025-06-18T13:25:39+02:00 debug layer=debugger detaching
```

after the fix

```
{"error":"lost connection to testmanagerd. the test-runner may have been killed","level":"info","msg":"Failed running Xcuitest","time":"2025-06-17T20:17:16+02:00"}
[{Name:GeneralTest StartDate:2025-06-17 18:16:44 +0000 UTC EndDate:0001-01-01 00:00:00 +0000 UTC TestDuration:0s TotalDuration:0s TestCases:[{ClassName:GeneralTest MethodName:testDeleteSignOut Status:failed Err:{Message:XCTAssertTrue failed - Resections button is not tappable after 120 seconds File:file:///Users/user/Documents/GitHub/app/myUITests/PageObjects/MyCasesPage.swift Line:1144} Duration:0s Attachments:[{Name:App UI hierarchy for com.test.MakoApp Path:/var/folders/q2/pmncxy_n5vq0s_9tzz7j8nq40000gn/T/b6f55992-c5e8-4de4-b76f-b48f9cd6c01f Type:com.apple.dt.xctest.activity-type.internal Timestamp:7.71877016952447e+08 Activity:Collecting debug information to assist test failure triage UniformTypeIdentifier:public.plain-text}]}]}]{"level":"info","msg":"782 \u003cnil\u003e","time":"2025-06-17T20:17:16+02:00"}
Exiting.
2025-06-17T20:17:16+02:00 debug layer=debugger detaching
```