### PR TITLE
reduce memory footprint and reduce disk I/O for zip conduit installs

### DIFF
--- a/ios/zipconduit/zipconduit_installer.go
+++ b/ios/zipconduit/zipconduit_installer.go
@@ -46,7 +46,7 @@ const (
 )
 
 // those permissions were observed by capturing Xcode traffic, and we use exactly the same values.
-// we also tried using only the last three numbers in octal representation. This worked fine, but we sill use the same
+// we also tried using only the last three numbers in octal representation. This worked fine, but we still use the same
 // values as Xcode
 const (
 	stdDirPerm  = 16877  // 0o40755 -> 0o755


### PR DESCRIPTION
when we get an IPA file we don't need to extract it's contents to disk first, we can uncompress and send the files directly to the device, which reduces disk I/O. and while unzipping, we are re-using a single buffer to copy the contents so that we don't allocate a new buffer for every single file