### PR TITLE
Implemented BDD tests support

### DIFF
--- a/ios/testmanagerd/testlistener.go
+++ b/ios/testmanagerd/testlistener.go
@@ -293,25 +293,31 @@ func (t *TestListener) Done() <-chan struct{} {
 }
 
 func (t *TestListener) findTestCase(className string, methodName string) *TestCase {
-	ts := t.findTestSuite(className)
-
-	if ts != nil && len(ts.TestCases) > 0 {
-		tc := &ts.TestCases[len(ts.TestCases)-1]
-		if tc.ClassName == className && tc.MethodName == methodName {
-			return tc
+	if ts := t.findTestSuite(className); ts != nil {
+		if len(ts.TestCases) > 0 {
+			tc := &ts.TestCases[len(ts.TestCases)-1]
+			if tc.ClassName == className && tc.MethodName == methodName {
+				return tc
+			}
 		}
 	}
-
+	
+	if t.runningTestSuite != nil {
+		// Search backwards to find the most recent matching test case without status
+		for i := len(t.runningTestSuite.TestCases) - 1; i >= 0; i-- {
+			tc := &t.runningTestSuite.TestCases[i]
+			if tc.ClassName == className && tc.MethodName == methodName && tc.Status == "" {
+				return tc
+			}
+		}
+	}
+	
 	return nil
 }
 
 func (t *TestListener) findTestSuite(className string) *TestSuite {
 	if t.runningTestSuite != nil {
 		if t.runningTestSuite.Name == className {
-			return t.runningTestSuite
-		}
-		// Check if className ends with "|suiteName"
-		if strings.HasSuffix(className, "|"+t.runningTestSuite.Name) {
 			return t.runningTestSuite
 		}
 	}

--- a/ios/testmanagerd/testlistener.go
+++ b/ios/testmanagerd/testlistener.go
@@ -301,7 +301,7 @@ func (t *TestListener) findTestCase(className string, methodName string) *TestCa
 			}
 		}
 	}
-	
+
 	if t.runningTestSuite != nil {
 		// Search backwards to find the most recent matching test case without status
 		for i := len(t.runningTestSuite.TestCases) - 1; i >= 0; i-- {
@@ -311,7 +311,7 @@ func (t *TestListener) findTestCase(className string, methodName string) *TestCa
 			}
 		}
 	}
-	
+
 	return nil
 }
 

