### PR TITLE
fix(simlocation): use defer to close connections and prevent resource leaks

### DIFF
--- a/ios/simlocation/simlocation.go
+++ b/ios/simlocation/simlocation.go
@@ -50,6 +50,7 @@ func SetLocation(device ios.DeviceEntry, lat string, lon string) error {
 	if err != nil {
 		return err
 	}
+	defer locationConn.Close()
 
 	latitude, err := strconv.ParseFloat(lat, 64)
 	if err != nil {
@@ -80,7 +81,6 @@ func SetLocation(device ios.DeviceEntry, lat string, lon string) error {
 		return err
 	}
 
-	locationConn.Close()
 	return nil
 }
 
@@ -179,6 +179,7 @@ func ResetLocation(device ios.DeviceEntry) error {
 	if err != nil {
 		return err
 	}
+	defer locationConn.Close()
 
 	buf := new(bytes.Buffer)
 


### PR DESCRIPTION
### Summary
`SetLocation()` and `ResetLocation()` in `ios/simlocation/simlocation.go` were not properly closing their connections on all return paths, leaking Unix socket file descriptors to usbmuxd.

- `ResetLocation()` had no `Close()` call at all — every invocation leaked a connection
- `SetLocation()` called `Close()` only on the success path — any error from `ParseFloat`, `LocationBytes`, or `Send` would leak the connection

### Changes
- Replaced the explicit `locationConn.Close()` in `SetLocation()` with `defer locationConn.Close()` placed immediately after `New()` succeeds
- Added `defer locationConn.Close()` in `ResetLocation()` in the same position

### Impact
- **Without fix:** Both functions leak socket FDs on error paths; `ResetLocation()` leaks unconditionally. In long-running processes this can exhaust OS-level FD limits (`too many open files`)
- **With fix:** Both functions guarantee connection cleanup on all return paths, including early error returns