### PR TITLE
Add iOS 17+ file service support via RemoteXPC

### DIFF
--- a/ios/fileservice/datatransfer.go
+++ b/ios/fileservice/datatransfer.go
@@ -1,0 +1,89 @@
+package fileservice
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/danielpaulus/go-ios/ios"
+)
+
+// sendRawData sends raw bytes through the raw connection
+func sendRawData(conn ios.DeviceConnectionInterface, data []byte) error {
+	// Write raw bytes directly to the connection
+	_, err := conn.Write(data)
+	return err
+}
+
+// receiveFileData receives file data from the data service
+// Protocol: 36 bytes header + 4 bytes file size (BE) + file data
+func receiveFileData(conn ios.DeviceConnectionInterface) ([]byte, error) {
+	// Read the 36-byte header + 4-byte size field
+	header := make([]byte, 40)
+	_, err := io.ReadFull(conn, header)
+	if err != nil {
+		return nil, fmt.Errorf("receiveFileData: failed to read header: %w", err)
+	}
+
+	// Read file size (4 bytes, big-endian) at offset 36
+	fileSize := binary.BigEndian.Uint32(header[36:40])
+
+	// Validate file size to prevent OOM
+	if fileSize > MaxFileSize {
+		return nil, fmt.Errorf("receiveFileData: file size %d exceeds maximum allowed size %d", fileSize, MaxFileSize)
+	}
+
+	// Read file data
+	fileData := make([]byte, fileSize)
+	_, err = io.ReadFull(conn, fileData)
+	if err != nil {
+		return nil, fmt.Errorf("receiveFileData: failed to read file data: %w", err)
+	}
+
+	return fileData, nil
+}
+
+// receiveFileDataToWriter receives file data from the data service and streams it to a writer
+// Protocol: 36 bytes header + 4 bytes file size (BE) + file data
+func receiveFileDataToWriter(conn ios.DeviceConnectionInterface, writer io.Writer) error {
+	// Read the 36-byte header + 4-byte size field
+	header := make([]byte, 40)
+	_, err := io.ReadFull(conn, header)
+	if err != nil {
+		return fmt.Errorf("receiveFileDataToWriter: failed to read header: %w", err)
+	}
+
+	// Read file size (4 bytes, big-endian) at offset 36
+	fileSize := binary.BigEndian.Uint32(header[36:40])
+
+	// Validate file size to prevent OOM
+	if fileSize > MaxFileSize {
+		return fmt.Errorf("receiveFileDataToWriter: file size %d exceeds maximum allowed size %d", fileSize, MaxFileSize)
+	}
+
+	// Stream file data in chunks
+	const chunkSize = 256 * 1024 // 256KB chunks
+	buffer := make([]byte, chunkSize)
+	remaining := int64(fileSize)
+
+	for remaining > 0 {
+		toRead := chunkSize
+		if remaining < int64(chunkSize) {
+			toRead = int(remaining)
+		}
+
+		n, err := io.ReadFull(conn, buffer[:toRead])
+		if err != nil {
+			return fmt.Errorf("receiveFileDataToWriter: failed to read chunk: %w", err)
+		}
+
+		_, err = writer.Write(buffer[:n])
+		if err != nil {
+			return fmt.Errorf("receiveFileDataToWriter: failed to write chunk: %w", err)
+		}
+
+		remaining -= int64(n)
+	}
+
+	return nil
+}

