### PR TITLE
ci: fix changelog insertion + verify_install npm-propagation wait

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -167,14 +167,16 @@ jobs:
           EXPECTED_VERSION: 0.0.${{ github.run_number }}
         run: |
           set -euo pipefail
-          # npm registry propagation is usually instant but can lag a few
-          # seconds right after publish; retry the pinned-version install.
-          for i in 1 2 3 4 5; do
+          # npm registry propagation to all replicas can lag well past a minute
+          # right after publish. Give it a 60s head start, then retry generously.
+          echo "waiting 60s for npm registry propagation before first install..."
+          sleep 60
+          for i in $(seq 1 12); do
             if npm install -g "go-ios-canary@${EXPECTED_VERSION}"; then
               break
             fi
-            echo "install attempt $i failed, retrying in 10s..."
-            sleep 10
+            echo "install attempt $i failed (version may not have propagated yet), retrying in 15s..."
+            sleep 15
           done
 
           # The package has no "bin" field; postinstall.js drops the binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,16 +167,19 @@ jobs:
           set -euo pipefail
           DATE="$(date +%Y-%m-%d)"
           printf '%s\n' "$RELEASE_NOTES" > /tmp/notes.md
-          # Insert a new "## [VERSION] - DATE" section directly after "## [Unreleased]".
+          # Insert a new "## [VERSION] - DATE" section just before the most recent
+          # released version (the first "## [x.y.z]" heading). This keeps any
+          # existing "## [Unreleased]" content under [Unreleased] instead of
+          # absorbing it into the new section.
           awk -v hdr="## [${VERSION}] - ${DATE}" -v notesfile="/tmp/notes.md" '
-            { print }
-            /^## \[Unreleased\]/ && !done {
-              print ""
+            /^## \[[0-9]/ && !done {
               print hdr
               print ""
               while ((getline line < notesfile) > 0) print line
+              print ""
               done = 1
             }
+            { print }
           ' CHANGELOG.md > CHANGELOG.new
           mv CHANGELOG.new CHANGELOG.md
 
@@ -250,13 +253,16 @@ jobs:
           EXPECTED_VERSION: ${{ needs.prepare_version.outputs.version }}
         run: |
           set -euo pipefail
-          # npm registry propagation can lag a few seconds after publish.
-          for i in 1 2 3 4 5; do
+          # npm registry propagation to all replicas can lag well past a minute
+          # right after publish. Give it a 60s head start, then retry generously.
+          echo "waiting 60s for npm registry propagation before first install..."
+          sleep 60
+          for i in $(seq 1 12); do
             if npm install -g "go-ios@${EXPECTED_VERSION}"; then
               break
             fi
-            echo "install attempt $i failed, retrying in 10s..."
-            sleep 10
+            echo "install attempt $i failed (version may not have propagated yet), retrying in 15s..."
+            sleep 15
           done
 
           OUTPUT="$(ios version 2>&1)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,6 @@ Use `## [Unreleased]` to jot down notable changes between releases if you like.
 ### 🐛 Fixes
 - **REST API `KillApp`** — fixed kill-by-bundle-ID, which stopped matching after `CFBundleIdentifier`/`CFBundleExecutable` became method calls on the app model. (#729)
 
-### ✨ New features & improvements
-- **Redesigned help output** — `ios --help` now shows a clean, sectioned layout (global options + a full command table with one-line descriptions) instead of the raw docopt usage block. `ios help <command>`, `ios <command> --help`, and `ios <command> -h` are all equivalent, including nested subcommands like `ios help tunnel start`. (#716)
-
-### 🐛 Fixes
-- **REST API `KillApp`** — fixed kill-by-bundle-ID, which stopped matching after `CFBundleIdentifier`/`CFBundleExecutable` became method calls on the app model. (#729)
-
 ## [1.0.217] - 2026-06-03
 
 First release published to npm since `1.0.213` — npm publishing broke when npm


### PR DESCRIPTION
Follow-ups from the first dispatch release (v1.0.218):

- **Changelog insertion bug**: the workflow inserted the new section right after the `## [Unreleased]` heading, which absorbed any existing `[Unreleased]` body into the new version section (the v1.0.218 entry got duplicated). Now it inserts *before* the latest released version, preserving `[Unreleased]`. Verified against both empty and non-empty `[Unreleased]`.
- **verify_install propagation**: npm took longer than the old 50s retry window to propagate 1.0.218 to the replicas the mac/linux runners hit, so they failed `ETARGET` while windows passed. Added a 60s head start + 12×15s retries (~4 min) in both `release.yml` and `release-canary.yml`.
- De-duplicated the v1.0.218 `CHANGELOG.md` section the old logic produced.

No release impact — `release.yml` is dispatch-only; merging this just updates the workflows + changelog.