### PR TITLE
修复syslog带--parse参数时转换异常的问题

### DIFF
--- a/ios/syslog/syslog.go
+++ b/ios/syslog/syslog.go
@@ -77,7 +77,7 @@ type LogEntry struct {
 }
 
 func Parser() func(log string) (*LogEntry, error) {
-	pattern := `(?P<Timestamp>[A-Z][a-z]{2} \d{1,2} \d{2}:\d{2}:\d{2}) (?P<Device>\S+) (?P<Process>[^\[]+)\[(?P<PID>\d+)\] <(?P<Level>\w+)>: (?P<Message>.+)`
+	pattern := `(?P<Timestamp>[A-Z][a-z]{2}\s+\d+\s+\d{2}:\d{2}:\d{2})\s+(?P<Device>\S+)\s+(?P<Process>[^\[]+)\[(?P<PID>\d+)\]\s+<(?P<Level>\w+)>: (?P<Message>.+)`
 	regexp := regexp.MustCompile(pattern)
 
 	return func(log string) (*LogEntry, error) {


### PR DESCRIPTION
处理带 syslog 带 `--parse` 参数时转换异常的问题

相关原始数据如下：
```text
{"msg":"Aug  6 14:25:59 Ip locationd[79] \u003cNotice\u003e: {\"msg\":\"onAvengerAdvertisementDetected: got avenger advertisement\", \"subHarvester\":\"Avenger\"}"}
{"msg":"Aug  6 14:25:59 Ip locationd(TrackingAvoidance)[79] \u003cNotice\u003e: \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip locationd[79] \u003cNotice\u003e: {\"msg\":\"convertToSPAdvertisement\", \"address\":\u003cprivate\u003e, \"data\":\u003cprivate\u003e, \"date\":\u003cprivate\u003e, \"rssi\":\u003cprivate\u003e, \"status\":\u003cprivate\u003e, \"reserved\":\u003cprivate\u003e, \"subHarvester\":\"Avenger\"}"}
{"msg":"Aug  6 14:25:59 Ip locationd[79] \u003cNotice\u003e: {\"msg\":\"derivedPruneHarvest\", \"cacheSize\":1, \"beaconPayloadCacheSize\":0, \"subHarvester\":\"Avenger\"}"}
{"msg":"Aug  6 14:25:59 Ip locationd[79] \u003cNotice\u003e: {\"msg\":\"processAdvertisementCache: advertisement within valid time window for location\", \"timeOffset\":\"-571.505995\", \"fCurrentTimeOffsetThreshold\":\"600.000000\", \"subHarvester\":\"Avenger\"}"}
{"msg":"Aug  6 14:25:59 Ip locationd[79] \u003cNotice\u003e: {\"msg\":\"prepareAdvertisementsForSPFinder\", \"avengerPublicKey\":\"e8be7ea611c2\", \"appendLocation\":1, \"subHarvester\":\"Avenger\"}"}
{"msg":"Aug  6 14:25:59 Ip locationd[79] \u003cNotice\u003e: {\"msg\":\"processAdvertisementCache: completed process\", \"Remaining fAdvertisementCache.count\":0, \"saveableAdvertisements.count\":1, \"purgeableAdvertisements.count\":0, \"saveableAdvertisementsWithoutLocationToRemoveFromCache.count\":0, \"saveableAdvertisementsWithoutLocationToPersistInCache.count\":0, \"fBeaconPayloadCache.count\":1, \"subHarvester\":\"Avenger\"}"}
{"msg":"Aug  6 14:25:59 Ip locationd(SPFinder)[79] \u003cNotice\u003e: saveBeaconPayload: 1"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: Publishing 1 advertisements to subscribers."}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: Opened \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: Publishing advertisements to subscriber: \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: Publishing advertisements to subscriber: \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: Publishing advertisements to subscriber: \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: \u003cprivate\u003e: updateCriteria called on XPCActivity"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: BeaconPayloadPublisher expected to run with existing criteria: \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: \u003cprivate\u003e: Keeping existing criteria for: \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: BeaconPayloadPublisher checked-in \u003cprivate\u003e publish activity \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: \u003cprivate\u003e: updateCriteria called on XPCActivity"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: BeaconPayloadPublisher expected to run with existing criteria: \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: \u003cprivate\u003e: Keeping existing criteria for: \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: BeaconPayloadPublisher checked-in \u003cprivate\u003e publish activity \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: \u003cprivate\u003e: updateCriteria called on XPCActivity"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: BeaconPayloadPublisher expected to run with existing criteria: \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: \u003cprivate\u003e: Keeping existing criteria for: \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: BeaconPayloadPublisher checked-in \u003cprivate\u003e publish activity \u003cprivate\u003e"}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: Finished scheduling next publish."}
{"msg":"Aug  6 14:25:59 Ip searchpartyd[179] \u003cNotice\u003e: Closed \u003cprivate\u003e"}
```

修复之后效果：
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/83eb7e1d-3148-44fa-9e21-b32daeb81199" />
