### PR TITLE
fix: prevent socket leak in TunnelManager

### DIFF
--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -311,12 +311,23 @@ func RefreshTunnelForDevice(udid string, tunnelInfoHost string, tunnelInfoPort i
 
 // TunnelManager starts tunnels for devices when needed (if no tunnel is running yet) and stores the information
 // how those tunnels are reachable (address and remote service discovery port)
+// failedDevice tracks a device whose tunnel failed to start, so retries can be
+// backed off instead of attempted every UpdateTunnels cycle (each attempt opens
+// a usbmux socket, so hammering a device that always fails leaks sockets).
+type failedDevice struct {
+	lastAttempt time.Time
+	failCount   int
+}
+
 type TunnelManager struct {
-	ts                   tunnelStarter
-	dl                   deviceLister
-	pm                   PairRecordManager
-	mux                  sync.Mutex
-	tunnels              map[string]Tunnel
+	ts      tunnelStarter
+	dl      deviceLister
+	pm      PairRecordManager
+	mux     sync.Mutex
+	tunnels map[string]Tunnel
+	// failedDevices tracks devices whose tunnel start failed (keyed by udid) so
+	// UpdateTunnels can back off before retrying them.
+	failedDevices        map[string]failedDevice
 	startTunnelTimeout   time.Duration
 	firstUpdateCompleted bool
 	userspaceTUN         bool
@@ -355,6 +366,7 @@ func newTunnelManager(pm PairRecordManager, userspaceTUN bool, udidFilter string
 		dl:                 deviceList{},
 		pm:                 pm,
 		tunnels:            map[string]Tunnel{},
+		failedDevices:      map[string]failedDevice{},
 		startTunnelTimeout: 10 * time.Second,
 		userspaceTUN:       userspaceTUN,
 		udidFilter:         udidFilter,
@@ -396,6 +408,8 @@ func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 	m.mux.Lock()
 	localTunnels := map[string]Tunnel{}
 	maps.Copy(localTunnels, m.tunnels)
+	localFailed := map[string]failedDevice{}
+	maps.Copy(localFailed, m.failedDevices)
 	m.mux.Unlock()
 
 	devices, err := m.dl.ListDevices()
@@ -410,12 +424,28 @@ func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 		}
 		return fmt.Errorf("UpdateTunnels: failed to get list of devices: %w", err)
 	}
+
+	// currentUDIDs holds every connected device (built before the udidFilter
+	// check) so stale failedDevices entries for now-disconnected devices can be
+	// pruned below, letting a reconnect retry immediately.
+	currentUDIDs := make(map[string]bool, len(devices.DeviceList))
+	for _, d := range devices.DeviceList {
+		currentUDIDs[d.Properties.SerialNumber] = true
+	}
+
 	for _, d := range devices.DeviceList {
 		udid := d.Properties.SerialNumber
 		if m.udidFilter != "" && udid != m.udidFilter {
 			continue
 		}
 		if _, exists := localTunnels[udid]; exists {
+			continue
+		}
+		// Skip network devices (they can't tunnel) and devices still inside their
+		// failure backoff window. Either way, attempting a tunnel here would open
+		// a usbmux socket (via GetProductVersion) that, for a device that always
+		// fails, accumulates as a leaked socket every cycle.
+		if shouldSkipDevice(d, localFailed, time.Now()) {
 			continue
 		}
 		if m.userspaceTUN && d.UserspaceTUNPort == 0 {
@@ -425,9 +455,13 @@ func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 		t, err := m.startTunnel(ctx, d)
 		if err != nil {
 			golog.Warn("failed to start tunnel", "module", logModule, "udid", udid, "error", err)
+			m.mux.Lock()
+			m.failedDevices[udid] = failedDevice{lastAttempt: time.Now(), failCount: m.failedDevices[udid].failCount + 1}
+			m.mux.Unlock()
 			continue
 		}
 		m.mux.Lock()
+		delete(m.failedDevices, udid)
 		localTunnels[udid] = t
 		m.tunnels[udid] = t
 		m.mux.Unlock()
@@ -441,9 +475,44 @@ func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 		}
 	}
 	m.mux.Lock()
+	for udid := range m.failedDevices {
+		if !currentUDIDs[udid] {
+			delete(m.failedDevices, udid)
+		}
+	}
 	m.firstUpdateCompleted = true
 	m.mux.Unlock()
 	return nil
+}
+
+// shouldSkipDevice reports whether UpdateTunnels should not attempt a tunnel for
+// d on this cycle: network-connected devices can never establish a tunnel, and a
+// device that recently failed is held off until its backoff window elapses.
+func shouldSkipDevice(d ios.DeviceEntry, failed map[string]failedDevice, now time.Time) bool {
+	if d.Properties.ConnectionType == "Network" {
+		return true
+	}
+	if f, ok := failed[d.Properties.SerialNumber]; ok && now.Sub(f.lastAttempt) < failedDeviceBackoff(f.failCount) {
+		return true
+	}
+	return false
+}
+
+// failedDeviceBackoff returns how long to wait before retrying a device after
+// failCount consecutive failures: 30s, 60s, 120s, 240s, capped at 5 minutes.
+func failedDeviceBackoff(failCount int) time.Duration {
+	shift := failCount - 1
+	if shift < 0 {
+		shift = 0
+	}
+	if shift > 4 {
+		shift = 4
+	}
+	seconds := 30 * (1 << shift)
+	if seconds > 300 {
+		seconds = 300
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 func (m *TunnelManager) RemoveTunnel(ctx context.Context, serialNumber string) error {

--- a/ios/tunnel/tunnel_socketleak_test.go
+++ b/ios/tunnel/tunnel_socketleak_test.go
@@ -1,0 +1,130 @@
+package tunnel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios"
+)
+
+type stubDeviceLister struct{ list ios.DeviceList }
+
+func (s stubDeviceLister) ListDevices() (ios.DeviceList, error) { return s.list, nil }
+
+func devEntry(udid, connType string) ios.DeviceEntry {
+	return ios.DeviceEntry{Properties: ios.DeviceProperties{SerialNumber: udid, ConnectionType: connType}}
+}
+
+func leakTestManager(entries ...ios.DeviceEntry) *TunnelManager {
+	return &TunnelManager{
+		dl:                 stubDeviceLister{list: ios.DeviceList{DeviceList: entries}},
+		tunnels:            map[string]Tunnel{},
+		failedDevices:      map[string]failedDevice{},
+		startTunnelTimeout: time.Second,
+	}
+}
+
+func TestFailedDeviceBackoff(t *testing.T) {
+	cases := []struct {
+		failCount int
+		want      time.Duration
+	}{
+		{1, 30 * time.Second},
+		{2, 60 * time.Second},
+		{3, 120 * time.Second},
+		{4, 240 * time.Second},
+		{5, 300 * time.Second}, // 480s capped to 5 min
+		{10, 300 * time.Second},
+	}
+	for _, c := range cases {
+		if got := failedDeviceBackoff(c.failCount); got != c.want {
+			t.Errorf("failedDeviceBackoff(%d) = %v, want %v", c.failCount, got, c.want)
+		}
+	}
+}
+
+func TestShouldSkipDevice(t *testing.T) {
+	now := time.Now()
+	failed := map[string]failedDevice{
+		"recent": {lastAttempt: now.Add(-10 * time.Second), failCount: 1}, // 30s window, 10s elapsed → skip
+		"stale":  {lastAttempt: now.Add(-31 * time.Second), failCount: 1}, // 30s window, 31s elapsed → retry
+	}
+	cases := []struct {
+		name, udid, conn string
+		want             bool
+	}{
+		{"network always skipped", "net", "Network", true},
+		{"fresh usb attempted", "fresh", "USB", false},
+		{"recent failure backed off", "recent", "USB", true},
+		{"stale failure retried", "stale", "USB", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldSkipDevice(devEntry(c.udid, c.conn), failed, now); got != c.want {
+				t.Fatalf("shouldSkipDevice = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// A network device can never tunnel, so UpdateTunnels must never attempt one —
+// proven by it leaving no failedDevices entry (an attempt would record a
+// failure) and creating no tunnel.
+func TestUpdateTunnelsSkipsNetworkDevices(t *testing.T) {
+	tm := leakTestManager(devEntry("net-1", "Network"))
+	if err := tm.UpdateTunnels(context.Background()); err != nil {
+		t.Fatalf("UpdateTunnels: %v", err)
+	}
+	if len(tm.failedDevices) != 0 {
+		t.Fatalf("network device must not be attempted; failedDevices=%v", tm.failedDevices)
+	}
+	if len(tm.tunnels) != 0 {
+		t.Fatalf("no tunnel expected for network device; tunnels=%v", tm.tunnels)
+	}
+}
+
+// A device still inside its backoff window must not be retried — the leak this
+// whole change prevents. Pre-seeding a long backoff means UpdateTunnels skips it
+// and leaves its entry untouched (no new attempt timestamp).
+func TestUpdateTunnelsRespectsBackoff(t *testing.T) {
+	tm := leakTestManager(devEntry("usb-1", "USB"))
+	seeded := time.Now()
+	tm.failedDevices["usb-1"] = failedDevice{lastAttempt: seeded, failCount: 5} // 5 min backoff
+	if err := tm.UpdateTunnels(context.Background()); err != nil {
+		t.Fatalf("UpdateTunnels: %v", err)
+	}
+	got, ok := tm.failedDevices["usb-1"]
+	if !ok {
+		t.Fatal("usb-1 should remain in failedDevices (still backed off)")
+	}
+	if !got.lastAttempt.Equal(seeded) || got.failCount != 5 {
+		t.Fatalf("backed-off device must not be retried; entry changed: %+v", got)
+	}
+}
+
+// failedDevices entries for devices that are no longer connected get pruned, so
+// a reconnect retries immediately instead of waiting out a stale backoff.
+func TestUpdateTunnelsPrunesDisconnectedFailedDevices(t *testing.T) {
+	tm := leakTestManager(devEntry("net-1", "Network"))
+	tm.failedDevices["gone"] = failedDevice{lastAttempt: time.Now(), failCount: 2}
+	if err := tm.UpdateTunnels(context.Background()); err != nil {
+		t.Fatalf("UpdateTunnels: %v", err)
+	}
+	if _, ok := tm.failedDevices["gone"]; ok {
+		t.Fatal("disconnected device should be pruned from failedDevices")
+	}
+}
+
+// A USB device whose tunnel start fails (no real backend on CI → GetProductVersion
+// errors) must be recorded so the next cycle backs off instead of retrying.
+func TestUpdateTunnelsRecordsFailure(t *testing.T) {
+	tm := leakTestManager(devEntry("usb-1", "USB"))
+	if err := tm.UpdateTunnels(context.Background()); err != nil {
+		t.Fatalf("UpdateTunnels: %v", err)
+	}
+	got, ok := tm.failedDevices["usb-1"]
+	if !ok || got.failCount != 1 {
+		t.Fatalf("failed USB device should be recorded with failCount=1, got ok=%v entry=%+v", ok, got)
+	}
+}


### PR DESCRIPTION
## Problem                                                                                                                                      
                                                                                                                                                  
  The `TunnelManager.UpdateTunnels()` function was creating socket connections to `/var/run/usbmuxd` for every device on every call, including    
  network-connected devices that can never establish tunnels. This caused thousands of orphaned Unix sockets to accumulate over time.             
                                                                                                                                                  
  **Root cause:**                                                                                                                                 
  1. `ListDevices()` returns all devices including 50+ network-connected devices                                                                  
  2. For each device not in `m.tunnels`, it calls `startTunnel()` which creates socket connections via `ios.GetProductVersion()`                  
  3. Network devices always fail to connect, but are **never tracked as failed**                                                                  
  4. Next `UpdateTunnels()` call retries the same failing devices                                                                                 
  5. With default 1-second interval × 50+ network devices = hundreds of leaked sockets per hour                                                   
                                                                                                                                                  
  **Evidence:** After running overnight, `lsof` showed 3000+ orphaned Unix sockets:                                                               
  Busymate 94207    v    5u     unix 0x5bcac11ae229dddf   ->(none)                                                                                
  Busymate 94207    v    6u     unix 0x1c4c7d88a25e315b   ->(none)                                                                                
  ... (3000+ more)                                                                                                                                
                                                                                                                                                  
  ## Solution                                                                                                                                     
                                                                                                                                                  
  1. **Skip network-connected devices** - They cannot establish tunnels anyway (`ConnectionType == "Network"`)                                    
                                                                                                                                                  
  2. **Track failed devices with exponential backoff** - Instead of retrying every cycle:                                                         
     - 30s after 1st failure                                                                                                                      
     - 60s after 2nd failure                                                                                                                      
     - 120s after 3rd failure                                                                                                                     
     - Max 5 minutes between retries                                                                                                              
                                                                                                                                                  
  3. **Clean up on disconnect** - Remove device from failed list when it disconnects, allowing fresh retry on reconnect                           
                                                                                                                                                  
  4. **Clean up on success** - Remove device from failed list when tunnel succeeds                                                                
                                                                                                                                                  
## Testing                                                                                                                                      
                                                                                                                                                  
  - **OS:** macOS 15 Sequoia (Darwin 24.6.0)                                                                                                      
  - Ran app overnight with 50+ network devices discovered                                                                                         
  - Socket count remained stable instead of growing unboundedly                                                                                   
  - USB-connected devices still establish tunnels correctly