### PR TITLE
Fix IPv6 header check

### DIFF
--- a/ios/tunnel/tunnel_lockdown.go
+++ b/ios/tunnel/tunnel_lockdown.go
@@ -107,7 +107,7 @@ func forwardTCPToInterface(ctx context.Context, mtu uint64, deviceConn io.Reader
 			}
 
 			if ip6Header[0]>>4 != 6 {
-				return fmt.Errorf("not an IPv6 packet. expected 0x60, but got 0x%02x", ip6Header[0])
+				return fmt.Errorf("not an IPv6 packet: expected version 6, got %d", ip6Header[0]>>4)
 			}
 			payloadLength := binary.BigEndian.Uint16(ip6Header[4:6])
 			_, err = io.ReadFull(br, payload[:payloadLength])


### PR DESCRIPTION
Now the code correctly checks for IPv6 packets by verifying the version field, rather than relying on a hardcoded value.

(To add support for Traffic Class bytes)