### PR TITLE
ci: device tests on fork PRs (/test-devices) + release on make-release label

### DIFF
--- a/.github/workflows/device-tests-comment.yml
+++ b/.github/workflows/device-tests-comment.yml
@@ -1,0 +1,73 @@
+on:
+  issue_comment:
+    types: [created]
+
+name: Device tests (/test-devices)
+
+# Lets a maintainer run the real-device e2e suite on a fork PR by commenting
+# "/test-devices". The run executes in this repo's trusted context (so it gets
+# the device repo vars and the self-hosted runners) but only after an explicit
+# command from someone with write access — fork code never runs unreviewed.
+
+permissions:
+  contents: read
+
+jobs:
+  authorize:
+    name: Authorize
+    # Only PR comments that start with the command, from a trusted author.
+    if: >-
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/test-devices') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Acknowledge the command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🧪 Running real-device tests on PR #${context.issue.number} — [run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+            });
+
+  real-device:
+    needs: authorize
+    uses: ./.github/workflows/real-device.yml
+    # Test the PR's merge ref (the fork's code merged into the base).
+    with:
+      ref: refs/pull/${{ github.event.issue.number }}/merge
+    permissions:
+      contents: read
+
+  report:
+    needs: [authorize, real-device]
+    if: always() && needs.authorize.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const ok = '${{ needs.real-device.result }}' === 'success';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: ok
+                ? '✅ Real-device tests passed.'
+                : `❌ Real-device tests failed — [see run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`,
+            });

--- a/.github/workflows/real-device.yml
+++ b/.github/workflows/real-device.yml
@@ -1,6 +1,13 @@
 on:
-  # Reusable: called by the Unit tests workflow after the unit jobs pass.
+  # Reusable: called by the Unit tests workflow after the unit jobs pass, and by
+  # the comment-triggered workflow for fork PRs (with an explicit ref).
   workflow_call:
+    inputs:
+      ref:
+        description: Git ref or SHA to check out (e.g. refs/pull/<n>/merge). Empty = the triggering ref.
+        type: string
+        required: false
+        default: ''
   # Also runnable on its own (e.g. against a branch or main).
   workflow_dispatch:
 
@@ -28,6 +35,8 @@ jobs:
     runs-on: [self-hosted, "${{ matrix.os }}"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,19 @@
 on:
-  push:
-    branches:
-      - main
+  # Release only when a PR is merged to main with the "make-release" label.
+  pull_request:
+    types: [closed]
 
 name: Release-Go-iOS
 jobs:
   build_on_windows:
+    # Gate the whole release chain: merged + labeled. The downstream jobs depend
+    # on this one, so skipping it here skips the entire release.
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'make-release')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Create Release
         id: create_release
@@ -45,6 +50,8 @@ jobs:
     needs: build_on_windows
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -88,6 +95,8 @@ jobs:
     needs: build_on_mac
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Install Go
         uses: actions/setup-go@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,12 +66,14 @@ jobs:
       - name: Verify code formatting
         run: test -z "$(gofmt -l .)"
 
-  # Run the real-device e2e suite only after all unit jobs pass. It runs on the
-  # self-hosted device runners; for fork PRs GitHub requires a maintainer to
-  # approve the run before it executes on those runners.
+  # Run the real-device e2e suite only after all unit jobs pass, and only for
+  # same-repo PRs. Fork PRs can't access the device repo vars and must not run
+  # untrusted code on the self-hosted device runners — a maintainer triggers
+  # those with a "/test-devices" comment (see device-tests-comment.yml).
   real-device:
     name: Real device tests
     needs: [lint, test_on_windows, test_on_linux]
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/real-device.yml
     permissions:
       contents: read


### PR DESCRIPTION
Two CI workflow changes (bundled per maintainer request).

## 1. Real-device tests on fork PRs via `/test-devices` comment
- **Guard** the auto real-device job (in `test.yml`) to same-repo PRs only — fork PRs no longer auto-run it and fail with empty `GO_IOS_E2E_DEVICES` (GitHub withholds repo vars from fork `pull_request` runs), and untrusted code no longer runs on the self-hosted device runners.
- **`/test-devices` comment trigger** (`device-tests-comment.yml`): a maintainer (OWNER/MEMBER/COLLABORATOR) comments `/test-devices` → the real-device suite runs on the PR's merge ref in the trusted base context (vars + self-hosted), with a ✅/❌ comment posted back. Untrusted code never runs unreviewed.
- **`ref` input** on the reusable `real-device.yml` so it can check out the PR.

## 2. Release only on `make-release` label
- `release.yml` now triggers on `pull_request: closed` and runs only when the PR was **merged AND labeled `make-release`** — instead of releasing on every push to main. Builds check out the base branch so they release the merged code.

**Note:** the comment trigger only becomes active once on `main` (issue_comment runs from the default branch). After merge, test `/test-devices` on a fork PR like #719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)