### PR TITLE
Fix Windows npm install + release verification (cuts a release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,10 @@ jobs:
   build_on_linux_and_release:
     runs-on: ubuntu-latest
     needs: build_on_mac
+    outputs:
+      # The exact version published to npm, consumed by verify_install. Read
+      # from package.json after the version sed so it is format-agnostic.
+      published_version: ${{ steps.publish.outputs.published_version }}
     permissions:
       # contents: write is needed to upload the release assets below. Declaring a
       # permissions block opts out of the default token scopes, so we must list it
@@ -163,6 +167,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish NPM
+        id: publish
         run: |
           npm install -g npm@latest
           mkdir ./npm_publish/dist
@@ -183,3 +188,46 @@ jobs:
           # No NODE_AUTH_TOKEN / .npmrc auth line: npm authenticates via OIDC
           # trusted publishing. Setting an (even empty) token would break OIDC.
           npm publish
+          # Surface the exact published version for the verify_install job.
+          echo "published_version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+  # Post-publish smoke test: install the freshly released go-ios from the public
+  # registry on every OS and run the binary, asserting the version matches what
+  # we just published. This runs AFTER the release is out (it alerts, it does not
+  # gate), and is what would have caught the Windows-PATH install bug earlier.
+  verify_install:
+    needs: build_on_linux_and_release
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install published release and run it
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ needs.build_on_linux_and_release.outputs.published_version }}
+        run: |
+          set -euo pipefail
+          # npm registry propagation can lag a few seconds after publish.
+          for i in 1 2 3 4 5; do
+            if npm install -g "go-ios@${EXPECTED_VERSION}"; then
+              break
+            fi
+            echo "install attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
+
+          # The package has no "bin" field; postinstall.js drops the binary
+          # straight into npm's global bin dir, which is on PATH.
+          OUTPUT="$(ios version 2>&1)"
+          echo "ios version output: $OUTPUT"
+          echo "$OUTPUT" | grep -q "\"version\":\"${EXPECTED_VERSION}\"" \
+            || { echo "::error::expected version ${EXPECTED_VERSION} not found in 'ios version' output"; exit 1; }
+          echo "OK: go-ios@${EXPECTED_VERSION} installed and runs on ${{ matrix.os }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,27 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           release-tag: ${{ env.release_tag }}
 
