### PR TITLE
Add golangci-lint with pre-commit hook and CI integration

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Pre-commit hook for go-ios
+# Runs gofmt and golangci-lint before allowing commits
+
+set -e
+
+echo "Running pre-commit checks..."
+
+# Check if golangci-lint is installed
+if ! command -v golangci-lint &> /dev/null; then
+    echo "Error: golangci-lint is not installed."
+    echo "Install it with: brew install golangci-lint"
+    echo "Or see: https://golangci-lint.run/docs/welcome/install/"
+    exit 1
+fi
+
+# Check formatting
+echo "Checking code formatting..."
+UNFORMATTED=$(gofmt -l .)
+if [ -n "$UNFORMATTED" ]; then
+    echo "Error: The following files are not formatted:"
+    echo "$UNFORMATTED"
+    echo ""
+    echo "Run 'gofmt -w .' to fix formatting."
+    exit 1
+fi
+
+# Run linter
+echo "Running golangci-lint..."
+golangci-lint run
+if [ $? -ne 0 ]; then
+    echo "Error: Linter found issues. Please fix them before committing."
+    exit 1
+fi
+
+echo "All checks passed!"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,24 @@ on:
 
 name: Unit tests
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install libusb
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.6
+
   test_on_windows:
     runs-on: windows-latest
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - forbidigo
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: ^print$
+          msg: "use fmt.Print* or log.* instead of built-in print (prints to stderr)"
+        - pattern: ^println$
+          msg: "use fmt.Println or log.* instead of built-in println (prints to stderr)"
+      analyze-types: true

--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,15 @@ run: build
 # Build and run
 up: build run
 
+# Run linter
+lint:
+	@golangci-lint run
+
+# Setup development environment (installs git hooks)
+setup:
+	@echo "Configuring git hooks..."
+	@git config core.hooksPath .githooks
+	@echo "Done! Pre-commit hooks are now active."
+
 # Phony targets
-.PHONY: build run up
+.PHONY: build run up lint setup

--- a/ios/discover.go
+++ b/ios/discover.go
@@ -58,7 +58,7 @@ func checkEntry(ctx context.Context, device DeviceEntry, interfaceName string, e
 			if entry == nil {
 				continue
 			}
-			print(entry.ServiceInstanceName())
+			fmt.Print(entry.ServiceInstanceName())
 			for _, ip6 := range entry.AddrIPv6 {
 				tryHandshake(ctx, ip6, entry.Port, interfaceName, device, result)
 			}

--- a/ios/fileservice/fileservice_test.go
+++ b/ios/fileservice/fileservice_test.go
@@ -3,6 +3,8 @@
 package fileservice_test
 
 import (
+	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -101,11 +103,12 @@ func TestPullFile(t *testing.T) {
 	defer conn.Close()
 
 	// Try to pull a file (adjust path as needed)
-	data, err := conn.PullFile("some/known/file.txt")
+	var buf bytes.Buffer
+	err = conn.PullFile("some/known/file.txt", &buf)
 	require.NoError(t, err, "Failed to pull file")
 
-	assert.Greater(t, len(data), 0, "File data should not be empty")
-	t.Logf("Downloaded file: %d bytes", len(data))
+	assert.Greater(t, buf.Len(), 0, "File data should not be empty")
+	t.Logf("Downloaded file: %d bytes", buf.Len())
 }
 
 // TestPushFile tests uploading a file to the device
@@ -134,7 +137,7 @@ func TestPushFile(t *testing.T) {
 	testFileName := "test_upload.txt"
 
 	// Push the file (0o644 = rw-r--r--)
-	err = conn.PushFile(testFileName, testData, 0o644, 501, 501)
+	err = conn.PushFile(testFileName, bytes.NewReader(testData), int64(len(testData)), 0o644, 501, 501)
 	require.NoError(t, err, "Failed to push file")
 
 	t.Logf("Successfully uploaded file: %s", testFileName)
@@ -208,7 +211,7 @@ func ExampleConnection_ListDirectory() {
 	// List files in the root directory
 	files, _ := conn.ListDirectory(".")
 	for _, file := range files {
-		println(file)
+		fmt.Println(file)
 	}
 }
 

--- a/ios/nskeyedarchiver/archiver_test.go
+++ b/ios/nskeyedarchiver/archiver_test.go
@@ -31,7 +31,7 @@ func TestArchiveSlice(t *testing.T) {
 	assert.Equal(t, "abc", val[0])
 	assert.Equal(t, "def", val[1])
 	assert.Equal(t, "ok", val[2])
-	print(val)
+	fmt.Print(val)
 }
 
 // TODO currently only partially decoding XCTestConfig is supported, fix later
@@ -43,7 +43,7 @@ func TestXCTestconfig(t *testing.T) {
 		log.Error(err)
 		t.Fatal()
 	}
-	print(result)
+	fmt.Print(result)
 	log.Info(uuid.String())
 	res, err := nskeyedarchiver.Unarchive([]byte(result))
 	assert.NoError(t, err)
@@ -317,7 +317,7 @@ func TestDecoderJson(t *testing.T) {
 		plistBytes, _ := hex.DecodeString(plistHex)
 		nska, err := archiver.Unarchive(plistBytes)
 		output := convertToJSON(nska)
-		print(output)
+		fmt.Print(output)
 		assert.NoError(t, err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -403,7 +403,7 @@ The commands work as following:
 		}
 
 		exitIfError("failed erasing", mcinstall.Erase(device))
-		print(convertToJSONString("ok"))
+		fmt.Print(convertToJSONString("ok"))
 		return
 	}
 
@@ -417,7 +417,7 @@ The commands work as following:
 			} else {
 				b, err := marshalJSON(services)
 				exitIfError("failed json conversion", err)
-				println(string(b))
+				fmt.Println(string(b))
 			}
 			return
 		}
@@ -465,7 +465,7 @@ The commands work as following:
 		}
 		b, _ = arguments.Bool("printskip")
 		if b {
-			println(convertToJSONString(mcinstall.GetAllSetupSkipOptions()))
+			fmt.Println(convertToJSONString(mcinstall.GetAllSetupSkipOptions()))
 			return
 		}
 		skip := mcinstall.GetAllSetupSkipOptions()
