### PR TITLE
Bugfix: use service version instead of OS version for Audit API

### DIFF
--- a/ios/accessibility/accessibility_control.go
+++ b/ios/accessibility/accessibility_control.go
@@ -409,7 +409,6 @@ func (a ControlInterface) deviceAllAuditCaseIDs(api uint64) ([]string, error) {
 	var response dtx.Message
 	var err error
 	// api version 21 corresponds to iOS 15.
-	log.Info("deviceAllAuditCaseIDs api version:", api)
 	if api >= 21 {
 		response, err = a.channel.MethodCall("deviceAllSupportedAuditTypes")
 	} else {


### PR DESCRIPTION
**Problem:**

Enable AX inspector breaks for iOS 14 or below because during inspector's initialisation we grab audit case id. We use the newer version api for iOS 14 which breaks enabling Accessibility Inspector.


**Solution:** 
The Accessibility Audit API changed after iOS 15. The AX inspector provides `deviceAPIVersion` which uses a different version numbering scheme than the OS version API version 21 corresponds to iOS 15 and so on.