### PR TITLE
ci: run real-device e2e only after unit tests pass

### DIFF
--- a/.github/workflows/real-device.yml
+++ b/.github/workflows/real-device.yml
@@ -1,4 +1,7 @@
 on:
+  # Reusable: called by the Unit tests workflow after the unit jobs pass.
+  workflow_call:
+  # Also runnable on its own (e.g. against a branch or main).
   workflow_dispatch:
 
 name: CI Real Device Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,3 +65,13 @@ jobs:
 
       - name: Verify code formatting
         run: test -z "$(gofmt -l .)"
+
+  # Run the real-device e2e suite only after all unit jobs pass. It runs on the
+  # self-hosted device runners; for fork PRs GitHub requires a maintainer to
+  # approve the run before it executes on those runners.
+  real-device:
+    name: Real device tests
+    needs: [lint, test_on_windows, test_on_linux]
+    uses: ./.github/workflows/real-device.yml
+    permissions:
+      contents: read


### PR DESCRIPTION
Gates the real-device e2e suite behind the unit tests on PRs.

- `real-device.yml` becomes a reusable workflow (`workflow_call`), still dispatchable manually.
- The Unit tests workflow gains a `real-device` job that `needs: [lint, test_on_windows, test_on_linux]` and calls the reusable workflow — so real-device runs only when all unit jobs pass.
- On self-hosted device runners; fork PRs require maintainer approval to run (security).

This PR self-tests the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)