### PR TITLE
ci: dispatch-only release flow with workflow-managed versioning + changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,69 @@
+# Release pipeline — manual dispatch only.
+#
+# Run it from the Actions tab (or `gh workflow run release.yml -f release_notes=... -f bump=patch`).
+# The workflow owns the version and the changelog: it computes the next version
+# from the latest tag, writes a "## [version] - date" section with your notes
+# into CHANGELOG.md, pushes that to main, tags it, creates the GitHub release
+# with those notes, publishes to npm via OIDC trusted publishing, and finally
+# verifies the published package installs and runs on all three OSes.
+#
+# All repo-mutating and outbound steps live in release_and_publish (the last
+# job before verify), so a failed build leaves nothing pushed or published.
+#
+# Requires the RELEASE_PAT secret: a fine-grained PAT (Contents: read/write on
+# this repo) from an admin account. main is a protected branch; since
+# enforce_admins is off, an admin token can push the changelog commit to it.
 on:
-  # Release only when a PR is merged to main with the "make-release" label.
-  pull_request:
-    types: [closed]
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: "Release notes (markdown). Written into CHANGELOG.md and used as the GitHub release body."
+        required: true
+        type: string
+      bump:
+        description: "Which semver part to bump from the latest tag"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 name: Release-Go-iOS
+
 jobs:
-  build_on_windows:
-    # Gate the whole release chain: merged + labeled. The downstream jobs depend
-    # on this one, so skipping it here skips the entire release.
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'make-release')
-    runs-on: windows-latest
+  prepare_version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: main
+          fetch-depth: 0 # need all tags to find the latest
 
-      - name: Create Release
-        id: create_release
-        uses: zendesk/action-create-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_schema: semantic
+      - name: Compute next version
+        id: compute
+        run: |
+          set -euo pipefail
+          LATEST="$(git tag -l 'v*' | sort -V | tail -1)"
+          LATEST="${LATEST#v}"
+          IFS=. read -r MA MI PA <<< "$LATEST"
+          case "${{ inputs.bump }}" in
+            major) MA=$((MA + 1)); MI=0; PA=0 ;;
+            minor) MI=$((MI + 1)); PA=0 ;;
+            patch) PA=$((PA + 1)) ;;
+          esac
+          NEXT="${MA}.${MI}.${PA}"
+          echo "version=${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "Latest tag v${LATEST} -> next v${NEXT} (${{ inputs.bump }} bump)"
+
+  build_on_windows:
+    runs-on: windows-latest
+    needs: prepare_version
+    steps:
+      - uses: actions/checkout@v3
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -31,11 +73,10 @@ jobs:
 
       - name: Build
         run: |
-          ((Get-Content -path main.go -Raw) -replace "local-build","${{ steps.create_release.outputs.current_tag }}") | Set-Content -Path main.go
+          ((Get-Content -path main.go -Raw) -replace "local-build","${{ needs.prepare_version.outputs.version }}") | Set-Content -Path main.go
           mkdir bin
           go build -ldflags="-s -w" -o bin/ios.exe
-          "${{ steps.create_release.outputs.current_tag }}" | Out-File -Encoding utf8NoBOM release_tag -NoNewline
-          Compress-Archive -Path .\bin\ios.exe, release_tag -CompressionLevel Optimal -DestinationPath go-ios-windows.zip
+          Compress-Archive -Path .\bin\ios.exe -CompressionLevel Optimal -DestinationPath go-ios-windows.zip
 
       - name: upload the windows build
         uses: actions/upload-artifact@v4
@@ -47,11 +88,9 @@ jobs:
 
   build_on_mac:
     runs-on: macos-latest
-    needs: build_on_windows
+    needs: [prepare_version, build_on_windows]
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -59,23 +98,10 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Download win release from previous job
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-build
-          path: ./win-bin
-
-      - name: Extract release tag
-        working-directory: ./win-bin
-        run: |
-          unzip go-ios-windows.zip
-          echo "release_tag="$(cat release_tag) >> $GITHUB_ENV
-
       - name: Build
         run: |
           brew install gnu-sed
-          alias sed=gsed
-          gsed -i 's/version \= \"local-build\"/version = \"${{ env.release_tag }}\"/' main.go
+          gsed -i 's/version \= \"local-build\"/version = \"${{ needs.prepare_version.outputs.version }}\"/' main.go
           mkdir bin
           GOARCH=arm64 go build -ldflags="-s -w" -o bin/ios-arm64
           GOARCH=amd64 go build -ldflags="-s -w" -o bin/ios-amd64
@@ -90,24 +116,20 @@ jobs:
           retention-days: 1
           overwrite: true
 
-  build_on_linux_and_release:
+  release_and_publish:
     runs-on: ubuntu-latest
