### PR TITLE
Improve error messages for developer mode enabling

### DIFF
--- a/ios/amfi/amfi.go
+++ b/ios/amfi/amfi.go
@@ -61,8 +61,8 @@ func (devModeConn *Connection) EnableDevMode() error {
 	}
 
 	// Check if we have an error returned by the service
-	if _, ok := plist["Error"]; ok {
-		return fmt.Errorf("EnableDevMode: could not enable developer mode through amfi service")
+	if errorMsg, ok := plist["Error"]; ok {
+		return fmt.Errorf("EnableDevMode: could not enable developer mode through amfi service with error: %s", errorMsg)
 	}
 
 	if _, ok := plist["success"]; ok {


### PR DESCRIPTION
Provide error handling with developer mode enabled, providing specific error messages based on the response from the amfi service. For example, unable to enable developer mode while passcode set.
`time="2026-01-31T13:25:51+08:00" level=fatal msg="Failed enabling developer mode" err="EnableDeveloperMode: failed enabling developer mode with err: EnableDevMode: could not enable developer mode through amfi service with error: Device has a passcode set"`