@@ -487,7 +487,7 @@ The commands work as following:
 			}
 		}
 		exitIfError("failed erasing", mcinstall.Prepare(device, skip, certBytes, orgname, locale, lang))
-		print(convertToJSONString("ok"))
+		fmt.Print(convertToJSONString("ok"))
 		return
 	}
 
@@ -501,7 +501,7 @@ The commands work as following:
 	if b {
 		ip, err := pcap.FindIp(device)
 		exitIfError("failed", err)
-		println(convertToJSONString(ip))
+		fmt.Println(convertToJSONString(ip))
 		return
 	}
 
@@ -1615,7 +1615,7 @@ func instrumentsCommand(device ios.DeviceEntry, arguments docopt.Opts) bool {
 					return
 				}
 				s, _ := json.Marshal(notification)
-				println(string(s))
+				fmt.Println(string(s))
 			}
 		}()
 		c := make(chan os.Signal, 1)
@@ -1661,7 +1661,7 @@ func crashCommand(device ios.DeviceEntry, arguments docopt.Opts) bool {
 			}
 			files, err := crashreport.ListReports(device, pattern)
 			exitIfError("failed listing crashreports", err)
-			println(
+			fmt.Println(
 				convertToJSONString(
 					map[string]interface{}{"files": files, "length": len(files)},
 				),
@@ -1698,7 +1698,7 @@ func deviceState(device ios.DeviceEntry, list bool, enable bool, profileTypeId s
 		} else {
 			b, err := marshalJSON(profileTypes)
 			exitIfError("failed json conversion", err)
-			println(string(b))
+			fmt.Println(string(b))
 		}
 		return
 	}
@@ -1736,7 +1736,7 @@ func outputPrettyStateList(types []instruments.ProfileType) {
 		}
 		buffer.WriteString("\n\n")
 	}
-	println(buffer.String())
+	fmt.Println(buffer.String())
 }
 
 func listMountedImages(device ios.DeviceEntry) {


### PR DESCRIPTION
## Summary
- Add `.golangci.yml` config with `forbidigo` linter to catch built-in `print`/`println` usage (these print to stderr instead of stdout)
- Replace all `print`/`println` calls with `fmt.Print`/`fmt.Println` across the codebase
- Fix `fileservice_test.go` to use correct `PullFile`/`PushFile` API signatures
- Add lint job to GitHub Actions CI workflow (runs on PRs)
- Add pre-commit hook (`.githooks/pre-commit`) that runs `gofmt` and `golangci-lint`
- Add `make setup` to configure git hooks and `make lint` to run linter manually

## Usage
New contributors should run once after cloning:
```bash
make setup
```

To run linter manually:
```bash
make lint
```

## Test plan
- [x] `golangci-lint run` passes with 0 issues
- [x] `go build ./...` succeeds
- [x] Pre-commit hook tested locally

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)