### PR TITLE
Accessibility Inspector: return spoken description for focused element

### DIFF
--- a/ios/accessibility/accessibility_control.go
+++ b/ios/accessibility/accessibility_control.go
@@ -217,8 +217,28 @@ func (a ControlInterface) extractSpokenDescription(innerValue map[string]interfa
 	return ""
 }
 
-// extractPlatformElementBytes extracts the platform element bytes from innerValue.
-// Extraction path: ElementValue_v1 -> Value -> Value -> PlatformElementValue_v1 -> Value ([]byte)
+/*
+PlatformElementValue_v1: A base64-encoded string that uniquely identifies an accessibility element.
+It is required to perform actions on the element.
+
+Extraction path:
+    ElementValue_v1
+      └── Value
+          └── Value
+              └── PlatformElementValue_v1
+                  └── Value ([]byte)
+
+Binary ([]byte):
+    ┌──────────────────────────────┐
+    │ [0x50, 0x67, 0x41, ...]      │   // Raw bytes from dtx message payload
+    └──────────────────────────────┘
+
+Base64 (string):
+    ┌──────────────────────────────┐
+    │ "PgAAAACikAEBAAAACg..."      │   // base64 encoded unique ID of AX element
+    └──────────────────────────────┘
+*/
+
 func (a ControlInterface) extractPlatformElementBytes(innerValue map[string]interface{}) ([]byte, error) {
 	elementValue, err := getNestedMap(innerValue, "ElementValue_v1")
 	if err != nil {

--- a/ios/accessibility/utils.go
+++ b/ios/accessibility/utils.go
@@ -2,8 +2,6 @@ package accessibility
 
 import (
 	"fmt"
-
-	log "github.com/sirupsen/logrus"
 )
 
 func convertToStringList(payload []interface{}) ([]string, error) {
@@ -81,7 +79,6 @@ func deserializeObject(d interface{}) interface{} {
 	}
 }
 
-// extractStringFromField extracts a string value from a field in innerValue.
 func (a ControlInterface) extractStringFromField(innerValue map[string]interface{}, fieldName string) string {
 	raw, ok := innerValue[fieldName]
 	if !ok {
@@ -90,13 +87,11 @@ func (a ControlInterface) extractStringFromField(innerValue map[string]interface
 
 	val := deserializeObject(raw)
 	if s, ok := val.(string); ok && s != "" {
-		log.Infof("%s: %q", fieldName, s)
 		return s
 	}
 
 	if val != nil {
 		desc := fmt.Sprintf("%v", val)
-		log.Infof("%s: %q", fieldName, desc)
 		return desc
 	}
 


### PR DESCRIPTION
After navigating to a element we would like to return the spoken description of the focused element. That allows a client to consume the string and could potentially feed it to an audio engine.

Created some helper method to avoid repetition.