--- a/ios/fileservice/fileservice.go
+++ b/ios/fileservice/fileservice.go
@@ -1,0 +1,433 @@
+// Package fileservice provides functions to pull and push files on iOS 17+ devices using RemoteXPC.
+package fileservice
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/xpc"
+	"github.com/google/uuid"
+)
+
+const (
+	// ControlServiceName is the RemoteXPC service name for file operations control
+	ControlServiceName = "com.apple.coredevice.fileservice.control"
+	// DataServiceName is the RemoteXPC service name for file data transfer
+	DataServiceName = "com.apple.coredevice.fileservice.data"
+
+	// MaxFileSize is the maximum file size we'll process (1GB) to prevent OOM
+	MaxFileSize = 1024 * 1024 * 1024
+	// MaxInlineDataSize is the maximum file size that can be sent inline in XPC message
+	// Files larger than this must use the data service
+	MaxInlineDataSize = 500 // bytes - based on Ghidra code checking for 500 bytes
+)
+
+// Domain represents a file system domain on the iOS device
+type Domain uint64
+
+const (
+	// DomainAppDataContainer is the app's Documents directory
+	DomainAppDataContainer Domain = 1
+	// DomainAppGroupDataContainer is the app group shared container
+	DomainAppGroupDataContainer Domain = 2
+	// DomainTemporary is the temporary directory
+	DomainTemporary Domain = 3
+	// DomainRootStaging is the root staging directory (no idea what that would be)
+	DomainRootStaging Domain = 4
+	// DomainSystemCrashLogs is the system crash logs directory
+	DomainSystemCrashLogs Domain = 5
+)
+
+// Connection represents a connection to the file service on an iOS 17+ device.
+// It manages file operations like listing, pulling, and pushing files.
+// Note: Connection is not safe for concurrent use. Each goroutine should have its own Connection.
+type Connection struct {
+	mu         sync.Mutex
+	conn       *xpc.Connection
+	device     ios.DeviceEntry
+	sessionID  string
+	domain     Domain
+	identifier string
+}
+
+// New creates a new connection to the file service on the device for iOS 17+.
+// The domain parameter specifies which file system domain to access.
+// The identifier parameter is typically an app bundle ID (e.g., "com.example.app") for app domains.
+// For system domains like DomainSystemCrashLogs, the identifier can be empty.
+func New(device ios.DeviceEntry, domain Domain, identifier string) (*Connection, error) {
+	xpcConn, err := ios.ConnectToXpcServiceTunnelIface(device, ControlServiceName)
+	if err != nil {
+		return nil, fmt.Errorf("New: failed to connect to file service: %w", err)
+	}
+
+	c := &Connection{
+		conn:       xpcConn,
+		device:     device,
+		domain:     domain,
+		identifier: identifier,
+	}
+
+	// Create session immediately
+	if err := c.createSession(); err != nil {
+		xpcConn.Close()
+		return nil, fmt.Errorf("New: failed to create session: %w", err)
+	}
+
+	return c, nil
+}
+
+// createSession sends a CreateSession command to establish a file service session
+func (c *Connection) createSession() error {
+	request := map[string]interface{}{
+		"Cmd":        "CreateSession",
+		"Domain":     uint64(c.domain),
+		"Identifier": c.identifier,
+		"Session":    "",
+		"User":       "mobile",
+	}
+
+	if err := c.conn.Send(request, xpc.HeartbeatRequestFlag); err != nil {
+		return fmt.Errorf("createSession: failed to send request: %w", err)
+	}
+
+	// Session creation responses come on ServerClientStream
+	response, err := c.conn.ReceiveOnServerClientStream()
+	if err != nil {
+		return fmt.Errorf("createSession: failed to receive response: %w", err)
+	}
+
+	// Check for errors in response
+	if err := extractError(response); err != nil {
+		return fmt.Errorf("createSession: %w", err)
+	}
+
+	// Extract session ID
+	sessionID, ok := response["NewSessionID"].(string)
+	if !ok {
+		return fmt.Errorf("createSession: missing or invalid NewSessionID in response (got: %+v)", response)
+	}
+
+	c.sessionID = sessionID
+	return nil
+}
+
+// ListDirectory returns a list of file names in the specified directory path.
+// The path is relative to the domain root.
+func (c *Connection) ListDirectory(path string) ([]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	msgUUID := uuid.New().String()
+
+	request := map[string]interface{}{
+		"Cmd":         "RetrieveDirectoryList",
+		"MessageUUID": msgUUID,
+		"Path":        path,
+		"SessionID":   c.sessionID,
+	}
+
+	if err := c.conn.Send(request, xpc.HeartbeatRequestFlag); err != nil {
+		return nil, fmt.Errorf("ListDirectory: failed to send request: %w", err)
+	}
+
+	// Directory list responses come on ClientServerStream
+	response, err := c.conn.ReceiveOnClientServerStream()
+	if err != nil {
+		return nil, fmt.Errorf("ListDirectory: failed to receive response: %w", err)
+	}
+
+	// Check for errors in response
+	if err := extractError(response); err != nil {
+		return nil, fmt.Errorf("ListDirectory: %w", err)
+	}
+
+	// Extract file list
+	fileListRaw, ok := response["FileList"]
+	if !ok {
+		return nil, fmt.Errorf("ListDirectory: missing FileList in response")
+	}
+
+	fileList, ok := fileListRaw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("ListDirectory: FileList is not an array")
+	}
+
+	// Convert to string slice
+	result := make([]string, 0, len(fileList))
+	for _, item := range fileList {
+		if str, ok := item.(string); ok {
+			result = append(result, str)
+		}
+	}
+
+	return result, nil
+}
+
+// PullFile downloads a file from the device by streaming to an io.Writer.
+// This is memory-efficient as it streams the file in chunks rather than loading it entirely into memory.
+// The path is relative to the domain root.
+func (c *Connection) PullFile(path string, writer io.Writer) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Step 1: Send RetrieveFile command to control service
+	request := map[string]interface{}{
+		"Cmd":       "RetrieveFile",
+		"Path":      path,
+		"SessionID": c.sessionID,
+	}
+
+	if err := c.conn.Send(request, xpc.HeartbeatRequestFlag); err != nil {
+		return fmt.Errorf("PullFile: failed to send request: %w", err)
+	}
+
+	// File retrieval control responses come on ServerClientStream (like CreateSession)
+	response, err := c.conn.ReceiveOnServerClientStream()
+	if err != nil {
+		return fmt.Errorf("PullFile: failed to receive response: %w", err)
+	}
+
+	// Check for errors in response
+	if err := extractError(response); err != nil {
+		return fmt.Errorf("PullFile: %w", err)
+	}
+
+	// Extract response token and file ID
+	responseToken, ok := response["Response"].(uint64)
+	if !ok {
+		return fmt.Errorf("PullFile: missing or invalid Response token")
+	}
+
+	fileID, ok := response["NewFileID"].(uint64)
+	if !ok {
+		return fmt.Errorf("PullFile: missing or invalid NewFileID")
+	}
+
+	// Step 2: Connect to data service and download file
+	if err := c.downloadFileData(responseToken, fileID, writer); err != nil {
+		return fmt.Errorf("PullFile: failed to download file data: %w", err)
+	}
+
+	return nil
+}
+
+// downloadFileData connects to the data service and streams file contents to a writer
+func (c *Connection) downloadFileData(responseToken, fileID uint64, writer io.Writer) error {
+	// Connect to data service using raw connection (not XPC)
+	dataConn, err := ios.ConnectToServiceTunnelIface(c.device, DataServiceName)
+	if err != nil {
+		return fmt.Errorf("downloadFileData: failed to connect to data service: %w", err)
+	}
+	defer dataConn.Close()
+
+	// Build the wire protocol request
+	// Protocol: magic (8 bytes) + response token (8 bytes BE) + padding (8 bytes) + file ID (8 bytes BE) + padding (8 bytes)
+	wireRequest := make([]byte, 40)
+
+	// Magic: "rwb!FILE" (8 bytes)
+	copy(wireRequest[0:8], []byte("rwb!FILE"))
+
+	// Response token (8 bytes, big-endian)
+	binary.BigEndian.PutUint64(wireRequest[8:16], responseToken)
+
+	// Padding (8 bytes of zeros) - wireRequest is already zero-initialized
+
+	// File ID (8 bytes, big-endian)
+	binary.BigEndian.PutUint64(wireRequest[24:32], fileID)
+
+	// Padding (8 bytes of zeros) - wireRequest is already zero-initialized
+
+	// Send the wire protocol request through the raw connection
+	if err := sendRawData(dataConn, wireRequest); err != nil {
+		return fmt.Errorf("downloadFileData: failed to send wire request: %w", err)
+	}
+
+	// Receive and stream file data - Protocol: 36 bytes header + 4 bytes file size (BE) + file data
+	if err := receiveFileDataToWriter(dataConn, writer); err != nil {
+		return fmt.Errorf("downloadFileData: failed to receive file data: %w", err)
+	}
+
+	return nil
+}
+
+// PushFile uploads a file to the device by streaming from an io.Reader.
+// This is memory-efficient as it streams the file in chunks rather than loading it entirely into memory.
+// The path is relative to the domain root.
+// permissions should be in octal format (e.g., 0o644 or 420 in decimal)
+func (c *Connection) PushFile(path string, reader io.Reader, fileSize int64, permissions int64, uid, gid int64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Validate file size
+	if fileSize > MaxFileSize {
+		return fmt.Errorf("PushFile: file size %d exceeds maximum allowed size %d", fileSize, MaxFileSize)
+	}
+
+	// Get current time for file timestamps
+	now := time.Now().Unix()
+
+	// Use ProposeFile for files with data, ProposeEmptyFile for empty files
+	cmd := "ProposeFile"
+	if fileSize == 0 {
+		cmd = "ProposeEmptyFile"
+	}
+
+	request := map[string]interface{}{
+		"Cmd":                      cmd,
+		"FileCreationTime":         now,
+		"FileLastModificationTime": now,
+		"FilePermissions":          permissions,
+		"FileOwnerUserID":          uid,
+		"FileOwnerGroupID":         gid,
+		"Path":                     path,
+		"SessionID":                c.sessionID,
+	}
+
+	// For small files (<= 500 bytes), read data and send inline in XPC message
+	// For larger files, send via data service after ProposeFile
+	if cmd == "ProposeFile" {
+		request["FileSize"] = uint64(fileSize)
+		if fileSize <= MaxInlineDataSize {
+			// Small file: read into memory and include inline
+			data := make([]byte, fileSize)
+			_, err := io.ReadFull(reader, data)
+			if err != nil {
+				return fmt.Errorf("PushFile: failed to read small file: %w", err)
+			}
+			request["FileData"] = data
+		}
+	}
+
+	if err := c.conn.Send(request, xpc.HeartbeatRequestFlag); err != nil {
+		return fmt.Errorf("PushFile: failed to send request: %w", err)
+	}
+
+	// Propose responses come on ServerClientStream (like other control commands)
+	response, err := c.conn.ReceiveOnServerClientStream()
+	if err != nil {
+		return fmt.Errorf("PushFile: failed to receive response: %w", err)
+	}
+
+	// Check for errors in response
+	if err := extractError(response); err != nil {
+		return fmt.Errorf("PushFile: %w", err)
+	}
+
+	// For large files, stream data via data service
+	if cmd == "ProposeFile" && fileSize > MaxInlineDataSize {
+		// Extract response token and file ID for data service upload
+		responseToken, ok := response["Response"].(uint64)
+		if !ok {
+			return fmt.Errorf("PushFile: missing or invalid Response token")
+		}
+
+		fileID, ok := response["NewFileID"].(uint64)
+		if !ok {
+			return fmt.Errorf("PushFile: missing or invalid NewFileID")
+		}
+
+		if err := c.uploadFileData(responseToken, fileID, reader, fileSize); err != nil {
+			return fmt.Errorf("PushFile: failed to upload file data: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// uploadFileData uploads file data via the data service by streaming from an io.Reader
+func (c *Connection) uploadFileData(responseToken, fileID uint64, reader io.Reader, fileSize int64) error {
+	// Connect to data service using raw connection (not XPC)
+	dataConn, err := ios.ConnectToServiceTunnelIface(c.device, DataServiceName)
+	if err != nil {
+		return fmt.Errorf("uploadFileData: failed to connect to data service: %w", err)
+	}
+	defer dataConn.Close()
+
+	// Build and send the wire protocol header
+	// Based on reverse engineering DTRemoteServices FUN_000221f8:
+	// Offset 0: magic "rwb!FILE" (8 bytes)
+	// Offset 8: token = 0 (8 bytes big-endian)
+	// Offset 16: padding (8 bytes)
+	// Offset 24: file ID (8 bytes big-endian)
+	// Offset 32: file size (8 bytes big-endian)
+	// Offset 40: file data (streamed)
+	header := make([]byte, 40)
+
+	// Magic: "rwb!FILE" (8 bytes)
+	copy(header[0:8], []byte("rwb!FILE"))
+
+	// Response token (8 bytes, big-endian) - Set to 0 for uploads
+	binary.BigEndian.PutUint64(header[8:16], 0)
+
+	// Padding (8 bytes of zeros) - header is already zero-initialized
+
+	// File ID (8 bytes, big-endian)
+	binary.BigEndian.PutUint64(header[24:32], fileID)
+
+	// File size (8 bytes, big-endian)
+	binary.BigEndian.PutUint64(header[32:40], uint64(fileSize))
+
+	// Send the header
+	if err := sendRawData(dataConn, header); err != nil {
+		return fmt.Errorf("uploadFileData: failed to send header: %w", err)
+	}
+
+	// Stream the file data in chunks
+	const chunkSize = 256 * 1024 // 256KB chunks
+	buffer := make([]byte, chunkSize)
+
+	for {
+		n, err := reader.Read(buffer)
+		if n > 0 {
+			if err := sendRawData(dataConn, buffer[:n]); err != nil {
+				return fmt.Errorf("uploadFileData: failed to send chunk: %w", err)
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("uploadFileData: failed to read chunk: %w", err)
+		}
+	}
+
+	// Wait for confirmation from data service
+	confirmHeader := make([]byte, 32)
+	_, err = io.ReadFull(dataConn, confirmHeader)
+	if err != nil {
+		return fmt.Errorf("uploadFileData: failed to read confirmation: %w", err)
+	}
+
+	// Verify confirmation
+	confirmMagic := string(confirmHeader[0:8])
+	if confirmMagic != "rwb!FILE" {
+		return fmt.Errorf("uploadFileData: invalid confirmation magic: %s", confirmMagic)
+	}
+
+	return nil
+}
+
+// Close closes the connection to the file service
+func (c *Connection) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.conn.Close()
+}
+
+// extractError checks if the response contains an error and returns it
+func extractError(response map[string]interface{}) error {
+	if encodedError, ok := response["EncodedError"]; ok && encodedError != nil {
+		// Try to get localized description first
+		if errorMap, ok := encodedError.(map[string]interface{}); ok {
+			if desc, ok := errorMap["LocalizedDescription"].(string); ok && desc != "" {
+				return fmt.Errorf("device error: %s", desc)
+			}
+		}
+		return fmt.Errorf("device error: %+v", encodedError)
+	}
+	return nil
+}

--- a/ios/fileservice/fileservice_test.go
+++ b/ios/fileservice/fileservice_test.go
@@ -1,0 +1,246 @@
+//go:build !fast
+
+package fileservice_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/fileservice"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListDirectory tests listing files in an app's Documents directory
+func TestListDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	device, err := ios.GetDevice("")
+	require.NoError(t, err, "Failed to get device")
+
+	if !device.SupportsRsd() {
+		t.Skip("Device does not support RSD (iOS 17+)")
+	}
+
+	// Test with a known app - you'll need to replace this with an actual app bundle ID
+	bundleID := "com.apple.Preferences" // System Preferences app
+	conn, err := fileservice.New(device, fileservice.DomainAppDataContainer, bundleID)
+	if err != nil {
+		t.Skipf("Failed to create file service connection (app may not exist): %v", err)
+	}
+	defer conn.Close()
+
+	// List root directory
+	files, err := conn.ListDirectory(".")
+	require.NoError(t, err, "Failed to list directory")
+
+	t.Logf("Found %d files in root directory", len(files))
+	for _, file := range files {
+		t.Logf("  - %s", file)
+	}
+}
+
+// TestListSystemCrashLogs tests listing system crash logs
+func TestListSystemCrashLogs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	device, err := ios.GetDevice("")
+	require.NoError(t, err, "Failed to get device")
+
+	if !device.SupportsRsd() {
+		t.Skip("Device does not support RSD (iOS 17+)")
+	}
+
+	conn, err := fileservice.New(device, fileservice.DomainSystemCrashLogs, "")
+	if err != nil {
+		t.Skipf("Failed to create file service connection: %v", err)
+	}
+	defer conn.Close()
+
+	// List root directory of crash logs
+	files, err := conn.ListDirectory(".")
+	if err != nil {
+		t.Logf("Failed to list crash logs (may be empty or access denied): %v", err)
+		return
+	}
+
+	t.Logf("Found %d crash log files", len(files))
+	for i, file := range files {
+		if i < 10 { // Only print first 10
+			t.Logf("  - %s", file)
+		}
+	}
+}
+
+// TestPullFile tests downloading a file from the device
+func TestPullFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	device, err := ios.GetDevice("")
+	require.NoError(t, err, "Failed to get device")
+
+	if !device.SupportsRsd() {
+		t.Skip("Device does not support RSD (iOS 17+)")
+	}
+
+	// This test requires a known file to exist on the device
+	// You'll need to adjust this based on your test device
+	t.Skip("Skipping PullFile test - requires known file on device")
+
+	bundleID := "com.apple.Preferences"
+	conn, err := fileservice.New(device, fileservice.DomainAppDataContainer, bundleID)
+	require.NoError(t, err, "Failed to create file service connection")
+	defer conn.Close()
+
+	// Try to pull a file (adjust path as needed)
+	data, err := conn.PullFile("some/known/file.txt")
+	require.NoError(t, err, "Failed to pull file")
+
+	assert.Greater(t, len(data), 0, "File data should not be empty")
+	t.Logf("Downloaded file: %d bytes", len(data))
+}
+
+// TestPushFile tests uploading a file to the device
+func TestPushFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	device, err := ios.GetDevice("")
+	require.NoError(t, err, "Failed to get device")
+
+	if !device.SupportsRsd() {
+		t.Skip("Device does not support RSD (iOS 17+)")
+	}
+
+	// This test requires write access to an app's container
+	t.Skip("Skipping PushFile test - requires app with file sharing enabled")
+
+	bundleID := "com.example.testapp" // Replace with actual app
+	conn, err := fileservice.New(device, fileservice.DomainAppDataContainer, bundleID)
+	require.NoError(t, err, "Failed to create file service connection")
+	defer conn.Close()
+
+	// Create a test file
+	testData := []byte("Hello from go-ios fileservice!")
+	testFileName := "test_upload.txt"
+
+	// Push the file (0o644 = rw-r--r--)
+	err = conn.PushFile(testFileName, testData, 0o644, 501, 501)
+	require.NoError(t, err, "Failed to push file")
+
+	t.Logf("Successfully uploaded file: %s", testFileName)
+
+	// Verify the file exists
+	files, err := conn.ListDirectory(".")
+	require.NoError(t, err, "Failed to list directory")
+
+	found := false
+	for _, file := range files {
+		if file == testFileName {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Uploaded file should appear in directory listing")
+}
+
+// TestDomainTypes tests creating connections with different domain types
+func TestDomainTypes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	device, err := ios.GetDevice("")
+	require.NoError(t, err, "Failed to get device")
+
+	if !device.SupportsRsd() {
+		t.Skip("Device does not support RSD (iOS 17+)")
+	}
+
+	domains := []struct {
+		domain     fileservice.Domain
+		identifier string
+		name       string
+	}{
+		{fileservice.DomainAppDataContainer, "com.apple.Preferences", "App Data Container"},
+		{fileservice.DomainTemporary, "", "Temporary"},
+		{fileservice.DomainSystemCrashLogs, "", "System Crash Logs"},
+	}
+
+	for _, tc := range domains {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := fileservice.New(device, tc.domain, tc.identifier)
+			if err != nil {
+				t.Logf("Failed to create connection for %s: %v", tc.name, err)
+				return
+			}
+			defer conn.Close()
+
+			// Try to list root directory
+			files, err := conn.ListDirectory(".")
+			if err != nil {
+				t.Logf("Failed to list directory for %s: %v", tc.name, err)
+				return
+			}
+
+			t.Logf("%s: Found %d files", tc.name, len(files))
+		})
+	}
+}
+
+// Example usage documentation
+func ExampleConnection_ListDirectory() {
+	device, _ := ios.GetDevice("")
+
+	// Create a connection to an app's Documents directory
+	conn, _ := fileservice.New(device, fileservice.DomainAppDataContainer, "com.example.myapp")
+	defer conn.Close()
+
+	// List files in the root directory
+	files, _ := conn.ListDirectory(".")
+	for _, file := range files {
+		println(file)
+	}
+}
+
+// Example of pulling a file
+func ExampleConnection_PullFile() {
+	device, _ := ios.GetDevice("")
+
+	conn, _ := fileservice.New(device, fileservice.DomainAppDataContainer, "com.example.myapp")
+	defer conn.Close()
+
+	// Create output file for streaming
+	outputFile, _ := os.Create(filepath.Join(".", "myfile.txt"))
+	defer outputFile.Close()
+
+	// Download file (streaming)
+	_ = conn.PullFile("Documents/myfile.txt", outputFile)
+}
+
+// Example of pushing a file
+func ExampleConnection_PushFile() {
+	device, _ := ios.GetDevice("")
+
+	conn, _ := fileservice.New(device, fileservice.DomainAppDataContainer, "com.example.myapp")
+	defer conn.Close()
+
+	// Open local file for streaming
+	file, _ := os.Open("local_file.txt")
+	defer file.Close()
+
+	// Get file info for size and permissions
+	fileInfo, _ := file.Stat()
+
+	// Upload to device (streaming, preserves permissions)
+	_ = conn.PushFile("Documents/uploaded.txt", file, fileInfo.Size(), int64(fileInfo.Mode().Perm()), 501, 501)
+}