-    needs: build_on_mac
-    outputs:
-      # The exact version published to npm, consumed by verify_install. Read
-      # from package.json after the version sed so it is format-agnostic.
-      published_version: ${{ steps.publish.outputs.published_version }}
+    needs: [prepare_version, build_on_mac]
     permissions:
-      # contents: write is needed to upload the release assets below. Declaring a
-      # permissions block opts out of the default token scopes, so we must list it
-      # explicitly. id-token: write lets the job mint an OIDC token for npm
-      # trusted publishing (no long-lived npm token required).
       contents: write
-      id-token: write
+      id-token: write # OIDC token for npm trusted publishing
+    env:
+      VERSION: ${{ needs.prepare_version.outputs.version }}
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }} # admin token, can push to protected main
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -115,70 +137,66 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Download mac release from previous job
+      - name: Download mac build from previous job
         uses: actions/download-artifact@v4
         with:
           name: macos-build
           path: ./mac-bin
 
-      - name: Download and package mac binary
-        working-directory: ./mac-bin
-        run: |
-          unzip go-ios-mac.zip
-          rm go-ios-mac.zip
-          zip -j go-ios-mac.zip ios
-
-      - name: Download windows release from previous job
+      - name: Download windows build from previous job
         uses: actions/download-artifact@v4
         with:
           name: windows-build
           path: ./win-bin
 
-      - name: Download and package windows binary
-        working-directory: ./win-bin
+      - name: Build linux and package all artifacts
         run: |
-          unzip go-ios-windows.zip
-          echo "release_tag="$(cat release_tag) >> $GITHUB_ENV
-          rm go-ios-windows.zip
-          zip -j go-ios-win.zip ios.exe
-
-      - name: Build
-        run: |
-          sed -i 's/version \= \"local-build\"/version = \"${{ env.release_tag }}\"/' main.go
+          set -euo pipefail
+          sed -i 's/version \= \"local-build\"/version = \"'"${VERSION}"'\"/' main.go
           mkdir bin
           GOARCH=arm64 go build -ldflags="-s -w" -o bin/ios-arm64
           GOARCH=amd64 go build -ldflags="-s -w" -o bin/ios-amd64
-
-          cp ./mac-bin/go-ios-mac.zip .
-          cp ./win-bin/go-ios-win.zip .
+          ( cd mac-bin && unzip -o go-ios-mac.zip && rm go-ios-mac.zip && zip -j ../go-ios-mac.zip ios )
+          ( cd win-bin && unzip -o go-ios-windows.zip && zip -j ../go-ios-win.zip ios.exe )
           zip -j go-ios-linux.zip bin/ios-arm64 bin/ios-amd64
 
-      - uses: AButler/upload-release-assets@v2.0
-        with:
-          files: "*.zip"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          release-tag: ${{ env.release_tag }}
+      - name: Update CHANGELOG, commit, and tag
+        env:
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          DATE="$(date +%Y-%m-%d)"
+          printf '%s\n' "$RELEASE_NOTES" > /tmp/notes.md
+          # Insert a new "## [VERSION] - DATE" section directly after "## [Unreleased]".
+          awk -v hdr="## [${VERSION}] - ${DATE}" -v notesfile="/tmp/notes.md" '
+            { print }
+            /^## \[Unreleased\]/ && !done {
+              print ""
+              print hdr
+              print ""
+              while ((getline line < notesfile) > 0) print line
+              done = 1
+            }
+          ' CHANGELOG.md > CHANGELOG.new
+          mv CHANGELOG.new CHANGELOG.md
 
-      - name: Set release notes from CHANGELOG.md
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore(release): v${VERSION}"
+          git push origin HEAD:main
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Extract the top released section from CHANGELOG.md: everything from
-          # the first "## [x.y.z]" heading up to (not including) the next one.
-          # The "## [Unreleased]" heading is skipped (no leading digit).
-          awk '
-            /^## \[[0-9]+\.[0-9]+\.[0-9]+/ { count++; if (count == 1) { cap=1; print; next } else { exit } }
-            cap { print }
-          ' CHANGELOG.md > release_body.md
-          if [ ! -s release_body.md ]; then
-            echo "::warning::no released section found in CHANGELOG.md; leaving release notes empty"
-            exit 0
-          fi
-          # The action just created this release; it is the most recent one.
-          TAG="$(gh release list --limit 1 --json tagName --jq '.[0].tagName')"
-          echo "Setting notes on release $TAG"
-          gh release edit "$TAG" --notes-file release_body.md
+          gh release create "v${VERSION}" \
+            go-ios-linux.zip go-ios-mac.zip go-ios-win.zip \
+            --title "v${VERSION}" \
+            --notes-file /tmp/notes.md
 
       # OIDC trusted publishing needs Node >= 22.14.0 and npm >= 11.5.1.
       - name: Set up Node
@@ -188,8 +206,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish NPM
-        id: publish
         run: |
