### PR TITLE
Support GO_IOS_UDID environment variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ Options:
   --nojson                  Disable JSON output
   --pretty                  Pretty-print JSON command output
   -h --help                 Show this screen.
-  --udid=<udid>             UDID of the device.
+  --udid=<udid>             UDID of the device. Can also be set via GO_IOS_UDID environment variable.
   --tunnel-info-port=<port> When go-ios is used to manage tunnels for iOS 17+ it exposes them on an HTTP-API for localhost (default port: 28100)
   --address=<ipv6addrr>     Address of the device on the interface. This parameter is optional and can be set if a tunnel created by MacOS needs to be used.
   >                         To get this value run "log stream --debug --info --predicate 'eventMessage LIKE "*Tunnel established*" OR eventMessage LIKE "*for server port*"'",
@@ -351,6 +351,9 @@ The commands work as following:
 	tunnelCommand, _ := arguments.Bool("tunnel")
 
 	udid, _ := arguments.String("--udid")
+	if udid == "" {
+		udid = os.Getenv("GO_IOS_UDID")
+	}
 	address, addressErr := arguments.String("--address")
 	rsdPort, rsdErr := arguments.Int("--rsd-port")
 	userspaceTunnelHost, userspaceTunnelHostErr := arguments.String("--userspace-host")


### PR DESCRIPTION
## Summary

Add support for reading device UDID from the `GO_IOS_UDID` environment variable when the `--udid` flag is not specified.

## Changes

- Added fallback to `GO_IOS_UDID` environment variable in main.go
- The `--udid` flag takes precedence if both are specified

## Usage

Users can now set the device UDID via environment variable:

```bash
export GO_IOS_UDID=00008030-000E04D62E8B802E
ios file ls --app=com.example.app
```

Or continue using the flag as before:

```bash
ios --udid=00008030-000E04D62E8B802E file ls --app=com.example.app
```

## Test plan

- Build succeeds
- Command works with `--udid` flag (existing behavior)
- Command works with `GO_IOS_UDID` env var (new behavior)
- Flag takes precedence over env var when both are set

🤖 Generated with [Claude Code](https://claude.com/claude-code)