### PR TITLE
Fix release workflow using wrong version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Fetch all tags
-        run: git fetch --tags --force
-
       - name: Create Release
         id: create_release
-        uses: zendesk/action-create-release@v1
+        uses: zendesk/action-create-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- Upgrade `zendesk/action-create-release` from v1 to v3 to fix incorrect tag detection
- Remove unnecessary "Fetch all tags" step

## Problem
The release workflow was detecting `v1.0.99` as the latest tag instead of `v1.0.182`. This happened because:

1. GitHub API returns tags in **lexicographic order**: `v1.0.1`, `v1.0.10`, `v1.0.100`, ..., `v1.0.182`, ..., `v1.0.99`
2. The v1 action used `refs.reverse()` which simply reverses this order
3. Since `v1.0.99` is last lexicographically (after `v1.0.98`, nothing starts with `v1.0.9` after it), it became "first" after reversal

## Solution
The v3 action uses proper semantic version sorting (`semver.rcompare`) instead of simple reversal, correctly identifying `v1.0.182` as the highest version.

## Changes between v1 and v3
| Version | Node | Tag Sorting |
|---------|------|-------------|
| v1 | node12 | `reverse()` (lexicographic) |
| v3 | node16 | `semver.rcompare()` (semantic) |

No breaking changes - same inputs/outputs, drop-in replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)