### PR TITLE
'kill' and  'file push' command json output changes

### DIFF
--- a/main.go
+++ b/main.go
@@ -1397,7 +1397,7 @@ The commands work as following:
 			fileSize := fileInfo.Size()
 
 			if !JSONdisabled {
-				result := map[string]any{
+				result := map[string]interface{}{
 					"remote": remotePath,
 					"local":  localPath,
 					"size":   fileSize,
@@ -1438,7 +1438,7 @@ The commands work as following:
 			exitIfError("push: failed to upload file", err)
 
 			if !JSONdisabled {
-				result := map[string]any{
+				result := map[string]interface{}{
 					"remote": remotePath,
 					"local":  localPath,
 					"size":   fileSize,


### PR DESCRIPTION
Changes:

- The `kill` command JSON output now includes a `pid` field that contains the process ID of the killed process. For parity with the `launch` command output.

- The `file push` command now respects the `--nojson` flag. Previous implementation was checking the undocumented `--json` flag instead of `JSONdisabled` variable. Also removed the `success` field since `exitIfError` is checked before-hand.