### PR DESCRIPTION
## Summary

- Implements a new `fileservice` package for iOS 17+ file operations via RemoteXPC
- Adds CLI commands: `ios file ls`, `ios file pull`, `ios file push`
- Supports multiple domains: app containers, app groups, temporary directories, and system crash logs
- Uses efficient data transfer with inline support for small files (<= 500 bytes)

## Implementation Details

This PR adds support for file operations on iOS 17+ devices using the RemoteXPC services:
- `com.apple.coredevice.fileservice.control` - for control operations (listing, session management)
- `com.apple.coredevice.fileservice.data` - for data transfer (pull/push file contents)

The implementation includes:
1. **fileservice.go**: Core file service connection and operations (list, pull, push)
2. **datatransfer.go**: Low-level data transfer protocol handling
3. **main.go**: CLI integration with new `ios file` commands

### Domain Support
- `app` - App's Documents directory (requires `--app=<bundleID>`)
- `group` - App group shared containers (requires `--app=<groupID>`)
- `temp` - Temporary directory
- `crashlogs` - System crash logs directory

### Example Usage
```bash
# List files in app's Documents directory
ios file ls --app=com.example.app --path=Documents

# Download a file
ios file pull --app=com.example.app --remote=Documents/data.txt --local=./data.txt

# Upload a file
ios file push --app=com.example.app --local=./upload.txt --remote=Documents/upload.txt
```
