### PR TITLE
Add lockdown get command to query lockdown values

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ The commands work as following:
    ios launch <bundleID> [--wait] [--kill-existing] [--arg=<a>]... [--env=<e>]... [options] Launch app with the bundleID on the device. Get your bundle ID from the apps command. --wait keeps the connection open if you want logs.
    ios list [options] [--details]                                     Prints a list of all connected device's udids. If --details is specified, it includes version, name and model of each device.
    ios listen [options]                                               Keeps a persistent connection open and notifies about newly connected or disconnected devices.
+   ios lockdown get [<key>] [--domain=<domain>] [options]             Query lockdown values. Without arguments returns all values. Specify a key to get a specific value.
+   >                                                                  Use --domain to query from a specific domain (e.g., com.apple.disk_usage, com.apple.PurpleBuddy).
+   >                                                                  Examples: "ios lockdown get DeviceName", "ios lockdown get --domain=com.apple.PurpleBuddy"
    ios memlimitoff (--process=<processName>) [options]                Waives memory limit set by iOS (For instance a Broadcast Extension limit is 50 MB).
    ios mobilegestalt <key>... [--plist] [options]                     Lets you query mobilegestalt keys. Standard output is json but if desired you can get
    >                                                                  it in plist format by adding the --plist param.


### PR DESCRIPTION
## Summary

Add new CLI command `ios lockdown get [<key>] [--domain=<domain>]` that allows querying specific lockdown values from the device.

This is similar to pymobiledevice3's `lockdown get-value` command and provides a flexible way to query device state.

## Usage Examples

```bash
# Get all lockdown values
ios lockdown get

# Get a specific key
ios lockdown get DeviceName
ios lockdown get ActivationState

# Query from a specific domain
ios lockdown get --domain=com.apple.disk_usage
ios lockdown get TotalDiskCapacity --domain=com.apple.disk_usage

# Query PurpleBuddy (Setup Assistant) state
ios lockdown get --domain=com.apple.PurpleBuddy
```

## Use Cases

- Check device activation state
- Monitor Setup Assistant progress via `com.apple.PurpleBuddy` domain
- Query disk usage information
- Debug device configuration issues

## Test plan

- [x] `ios lockdown get` returns all values
- [x] `ios lockdown get DeviceName` returns just the device name
- [x] `ios lockdown get --domain=com.apple.disk_usage` returns domain values
- [x] `ios lockdown get --domain=com.apple.PurpleBuddy` returns Setup Assistant state

🤖 Generated with [Claude Code](https://claude.com/claude-code)