### PR TITLE
fix: only one device reconnect fail

### DIFF
--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -278,6 +278,10 @@ func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 
 	devices, err := m.dl.ListDevices()
 	if err != nil {
+		for udid, tun := range localTunnels {
+			log.WithField("udid", udid).Info("stopping tunnel due to device list error")
+			_ = m.stopTunnel(tun)
+		}
 		return fmt.Errorf("UpdateTunnels: failed to get list of devices: %w", err)
 	}
 	for _, d := range devices.DeviceList {


### PR DESCRIPTION
on linux  

1. connect one device
2. disconnect this device
3. wait a moment
4. reconnect this device fail  

because this device last connection don't close