### PR TITLE
Accessibility Inspector: added relevant method to Perform tap action on an element

### DIFF
--- a/ios/accessibility/accessibility_control.go
+++ b/ios/accessibility/accessibility_control.go
@@ -27,16 +27,13 @@ type actionMeta struct {
 	HumanReadable string
 }
 
-// actionMetadata holds known actions and their metadata.
-var actionMetadata = map[Action]actionMeta{
-	ActionTap: {AttributeName: "AXAction-2010", HumanReadable: "Activate"},
-}
-
 func getActionMeta(action Action) actionMeta {
-	if meta, ok := actionMetadata[action]; ok {
-		return meta
+	switch action {
+	case ActionTap:
+		return actionMeta{AttributeName: "AXAction-2010", HumanReadable: "Activate"}
+	default:
+		return actionMeta{}
 	}
-	return actionMeta{AttributeName: "", HumanReadable: ""}
 }
 
 // Direction represents navigation direction values used by AX service


### PR DESCRIPTION
We implemented generic perform action method `deviceElement:performAction:withValue:` that takes action name as an argument. 

It takes two arguments:

- **actionName**: For now we added Tap action name in types and we can iterate over it for other action types if it's needed. we grab metadata of action based on action type.
- **currentPlatformElement**: it's unique base64 element id  on which action will be performed.

