### PR TITLE
fix: proper parsing of locale and lang arguments in prepare command

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ Usage:
   ios mobilegestalt <key>... [--plist] [options]
   ios pair [--p12file=<orgid>] [--password=<p12password>] [options]
   ios pcap [options] [--pid=<processID>] [--process=<processName>]
-  ios prepare [--skip-all] [--skip=<option>]... [--certfile=<cert_file_path>] [--orgname=<org_name>] [--p12password=<p12password>] [--locale] [--lang] [options]
+  ios prepare [--skip-all] [--skip=<option>]... [--certfile=<cert_file_path>] [--orgname=<org_name>] [--p12password=<p12password>] [--locale=<locale>] [--lang=<lang>] [options]
   ios prepare cloudconfig [options]
   ios prepare create-cert
   ios prepare printskip


### PR DESCRIPTION
The arguments of the prepare subcommand are not parsed correctly

```
ios prepare --locale=it_IT --lang=it
ios prepare --locale it_IT --lang it
```

They both result in the help message

With the provided edit it is possible to properly set a locale and a language different from english