+      - name: Set release notes from CHANGELOG.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Extract the top released section from CHANGELOG.md: everything from
+          # the first "## [x.y.z]" heading up to (not including) the next one.
+          # The "## [Unreleased]" heading is skipped (no leading digit).
+          awk '
+            /^## \[[0-9]+\.[0-9]+\.[0-9]+/ { count++; if (count == 1) { cap=1; print; next } else { exit } }
+            cap { print }
+          ' CHANGELOG.md > release_body.md
+          if [ ! -s release_body.md ]; then
+            echo "::warning::no released section found in CHANGELOG.md; leaving release notes empty"
+            exit 0
+          fi
+          # The action just created this release; it is the most recent one.
+          TAG="$(gh release list --limit 1 --json tagName --jq '.[0].tagName')"
+          echo "Setting notes on release $TAG"
+          gh release edit "$TAG" --notes-file release_body.md
+
       # OIDC trusted publishing needs Node >= 22.14.0 and npm >= 11.5.1.
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable user-facing and internal changes to go-ios are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The release workflow publishes the **top released version section** below as the
+GitHub release notes, so add a new `## [x.y.z] - YYYY-MM-DD` section (newest
+first, just under `[Unreleased]`) in the PR that carries the `make-release`
+label. Move anything accumulated under `[Unreleased]` into that section.
+
+## [Unreleased]
+
+## [1.0.217] - 2026-06-03
+
+First release published to npm since `1.0.213` — npm publishing broke when npm
+revoked legacy tokens, and is now restored on secure OIDC trusted publishing.
+This release also makes the npm package install correctly on Windows for the
+first time.
+
+### ✨ New features & improvements
+- **`ostrace --follow`** — persistent log streaming that survives process restarts. Auto-reconnects when the target process exits/restarts: with `--process=<name>` it re-resolves the new PID, with an explicit `--pid` it exits cleanly when that PID ends. (#719)
+- **`ostrace` plain-text output** — `--nojson` now prints structured, human-readable lines `[timestamp] PID:##### <Level> [subsystem:category] message` instead of raw JSON, with ANSI color coding (Info=cyan, Debug=gray, Error=red, Fault=bold red). Colors are emitted only when stdout is a TTY, so pipes and files stay clean. (#718)
+- **More reliable Developer Disk Image (DDI) mounting on iOS 17+** — fixes `identity-not-found` failures on newer chips (e.g. A19 Pro) and adds a manifest fast-path that skips the nonce + Apple TSS round-trip on re-mounts when a valid personalization manifest already exists. (#720, #723)
+
+### 🐛 Fixes
+- **Windows npm install** — `npm i -g go-ios` previously installed a binary that wasn't on `PATH` (the postinstall placed it in a non-PATH `bin` subfolder), so `ios` was uncallable on Windows. The binary is now installed to the correct location. (#730)
+- **macOS 26 binary launch** — bump the Go toolchain to 1.24.13 so produced binaries carry an `LC_UUID` load command; without it, macOS 26's dyld rejects them with `abort trap`. (#723)
+
+### 🔧 Build, CI & internals
+- **npm publishing migrated to OIDC trusted publishing** — no more long-lived `NODE_AUTH_TOKEN`; releases authenticate per-run via GitHub OIDC, with provenance attestations. (#727)
+- **Cross-platform install verification** — release and canary pipelines now install the freshly published package on Windows, Linux and macOS and run the binary, asserting the version matches. (#728, #730)
+- **Canary release pipeline** — manual-dispatch workflow publishing a throwaway `go-ios-canary` package to validate the full release flow without shipping. (#727)
+- **Releases now gated behind the `make-release` label.** (#726)
+- **Real-device e2e test suite** on the self-hosted macOS/Linux runners, gated to run only after unit tests pass, and runnable on fork PRs via a maintainer `/test-devices` comment. (#723, #725, #726)

--- a/npm_publish/postinstall.js
+++ b/npm_publish/postinstall.js
@@ -40,7 +40,13 @@ async function getInstallationPath() {
         // Ex: /Users/foo/.nvm/versions/node/v4.3.0
         var env = process.env;
         if (env && env.npm_config_prefix) {
-            dir = path.join(env.npm_config_prefix, "bin");
+            // On Windows npm's global prefix IS the bin dir (executables/shims
+            // live directly in %AppData%\npm, which is what's on PATH). On
+            // Linux/macOS executables go in <prefix>/bin. Appending "bin" on
+            // Windows puts the binary in a folder that isn't on PATH.
+            dir = process.platform === "win32"
+                ? env.npm_config_prefix
+                : path.join(env.npm_config_prefix, "bin");
         }
     } else {
         dir = value.trim();


### PR DESCRIPTION
**This PR carries the `make-release` label — merging it cuts a real `go-ios` release** (GitHub release + tag + npm publish via OIDC). It bundles the remaining fixes from the npm OIDC migration.

## Contents
1. **`postinstall.js` — Windows global-install fix.** It always appended `bin` to npm's global prefix; on Windows the prefix *is* the bin dir, so `ios.exe` landed off-PATH and `npm i -g go-ios` produced an uncallable CLI (exit 127). Now uses the prefix directly on `win32`; Linux/macOS unchanged. This release will be the first npm publish that actually works on Windows.
2. **`release.yml` — post-publish install verification.** After the npm publish, a `verify_install` matrix (windows/linux/macOS) installs the freshly released `go-ios@<version>` from the public registry and runs `ios version`, asserting it matches. The publish job emits the exact version as an output. Post-publish smoke test (alerts, doesn't gate) — this is what would have caught the Windows bug.

## Already on `main` (from #727, #728), shipped implicitly by this release
- OIDC trusted publishing for `go-ios` (replaces the revoked classic `NODE_AUTH_TOKEN`).
- `release-canary.yml` — manual-dispatch canary pipeline + its own `verify_install` matrix.

## Verified on canary first
The full flow (OIDC publish → npm install → postinstall → working binary, incl. the Windows fix) is green on all three OSes via `release-canary.yml` (`go-ios-canary@0.0.3`).

## Preconditions for the release to succeed
- ✅ `go-ios` trusted publisher registered on npmjs.com → workflow `release.yml`.
- After this release verifies green, the unused `NODE_AUTH_TOKEN` repo secret can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: release notes now come from CHANGELOG.md
- Added `CHANGELOG.md` (Keep a Changelog), seeded with the v1.0.217 section + an empty `[Unreleased]`.
- `release.yml` extracts the top released section and sets it as the GitHub release body (releases were previously blank). This release will be the first with real notes.
