### PR TITLE
Suppress superflous errors generated closing a forwarding connection

### DIFF
--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -69,6 +69,13 @@ func connectionAccept(cl *ConnListener, deviceID int, phonePort uint16) {
 		default:
 			clientConn, err := cl.listener.Accept()
 			if err != nil {
+				// Close() shuts the listener down, which unblocks this Accept()
+				// with net.ErrClosed. That's a clean teardown, not a failure, so
+				// don't log it as an error — just exit the accept loop.
+				if errors.Is(err, net.ErrClosed) {
+					golog.Info("closed listener successfully", "module", logModule, "deviceID", deviceID, "phonePort", phonePort)
+					return
+				}
 				golog.Error("error accepting new connection", "module", logModule, "deviceID", deviceID, "phonePort", phonePort, "error", err)
 				continue
 			}


### PR DESCRIPTION
Just noticed that I've had this change locally on disk for a year.  If you look at the logic for `ConnListener.Close()` , it calls `cl.listener.Close()`, which in turn causes `listener.Accept()` calls in related goroutines to return with errors. These errors are logged to stderr before the routines end.

These errors should not be emitted when the connection is manually/cleanly closed. The existing call to `close(cl.quit)` has no impact on preventing these errors.

Especially when using `go-ios` as a library where connections are dynamically opened and closed, these errors are quite undesirable.