--- a/ios/testmanagerd/testlistener.go
+++ b/ios/testmanagerd/testlistener.go
@@ -306,8 +306,14 @@ func (t *TestListener) findTestCase(className string, methodName string) *TestCa
 }
 
 func (t *TestListener) findTestSuite(className string) *TestSuite {
-	if t.runningTestSuite != nil && t.runningTestSuite.Name == className {
-		return t.runningTestSuite
+	if t.runningTestSuite != nil {
+		if t.runningTestSuite.Name == className {
+			return t.runningTestSuite
+		}
+		// Check if className ends with "|suiteName"
+		if strings.HasSuffix(className, "|"+t.runningTestSuite.Name) {
+			return t.runningTestSuite
+		}
 	}
 
 	return nil

--- a/ios/testmanagerd/testlistener_test.go
+++ b/ios/testmanagerd/testlistener_test.go
@@ -277,49 +277,49 @@ func TestFindTestSuite(t *testing.T) {
 	t.Run("Exact match finds test suite", func(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
-		
+
 		result := testListener.findTestSuite("ShowAlert")
 		assert.NotNil(t, result)
 		assert.Equal(t, "ShowAlert", result.Name)
 	})
-	
+
 	t.Run("Suffix match with delimiter finds test suite", func(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
-		
+
 		result := testListener.findTestSuite("HelloButton|ShowAlert")
 		assert.NotNil(t, result)
 		assert.Equal(t, "ShowAlert", result.Name)
 	})
-	
+
 	t.Run("Suffix match with multiple delimiters finds test suite", func(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
-		
+
 		result := testListener.findTestSuite("Feature|Scenario|ShowAlert")
 		assert.NotNil(t, result)
 		assert.Equal(t, "ShowAlert", result.Name)
 	})
-	
+
 	t.Run("No match returns nil", func(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
-		
+
 		result := testListener.findTestSuite("DifferentTest")
 		assert.Nil(t, result)
 	})
-	
+
 	t.Run("Partial match without delimiter returns nil", func(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
 		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
-		
+
 		result := testListener.findTestSuite("ShowAlertTest")
 		assert.Nil(t, result)
 	})
-	
+
 	t.Run("No running test suite returns nil", func(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
-		
+
 		result := testListener.findTestSuite("ShowAlert")
 		assert.Nil(t, result)
 	})
@@ -328,38 +328,38 @@ func TestFindTestSuite(t *testing.T) {
 func TestFindTestSuiteIntegration(t *testing.T) {
 	t.Run("Test case status is updated with suffix matching", func(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
-		
+
 		// Start test suite
 		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
-		
+
 		// Start test case with prefixed class name
 		testListener.testCaseDidStartForClass("HelloButton|ShowAlert", "GivenILaunchTheApp")
-		
+
 		// Finish test case - this should now work with suffix matching
 		testListener.testCaseDidFinishForTest("HelloButton|ShowAlert", "GivenILaunchTheApp", "passed", 1.0)
-		
+
 		// Verify the test case was found and status updated
 		assert.Equal(t, 1, len(testListener.runningTestSuite.TestCases))
 		assert.Equal(t, TestCaseStatus("passed"), testListener.runningTestSuite.TestCases[0].Status)
 		assert.Equal(t, 1.0, testListener.runningTestSuite.TestCases[0].Duration.Seconds())
 	})
-	
+
 	t.Run("Multiple test cases with suffix matching", func(t *testing.T) {
 		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
-		
+
 		// Start test suite
 		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
-		
+
 		// Start multiple test cases
 		testListener.testCaseDidStartForClass("HelloButton|ShowAlert", "GivenILaunchTheApp")
 		testListener.testCaseDidFinishForTest("HelloButton|ShowAlert", "GivenILaunchTheApp", "passed", 1.0)
-		
+
 		testListener.testCaseDidStartForClass("HelloButton|ShowAlert", "WhenITapTheHelloButton")
 		testListener.testCaseDidFinishForTest("HelloButton|ShowAlert", "WhenITapTheHelloButton", "passed", 2.0)
-		
+
 		testListener.testCaseDidStartForClass("HelloButton|ShowAlert", "ThenISeeHelloWorldAlert")
 		testListener.testCaseDidFinishForTest("HelloButton|ShowAlert", "ThenISeeHelloWorldAlert", "passed", 3.0)
-		
+
 		// Verify all test cases have correct status
 		assert.Equal(t, 3, len(testListener.runningTestSuite.TestCases))
 		for i, testCase := range testListener.runningTestSuite.TestCases {

--- a/ios/testmanagerd/testlistener_test.go
+++ b/ios/testmanagerd/testlistener_test.go
@@ -366,7 +366,7 @@ func TestTestCaseLookup(t *testing.T) {
 
 		cases := listener.runningTestSuite.TestCases
 		assert.Len(t, cases, 3)
-		
+
 		for _, testCase := range cases {
 			assert.NotEqual(t, TestCaseStatus(""), testCase.Status)
 			assert.Greater(t, testCase.Duration.Seconds(), 0.0)

--- a/ios/testmanagerd/testlistener_test.go
+++ b/ios/testmanagerd/testlistener_test.go
@@ -272,3 +272,99 @@ func (w *assertionWriter) Write(p []byte) (n int, err error) {
 
 	return len(p), nil
 }
+
+func TestFindTestSuite(t *testing.T) {
+	t.Run("Exact match finds test suite", func(t *testing.T) {
+		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
+		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
+		
+		result := testListener.findTestSuite("ShowAlert")
+		assert.NotNil(t, result)
+		assert.Equal(t, "ShowAlert", result.Name)
+	})
+	
+	t.Run("Suffix match with delimiter finds test suite", func(t *testing.T) {
+		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
+		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
+		
+		result := testListener.findTestSuite("HelloButton|ShowAlert")
+		assert.NotNil(t, result)
+		assert.Equal(t, "ShowAlert", result.Name)
+	})
+	
+	t.Run("Suffix match with multiple delimiters finds test suite", func(t *testing.T) {
+		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
+		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
+		
+		result := testListener.findTestSuite("Feature|Scenario|ShowAlert")
+		assert.NotNil(t, result)
+		assert.Equal(t, "ShowAlert", result.Name)
+	})
+	
+	t.Run("No match returns nil", func(t *testing.T) {
+		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
+		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
+		
+		result := testListener.findTestSuite("DifferentTest")
+		assert.Nil(t, result)
+	})
+	
+	t.Run("Partial match without delimiter returns nil", func(t *testing.T) {
+		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
+		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
+		
+		result := testListener.findTestSuite("ShowAlertTest")
+		assert.Nil(t, result)
+	})
+	
+	t.Run("No running test suite returns nil", func(t *testing.T) {
+		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
+		
+		result := testListener.findTestSuite("ShowAlert")
+		assert.Nil(t, result)
+	})
+}
+
+func TestFindTestSuiteIntegration(t *testing.T) {
+	t.Run("Test case status is updated with suffix matching", func(t *testing.T) {
+		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
+		
+		// Start test suite
+		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
+		
+		// Start test case with prefixed class name
+		testListener.testCaseDidStartForClass("HelloButton|ShowAlert", "GivenILaunchTheApp")
+		
+		// Finish test case - this should now work with suffix matching
+		testListener.testCaseDidFinishForTest("HelloButton|ShowAlert", "GivenILaunchTheApp", "passed", 1.0)
+		
+		// Verify the test case was found and status updated
+		assert.Equal(t, 1, len(testListener.runningTestSuite.TestCases))
+		assert.Equal(t, TestCaseStatus("passed"), testListener.runningTestSuite.TestCases[0].Status)
+		assert.Equal(t, 1.0, testListener.runningTestSuite.TestCases[0].Duration.Seconds())
+	})
+	
+	t.Run("Multiple test cases with suffix matching", func(t *testing.T) {
+		testListener := NewTestListener(io.Discard, io.Discard, os.TempDir())
+		
+		// Start test suite
+		testListener.testSuiteDidStart("ShowAlert", "2024-01-16 15:36:43 +0000")
+		
+		// Start multiple test cases
+		testListener.testCaseDidStartForClass("HelloButton|ShowAlert", "GivenILaunchTheApp")
+		testListener.testCaseDidFinishForTest("HelloButton|ShowAlert", "GivenILaunchTheApp", "passed", 1.0)
+		
+		testListener.testCaseDidStartForClass("HelloButton|ShowAlert", "WhenITapTheHelloButton")
+		testListener.testCaseDidFinishForTest("HelloButton|ShowAlert", "WhenITapTheHelloButton", "passed", 2.0)
+		
+		testListener.testCaseDidStartForClass("HelloButton|ShowAlert", "ThenISeeHelloWorldAlert")
+		testListener.testCaseDidFinishForTest("HelloButton|ShowAlert", "ThenISeeHelloWorldAlert", "passed", 3.0)
+		
+		// Verify all test cases have correct status
+		assert.Equal(t, 3, len(testListener.runningTestSuite.TestCases))
+		for i, testCase := range testListener.runningTestSuite.TestCases {
+			assert.Equal(t, TestCaseStatus("passed"), testCase.Status, "Test case %d should have passed status", i)
+			assert.Greater(t, testCase.Duration.Seconds(), 0.0, "Test case %d should have duration > 0", i)
+		}
+	})
+}


### PR DESCRIPTION
Current issue: go-ios incorrectly marks successful tests as failed, when test cases are inside test cases (BDD).
Xcode has no issues running them.

for testClass "HelloButton|ShowAlert" and  testMethod "GivenILaunchTheApp" the status with value "passed" is not being set.
   t.runningTestSuite:
   ```go
*testmanagerd.TestSuite {Name: "ShowAlert", StartDate: time.Time(2025-07-01T18:35:28Z){wall: 0, ext: 63886991728, loc: *time.Location nil}, EndDate: time.Time(0001-01-01T00:00:00Z){wall: 0, ext: 0, loc: *time.Location nil}, TestDuration: gvisor.dev/gvisor/pkg/tcpip/stack.immediateDuration (0), TotalDuration: gvisor.dev/gvisor/pkg/tcpip/stack.immediateDuration (0), TestCases: []github.com/danielpaulus/go-ios/ios/testmanagerd.TestCase len: 1, cap: 1, [(*"github.com/danielpaulus/go-ios/ios/testmanagerd.TestCase")(0x14000031500)]}
   (*(*t).runningTestSuite).TestCases
   []testmanagerd.TestCase len: 1, cap: 1, [{ClassName: "HelloButton|ShowAlert", MethodName: "GivenILaunchTheApp", Status: "", Err: (*"github.com/danielpaulus/go-ios/ios/testmanagerd.TestError")(0x14000031530), Duration: gvisor.dev/gvisor/pkg/tcpip/stack.immediateDuration (0), Attachments: []github.com/danielpaulus/go-ios/ios/testmanagerd.TestAttachment len: 0, cap: 0, nil}]
   (*(*t).runningTestSuite).TestCases[0]
   testmanagerd.TestCase {ClassName: "HelloButton|ShowAlert", MethodName: "GivenILaunchTheApp", Status: "", Err: github.com/danielpaulus/go-ios/ios/testmanagerd.TestError {Message: "", File: "", Line: 0}, Duration: gvisor.dev/gvisor/pkg/

tcpip/stack.immediateDuration (0), Attachments: []github.com/danielpaulus/go-ios/ios/testmanagerd.TestAttachment len: 0, cap: 0, nil}
   ```
Example app:
[mydemoapp.zip](https://github.com/user-attachments/files/21056328/mydemoapp.zip)

After the fix has been implemented:
```
{"level":"error","msg":"error reading dtx connection read tcp [fddf:7696:6a44::2]:58945-\u003e[fddf:7696:6a44::1]:49806: read: connection reset by peer","time":"2025-07-04T13:25:25+02:00"}
{"level":"debug","msg":"DTX Connection with EOF","time":"2025-07-04T13:25:25+02:00"}
[{Name:CucumberStandardUITests StartDate:2025-07-04 11:25:17 +0000 UTC EndDate:2025-07-04 11:25:20 +0000 UTC TestDuration:2.797479s TotalDuration:2.803603s TestCases:[{ClassName:CucumberStandardUITests MethodName:testExample Status:passed Err:{Message: File: Line:0} Duration:2.797479s Attachments:[]}]} {Name:CucumberTest StartDate:2025-07-04 11:25:20 +0000 UTC EndDate:0001-01-01 00:00:00 +0000 UTC TestDuration:0s TotalDuration:0s TestCases:[{ClassName:CucumberTest MethodName:testGherkin Status:passed Err:{Message: File: Line:0} Duration:18.874ms Attachments:[]}]} {Name:GeneratedSteps StartDate:2025-07-04 11:25:20 +0000 UTC EndDate:2025-07-04 11:25:20 +0000 UTC TestDuration:0s TotalDuration:360µs TestCases:[]} {Name:ShowAlert StartDate:2025-07-04 11:25:20 +0000 UTC EndDate:2025-07-04 11:25:23 +0000 UTC TestDuration:3.444117s TotalDuration:3.452443s TestCases:[{ClassName:HelloButton|ShowAlert MethodName:GivenILaunchTheApp Status:passed Err:{Message: File: Line:0} Duration:2.600747s Attachments:[]} {ClassName:HelloButton|ShowAlert MethodName:WhenITapTheHelloButton Status:passed Err:{Message: File: Line:0} Duration:834.399ms Attachments:[]} {ClassName:HelloButton|ShowAlert MethodName:ThenISeeHelloWorldAlert Status:passed Err:{Message: File: Line:0} Duration:8.971ms Attachments:[]}]}]{"level":"info","msg":"1301 \u003cnil\u003e","time":"2025-07-04T13:25:25+02:00"}
Exiting.
```