### PR TITLE
Fix readme for npmjs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,7 @@ jobs:
           cp ./win-bin/ios.exe ./npm_publish/dist/go-ios-windows-amd64_windows_amd64/ios.exe
           cp ./bin/ios-amd64 ./npm_publish/dist/go-ios-linux-amd64_linux_amd64/ios
           cp ./bin/ios-arm64 ./npm_publish/dist/go-ios-linux-arm64_linux_arm64/ios
+          cp ./README.md ./npm_publish
           echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
           cd npm_publish
           sed -i 's/\"local-build\"/\"${{ env.release_tag }}\"/' package.json


### PR DESCRIPTION
The package page on npmjs: https://www.npmjs.com/package/go-ios does not show any content. This is because there's no README.md file in the package/ directory of the tgz generate by npm.

This one line fix just copies the README into the npm package, so it will appear in https://www.npmjs.com/package/go-ios . Any change to README.md that is published to npm will update the markdown there.

I know it's silly, it's the OCD talking :P 