### PR TITLE
Move defer statement for houseArrestService

### DIFF
--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -551,10 +551,10 @@ func setupXcuiTest(device ios.DeviceEntry, bundleID string, testRunnerBundleID s
 	}
 
 	houseArrestService, err := house_arrest.New(device, testRunnerBundleID)
-	defer houseArrestService.Close()
 	if err != nil {
 		return uuid.UUID{}, "", nskeyedarchiver.XCTestConfiguration{}, testInfo{}, err
 	}
+	defer houseArrestService.Close()
 	log.Debugf("creating test config")
 	testConfigPath, testConfig, err := createTestConfigOnDevice(testSessionID, info, houseArrestService, xctestConfigFileName, testsToRun, testsToSkip, isXCTest, version)
 	if err != nil {


### PR DESCRIPTION
defer needs to be called later to not cause crashes.

```
http: panic serving 172.20.0.188:39900: runtime error: invalid memory address or nil pointer dereference
goroutine 2110 [running]:
net/http.(*conn).serve.func1()
    /usr/local/go/src/net/http/server.go:1947 +0xbe
panic({0xb141e0?, 0x118a9a0?})
    /usr/local/go/src/runtime/panic.go:785 +0x132
github.com/danielpaulus/go-ios/ios/afc.(*Client).Close(0xc0000365a0?)
    /go/pkg/mod/github.com/danielpaulus/go-ios@v1.0.206/ios/afc/client.go:51 +0xe
github.com/danielpaulus/go-ios/ios/testmanagerd.setupXcuiTest({0x1, {0xc00055cca8, 0x8}, {0x1c9c3800, {0xc00055cdb6, 0x3}, 0x1, 0x10011, 0x12ab, {0xc0005361e0, ...}}, ...}, ...)
    /go/pkg/mod/github.com/danielpaulus/go-ios@v1.0.206/ios/testmanagerd/xcuitestrunner.go:556 +0x7a3
github.com/danielpaulus/go-ios/ios/testmanagerd.runXCUIWithBundleIdsXcode11Ctx({_, _}, {{0xc38705, 0x23}, {0xc428d2, 0x2d}, {0xc28024, 0x14}, 0xc0004bca20, {0x0, ...}, ...}, ...)
    /go/pkg/mod/github.com/danielpaulus/go-ios@v1.0.206/ios/testmanagerd/xcuitestrunner_11.go:20 +0x18e
github.com/danielpaulus/go-ios/ios/testmanagerd.RunTestWithConfig({_, _}, {{0xc38705, 0x23}, {0xc428d2, 0x2d}, {0xc28024, 0x14}, 0xc0004bca20, {0x0, ...}, ...})

```