### PR TITLE
Fix fsync with --app=bundleId

### DIFF
--- a/ios/afc/fsync.go
+++ b/ios/afc/fsync.go
@@ -50,24 +50,24 @@ func New(device ios.DeviceEntry) (*Connection, error) {
 	return &Connection{deviceConn: deviceConn}, nil
 }
 
-func NewContainer(device ios.DeviceEntry, bundleID string) (*Connection, error) {
+func NewVendDocuments(device ios.DeviceEntry, bundleID string) (*Connection, error) {
 	deviceConn, err := ios.ConnectToService(device, "com.apple.mobile.house_arrest")
 	if err != nil {
 		return nil, err
 	}
-	err = VendContainer(deviceConn, bundleID)
+	err = VendDocuments(deviceConn, bundleID)
 	if err != nil {
 		return nil, err
 	}
 	return &Connection{deviceConn: deviceConn}, nil
 }
 
-func VendContainer(deviceConn ios.DeviceConnectionInterface, bundleID string) error {
+func VendDocuments(deviceConn ios.DeviceConnectionInterface, bundleID string) error {
 	plistCodec := ios.NewPlistCodec()
-	vendContainer := map[string]interface{}{"Command": "VendContainer", "Identifier": bundleID}
-	msg, err := plistCodec.Encode(vendContainer)
+	vendDocuments := map[string]interface{}{"Command": "VendDocuments", "Identifier": bundleID}
+	msg, err := plistCodec.Encode(vendDocuments)
 	if err != nil {
-		return fmt.Errorf("VendContainer Encoding cannot fail unless the encoder is broken: %v", err)
+		return fmt.Errorf("VendDocuments encoding cannot fail unless the encoder is broken: %v", err)
 	}
 	err = deviceConn.Send(msg)
 	if err != nil {
@@ -81,8 +81,8 @@ func VendContainer(deviceConn ios.DeviceConnectionInterface, bundleID string) er
 	return checkResponse(response)
 }
 
-func checkResponse(vendContainerResponseBytes []byte) error {
-	response, err := plistFromBytes(vendContainerResponseBytes)
+func checkResponse(vendDocumentsResponseBytes []byte) error {
+	response, err := plistFromBytes(vendDocumentsResponseBytes)
 	if err != nil {
 		return err
 	}
@@ -92,11 +92,11 @@ func checkResponse(vendContainerResponseBytes []byte) error {
 	if response.Error != "" {
 		return errors.New(response.Error)
 	}
-	return errors.New("unknown error during vendcontainer")
+	return errors.New("unknown error during VendDocuments")
 }
 
-func plistFromBytes(plistBytes []byte) (vendContainerResponse, error) {
-	var vendResponse vendContainerResponse
+func plistFromBytes(plistBytes []byte) (vendDocumentsResponse, error) {
+	var vendResponse vendDocumentsResponse
 	decoder := plist.NewDecoder(bytes.NewReader(plistBytes))
 
 	err := decoder.Decode(&vendResponse)
@@ -106,7 +106,7 @@ func plistFromBytes(plistBytes []byte) (vendContainerResponse, error) {
 	return vendResponse, nil
 }
 
-type vendContainerResponse struct {
+type vendDocumentsResponse struct {
 	Status string
 	Error  string
 }

--- a/ios/house_arrest/house_arrest.go
+++ b/ios/house_arrest/house_arrest.go
@@ -22,7 +22,7 @@ func New(device ios.DeviceEntry, bundleID string) (*Connection, error) {
 	if err != nil {
 		return &Connection{}, err
 	}
-	err = afc.VendContainer(deviceConn, bundleID)
+	err = afc.VendDocuments(deviceConn, bundleID)
 	if err != nil {
 		return &Connection{}, err
 	}

--- a/main.go
+++ b/main.go
@@ -1091,7 +1091,7 @@ The commands work as following:
 		if containerBundleId == "" {
 			afcService, err = afc.New(device)
 		} else {
-			afcService, err = afc.NewContainer(device, containerBundleId)
+			afcService, err = afc.NewVendDocuments(device, containerBundleId)
 		}
 		exitIfError("fsync: connect afc service failed", err)
 		b, _ = arguments.Bool("rm")


### PR DESCRIPTION
Fixes #593.

According to [libimobiledevice issue 193](https://github.com/libimobiledevice/libimobiledevice/issues/193) from 2015 (in particular, [this comment](https://github.com/libimobiledevice/libimobiledevice/issues/193#issuecomment-106424991)), the service `com.apple.mobile.house_arrest` doesn't support the `VendContainer` command anymore (unless the app was installed via XCode).
However, for apps that have [`UIFileSharingEnabled`](https://developer.apple.com/documentation/bundleresources/information-property-list/uifilesharingenabled) set to `true` in their [information property list](https://developer.apple.com/documentation/bundleresources/information-property-list), the `VendDocuments` command can be used instead to access the app's `/Documents` directory.

This PR replaces `VendContainer` by `VendDocuments` to make this work.

Note that when using the go-iOS `fsync` command with the option `--app=BUNDLE_ID` set, the `PATH` passed with the option `--path=PATH` has to start with `/Documents` (in particular, `/` won't work).
For example, to use the `fsync tree` command for a specific app, one has to call `ios fsync --app=BUNDLE_ID tree --path=/Documents`.