+          set -euo pipefail
           npm install -g npm@latest
           mkdir ./npm_publish/dist
           mkdir ./npm_publish/dist/go-ios-darwin-amd64_darwin_amd64
@@ -204,20 +222,16 @@ jobs:
           cp ./bin/ios-arm64 ./npm_publish/dist/go-ios-linux-arm64_linux_arm64/ios
           cp ./README.md ./npm_publish
           cd npm_publish
-          sed -i 's/\"local-build\"/\"${{ env.release_tag }}\"/' package.json
+          sed -i 's/\"local-build\"/\"'"${VERSION}"'\"/' package.json
           npm install
           # No NODE_AUTH_TOKEN / .npmrc auth line: npm authenticates via OIDC
           # trusted publishing. Setting an (even empty) token would break OIDC.
           npm publish
-          # Surface the exact published version for the verify_install job.
-          echo "published_version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
   # Post-publish smoke test: install the freshly released go-ios from the public
-  # registry on every OS and run the binary, asserting the version matches what
-  # we just published. This runs AFTER the release is out (it alerts, it does not
-  # gate), and is what would have caught the Windows-PATH install bug earlier.
+  # registry on every OS and run the binary, asserting the version matches.
   verify_install:
-    needs: build_on_linux_and_release
+    needs: [prepare_version, release_and_publish]
     strategy:
       fail-fast: false
       matrix:
@@ -233,7 +247,7 @@ jobs:
       - name: Install published release and run it
         shell: bash
         env:
-          EXPECTED_VERSION: ${{ needs.build_on_linux_and_release.outputs.published_version }}
+          EXPECTED_VERSION: ${{ needs.prepare_version.outputs.version }}
         run: |
           set -euo pipefail
           # npm registry propagation can lag a few seconds after publish.
@@ -245,8 +259,6 @@ jobs:
             sleep 10
           done
 
-          # The package has no "bin" field; postinstall.js drops the binary
-          # straight into npm's global bin dir, which is on PATH.
           OUTPUT="$(ios version 2>&1)"
           echo "ios version output: $OUTPUT"
           echo "$OUTPUT" | grep -q "\"version\":\"${EXPECTED_VERSION}\"" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,18 @@
 All notable user-facing and internal changes to go-ios are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
-The release workflow publishes the **top released version section** below as the
-GitHub release notes, so add a new `## [x.y.z] - YYYY-MM-DD` section (newest
-first, just under `[Unreleased]`) in the PR that carries the `make-release`
-label. Move anything accumulated under `[Unreleased]` into that section.
+
+Releases are cut by dispatching the **Release-Go-iOS** workflow (Actions tab →
+Run workflow, or `gh workflow run release.yml -f release_notes=... -f bump=patch`).
+That workflow computes the next version, writes a new `## [x.y.z] - DATE` section
+here from the notes you provide, and uses the same text as the GitHub release
+body — so this file is updated automatically and never needs a manual PR.
+Use `## [Unreleased]` to jot down notable changes between releases if you like.
 
 ## [Unreleased]
+
+### 🐛 Fixes
+- **REST API `KillApp`** — fixed kill-by-bundle-ID, which stopped matching after `CFBundleIdentifier`/`CFBundleExecutable` became method calls on the app model. (#729)
 
 ## [1.0.217] - 2026-06-03
 


### PR DESCRIPTION
Reworks `release.yml` into a manual **workflow_dispatch** release flow. **Merging this does NOT cut a release** — the old `pull_request`/`make-release` trigger is removed; releases now only happen when someone runs the workflow.

## How it works
Run from the Actions tab (or `gh workflow run release.yml -f release_notes=... -f bump=patch`):
1. **`prepare_version`** computes the next version from the latest tag (single source of truth) per the `bump` input.
2. windows → mac builds (unchanged).
3. **`release_and_publish`** (last job before verify) does all mutating/outbound work, so a failed build leaves nothing pushed/published:
   - writes `## [version] - date` + your notes into `CHANGELOG.md`, commits/pushes to main via `RELEASE_PAT`, tags `vX.Y.Z`
   - creates the GitHub release with those notes + only the `go-ios-*.zip` assets (fixes the stray-asset issue from #731)
   - npm-publishes via OIDC
4. **`verify_install`** installs the published version on win/linux/mac and asserts it.

Because the workflow computes the version *and* writes the changelog in the same run, the changelog heading can never drift from the tag — closing the version-correctness gap.

## ⚠️ Required before the first dispatch
Create a **`RELEASE_PAT`** secret: a fine-grained PAT (Contents: read/write on this repo) from an admin account. `main` is protected (1 review required) but `enforce_admins` is off, so an admin token can push the changelog commit. The default `GITHUB_TOKEN` (the Actions bot) cannot.

Also records the merged-but-unreleased #729 `KillApp` fix under `[Unreleased]`.