### PR TITLE
Honor --nojson for ostrace

### DIFF
--- a/main.go
+++ b/main.go
@@ -2795,7 +2795,11 @@ func runOsTrace(device ios.DeviceEntry, pid int, processName string, messageFilt
 				done <- err
 				return
 			}
-			fmt.Println(convertToJSONString(entry))
+			if JSONdisabled {
+				fmt.Printf("%s %s %d %s\n", entry.Timestamp.Format(time.RFC3339Nano), entry.LevelName, entry.PID, entry.Message)
+			} else {
+				fmt.Println(convertToJSONString(entry))
+			}
 		}
 	}()
 	c := make(chan os.Signal, 1)


### PR DESCRIPTION
runOsTrace always emits JSON, regardless of the `--nojson` flag; this makes it honor the flag. Perhaps you would want to format it differently, though, but I could not find a similar example for when JSON is disabled. This keeps all the important info.