### PR TITLE
test(e2e): comprehensive pre-iOS17 device suite (tunnel-free)

### DIFF
--- a/.github/workflows/real-device.yml
+++ b/.github/workflows/real-device.yml
@@ -29,9 +29,11 @@ jobs:
           - os: macOS
             devices: GO_IOS_E2E_DEVICES
             tunnel_devices: GO_IOS_E2E_TUNNEL_DEVICES
+            preios17_devices: GO_IOS_E2E_PREIOS17_DEVICES
           - os: Linux
             devices: GO_IOS_E2E_LINUX_DEVICES
             tunnel_devices: GO_IOS_E2E_LINUX_TUNNEL_DEVICES
+            preios17_devices: GO_IOS_E2E_LINUX_PREIOS17_DEVICES
     runs-on: [self-hosted, "${{ matrix.os }}"]
     steps:
       - uses: actions/checkout@v6
@@ -60,3 +62,13 @@ jobs:
         env:
           GO_IOS_E2E_DEVICES: ${{ vars[matrix.tunnel_devices] }}
         run: go test -tags=e2e -count=1 -v ./test/e2e/tunnel/
+
+      # Pre-iOS17 devices serve the entire go-ios feature set — including the
+      # instruments/DTX commands (ps, screenshot, launch/kill) that need the
+      # tunnel on iOS 17+ — over usbmuxd with only a mounted Developer Disk Image
+      # and no tunnel. Targets its own device list and is skipped when empty.
+      - name: E2E pre-iOS17 (tunnel-free, DDI)
+        if: ${{ !cancelled() && vars[matrix.preios17_devices] != '' }}
+        env:
+          GO_IOS_E2E_DEVICES: ${{ vars[matrix.preios17_devices] }}
+        run: go test -tags=e2e -count=1 -v ./test/e2e/preios17/

--- a/test/e2e/preios17/apps_test.go
+++ b/test/e2e/preios17/apps_test.go
@@ -1,0 +1,34 @@
+//go:build e2e
+
+package preios17_test
+
+import "testing"
+
+// knownSystemApp is always installed, so the apps tests can assert it is listed.
+const knownSystemApp = "com.apple.Preferences"
+
+// TestApps lists system apps in compact text form and asserts a known system
+// app appears.
+func TestApps(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		smokeContains(t, udid, knownSystemApp, "apps", "--system", "--list")
+	})
+}
+
+// TestAppsAll lists all apps as JSON and asserts a known system app is present.
+func TestAppsAll(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		apps := smokeArr(t, udid, []string{"CFBundleIdentifier", "CFBundleName", "ApplicationType"}, "apps", "--all")
+		for _, a := range apps {
+			if m, ok := a.(map[string]any); ok && m["CFBundleIdentifier"] == knownSystemApp {
+				return
+			}
+		}
+		t.Fatalf("apps --all: %s not found in app list", knownSystemApp)
+	})
+}
+
+// TestFsyncTree lists the AFC media directory tree (lockdown/usbmux, no tunnel).
+func TestFsyncTree(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) { smoke(t, udid, "fsync", "tree", "--path=/") })
+}

--- a/test/e2e/preios17/info_test.go
+++ b/test/e2e/preios17/info_test.go
@@ -1,0 +1,169 @@
+//go:build e2e
+
+package preios17_test
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestInfo(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{
+			"ProductType", "ProductVersion", "BuildVersion", "DeviceClass",
+			"CPUArchitecture", "HardwareModel", "ProductName", "ModelNumber",
+			"SerialNumber", "UniqueDeviceID", "DeviceName",
+		}, "info")
+		assertSnapshot(t, udid, m)
+	})
+}
+
+func TestInfoLockdown(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{
+			"BuildVersion", "CPUArchitecture", "DeviceClass", "DeviceName",
+			"ProductType", "ProductVersion", "UniqueDeviceID",
+		}, "info", "lockdown")
+		assertSnapshot(t, udid, m)
+	})
+}
+
+// TestLockdownGet dumps all lockdown values and asserts the recorded identity
+// fields match the snapshot.
+func TestLockdownGet(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{
+			"BuildVersion", "CPUArchitecture", "DeviceClass", "DeviceName",
+			"ProductType", "ProductVersion", "UniqueDeviceID",
+		}, "lockdown", "get")
+		if exp, ok := expectedDevice(udid); ok {
+			for _, key := range []string{"ProductType", "ProductVersion", "BuildVersion"} {
+				if got, _ := m[key].(string); got != exp[key] {
+					t.Fatalf("lockdown get %s = %q, want %q", key, got, exp[key])
+				}
+			}
+		}
+	})
+}
+
+func TestDevicename(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{"devicename"}, "devicename")
+		if name, _ := m["devicename"].(string); name == "" {
+			t.Fatalf("devicename: empty")
+		}
+	})
+}
+
+// TestDate reads the device clock and asserts formatedDate is a well-formed
+// RFC850 date (e.g. "Thursday, 20-Mar-25 17:56:04 CET").
+func TestDate(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{"TimeIntervalSince1970", "formatedDate"}, "date")
+		fd, _ := m["formatedDate"].(string)
+		if _, err := time.Parse(time.RFC850, fd); err != nil {
+			t.Fatalf("date: formatedDate %q is not a parseable date: %v", fd, err)
+		}
+	})
+}
+
+func TestLang(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{"Language", "Locale", "SupportedLocales"}, "lang")
+		if lang, _ := m["Language"].(string); lang == "" {
+			t.Fatalf("lang: empty Language")
+		}
+	})
+}
+
+// TestMobilegestalt queries a key via the diagnostics relay. Unlike current iOS
+// (where MobileGestalt is deprecated and returns no value), pre-iOS17 devices
+// still serve it: assert the relay succeeds and returns the real value.
+func TestMobilegestalt(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{"Diagnostics", "Status"}, "mobilegestalt", "ProductVersion")
+		if status, _ := m["Status"].(string); status != "Success" {
+			t.Fatalf("mobilegestalt: Status = %q, want Success", status)
+		}
+		diag, _ := m["Diagnostics"].(map[string]any)
+		mg, _ := diag["MobileGestalt"].(map[string]any)
+		if s, _ := mg["Status"].(string); s != "Success" {
+			t.Fatalf("mobilegestalt: MobileGestalt.Status = %q, want Success", s)
+		}
+		if v, _ := mg["ProductVersion"].(string); v == "" {
+			t.Fatalf("mobilegestalt: MobileGestalt.ProductVersion is empty")
+		}
+	})
+}
+
+// TestDiagnosticsList asserts the diagnostics relay reports overall success.
+func TestDiagnosticsList(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{"Diagnostics", "Status"}, "diagnostics", "list")
+		if status, _ := m["Status"].(string); status != "Success" {
+			t.Fatalf("diagnostics list: Status = %q, want Success", status)
+		}
+	})
+}
+
+// TestVersion does not target a device: it verifies the built binary runs and
+// prints a JSON object with a non-empty version string.
+func TestVersion(t *testing.T) {
+	var m map[string]any
+	if err := json.Unmarshal(runIOS(t, "version"), &m); err != nil {
+		t.Fatalf("version: not JSON: %v", err)
+	}
+	if v, _ := m["version"].(string); v == "" {
+		t.Fatalf("version: missing/empty version field in %v", m)
+	}
+}
+
+func TestList(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		var v struct {
+			DeviceList []string `json:"deviceList"`
+		}
+		if err := json.Unmarshal(runIOS(t, "list"), &v); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if !slices.Contains(v.DeviceList, udid) {
+			t.Fatalf("device %s not present in list: %v", udid, v.DeviceList)
+		}
+	})
+}
+
+// TestListDetails asserts the device appears in `list --details` with a real
+// ConnectionType and identity fields matching the snapshot.
+func TestListDetails(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		var v struct {
+			DeviceList []map[string]any `json:"deviceList"`
+		}
+		if err := json.Unmarshal(runIOS(t, "list", "--details"), &v); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		exp, known := expectedDevice(udid)
+		found := false
+		for _, d := range v.DeviceList {
+			if u, _ := d["Udid"].(string); u != udid {
+				continue
+			}
+			found = true
+			if ct, _ := d["ConnectionType"].(string); ct != "USB" && ct != "Network" {
+				t.Fatalf("device %s ConnectionType = %q, want USB or Network", udid, ct)
+			}
+			if known {
+				for _, key := range []string{"ProductName", "ProductType", "ProductVersion"} {
+					if got, _ := d[key].(string); got != exp[key] {
+						t.Fatalf("%s = %q, want %q (testdata/devices.json)", key, got, exp[key])
+					}
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("device %s not present in list --details", udid)
+		}
+	})
+}

--- a/test/e2e/preios17/instruments_test.go
+++ b/test/e2e/preios17/instruments_test.go
@@ -1,0 +1,49 @@
+//go:build e2e
+
+// These commands are served by the instruments/DTX services. On iOS 17+ they
+// require the tunnel (and live in test/e2e/tunnel); on pre-iOS17 devices they
+// work directly over usbmuxd with only the Developer Disk Image mounted (done
+// in TestMain), which is exactly what this suite proves.
+package preios17_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPs lists running processes via the instruments device-info service.
+func TestPs(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		smokeArr(t, udid, []string{"Name", "Pid"}, "ps")
+	})
+}
+
+// TestScreenshot captures a screenshot to a file and asserts it is a real,
+// non-empty PNG.
+func TestScreenshot(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		out := filepath.Join(t.TempDir(), "shot.png")
+		runIOSForDevice(t, udid, "screenshot", "--output="+out)
+
+		b, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("screenshot: reading %s: %v", out, err)
+		}
+		if len(b) < 1024 {
+			t.Fatalf("screenshot: %s is only %d bytes, expected a real image", out, len(b))
+		}
+		if string(b[:8]) != "\x89PNG\r\n\x1a\n" {
+			t.Fatalf("screenshot: %s is not a PNG (magic %x)", out, b[:8])
+		}
+	})
+}
+
+// TestLaunchKill launches a known system app via the instruments process-control
+// service and then kills it. Both report success (non-zero exit fails the test).
+func TestLaunchKill(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		runIOSForDevice(t, udid, "launch", knownSystemApp)
+		runIOSForDevice(t, udid, "kill", knownSystemApp)
+	})
+}

--- a/test/e2e/preios17/main_test.go
+++ b/test/e2e/preios17/main_test.go
@@ -1,0 +1,90 @@
+//go:build e2e
+
+// Package preios17_test is the comprehensive real-device suite for devices
+// older than iOS 17. These devices serve the *entire* go-ios feature set —
+// including the instruments/DTX commands (ps, screenshot, launch/kill) that on
+// iOS 17+ require the tunnel — directly over usbmuxd/lockdown with only a
+// mounted Developer Disk Image and NO tunnel. It runs as its own GitHub Actions
+// step against a dedicated pre-iOS17 device list.
+//
+// The assertions here are deliberately separate from the tunnel-free suite
+// (test/e2e): several command outputs differ on old iOS (e.g. MobileGestalt is
+// not deprecated and returns real values, Developer Mode does not exist, crash
+// reports are not .ips), so dumping these devices into the iOS 18 suite's
+// exact-match tests would break it.
+package preios17_test
+
+import (
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/danielpaulus/go-ios/test/e2e/harness"
+)
+
+// Like the tunnel suite, mount the developer disk image up front: the
+// instruments services (ps, screenshot, launch) need it. Unlike the tunnel
+// suite, no tunnel is started — pre-iOS17 devices reach these services over the
+// classic lockdown/usbmux transport.
+func TestMain(m *testing.M) { harness.Main(m, harness.MountDeveloperImage) }
+
+// Thin aliases so the per-command test files read cleanly (mirrors the other
+// suites' helpers_test.go).
+func runIOS(t *testing.T, args ...string) []byte { return harness.RunIOS(t, args...) }
+
+func runIOSForDevice(t *testing.T, udid string, args ...string) []byte {
+	return harness.RunForDevice(t, udid, args...)
+}
+
+func smoke(t *testing.T, udid string, args ...string) []byte {
+	return harness.Smoke(t, udid, args...)
+}
+
+func smokeJSON(t *testing.T, udid string, args ...string) []byte {
+	return harness.SmokeJSON(t, udid, args...)
+}
+
+func smokeContains(t *testing.T, udid, want string, args ...string) []byte {
+	return harness.SmokeContains(t, udid, want, args...)
+}
+
+func smokeObj(t *testing.T, udid string, requiredKeys []string, args ...string) map[string]any {
+	return harness.SmokeJSONObject(t, udid, requiredKeys, args...)
+}
+
+func smokeArr(t *testing.T, udid string, elemKeys []string, args ...string) []any {
+	return harness.SmokeJSONArray(t, udid, elemKeys, args...)
+}
+
+func streamSmoke(t *testing.T, udid string, window time.Duration, args ...string) []byte {
+	return harness.StreamSmoke(t, udid, window, args...)
+}
+
+func startBackground(t *testing.T, udid string, stopSig syscall.Signal, args ...string) (output func() string, stop func()) {
+	return harness.StartBackground(t, udid, stopSig, args...)
+}
+
+func expectedDevice(udid string) (map[string]string, bool) {
+	return harness.ExpectedDevice(udid)
+}
+
+func forEachDevice(t *testing.T, fn func(t *testing.T, udid string)) {
+	harness.ForEachDevice(t, fn)
+}
+
+// assertSnapshot asserts the recorded identity fields in testdata/devices.json
+// match the live response for a known device. Keys absent from a particular
+// response are skipped (the fixture is a superset across commands); unknown
+// devices are skipped so adding a device does not break CI.
+func assertSnapshot(t *testing.T, udid string, m map[string]any) {
+	t.Helper()
+	exp, ok := expectedDevice(udid)
+	if !ok {
+		return
+	}
+	for key, want := range exp {
+		if got, present := m[key].(string); present && got != want {
+			t.Fatalf("%s = %q, want %q (test/e2e/testdata/devices.json)", key, got, want)
+		}
+	}
+}

--- a/test/e2e/preios17/resources_test.go
+++ b/test/e2e/preios17/resources_test.go
@@ -1,0 +1,81 @@
+//go:build e2e
+
+package preios17_test
+
+import "testing"
+
+// TestDiskspace asserts the reported capacities are internally consistent.
+func TestDiskspace(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{"BlockSize", "FreeBytes", "Model", "TotalBytes"}, "diskspace")
+		free, _ := m["FreeBytes"].(float64)
+		total, _ := m["TotalBytes"].(float64)
+		if total < 1e9 {
+			t.Fatalf("diskspace: implausible TotalBytes %.0f (< 1GB)", total)
+		}
+		if free <= 0 || free > total {
+			t.Fatalf("diskspace: FreeBytes %.0f out of range (0, TotalBytes=%.0f]", free, total)
+		}
+	})
+}
+
+// TestBatterycheck asserts a battery is present and reports a sane charge level.
+func TestBatterycheck(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{
+			"BatteryCurrentCapacity", "BatteryIsCharging", "ExternalConnected",
+			"FullyCharged", "HasBattery",
+		}, "batterycheck")
+		if has, _ := m["HasBattery"].(bool); !has {
+			t.Fatalf("batterycheck: HasBattery is false")
+		}
+		if lvl, _ := m["BatteryCurrentCapacity"].(float64); lvl < 0 || lvl > 100 {
+			t.Fatalf("batterycheck: BatteryCurrentCapacity %.0f not in 0..100", lvl)
+		}
+	})
+}
+
+func TestBatteryregistry(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		smokeObj(t, udid, []string{
+			"CurrentCapacity", "CycleCount", "DesignCapacity", "Temperature", "Voltage",
+		}, "batteryregistry")
+	})
+}
+
+func TestReadpair(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		smokeObj(t, udid, []string{
+			"DeviceCertificate", "HostCertificate", "HostID", "RootCertificate", "SystemBUID",
+		}, "readpair")
+	})
+}
+
+// TestProfileList lists configuration profiles; the list may be empty, so only
+// assert it is valid JSON.
+func TestProfileList(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) { smokeJSON(t, udid, "profile", "list") })
+}
+
+// TestCrashLs lists crash/diagnostic reports. Old iOS uses report names such as
+// "Analytics-...ips.ca.synced" rather than plain ".ips", so assert only that
+// the list is non-empty and length is consistent with the files array.
+func TestCrashLs(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{"files", "length"}, "crash", "ls")
+		files, _ := m["files"].([]any)
+		length, _ := m["length"].(float64)
+		if int(length) != len(files) {
+			t.Fatalf("crash ls: length=%d but files has %d entries", int(length), len(files))
+		}
+		if len(files) == 0 {
+			t.Fatalf("crash ls: no crash/diagnostic reports found")
+		}
+	})
+}
+
+// TestImageList runs after the harness mounted the developer disk image; assert
+// the command succeeds (output shape varies by iOS version).
+func TestImageList(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) { runIOSForDevice(t, udid, "image", "list") })
+}

--- a/test/e2e/preios17/settings_test.go
+++ b/test/e2e/preios17/settings_test.go
@@ -1,0 +1,119 @@
+//go:build e2e
+
+package preios17_test
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// boolField asserts "<cmd> get" returns field as a boolean.
+func boolField(t *testing.T, udid, field, cmd string) {
+	t.Helper()
+	m := smokeObj(t, udid, []string{field}, cmd, "get")
+	if _, ok := m[field].(bool); !ok {
+		t.Fatalf("%s get: %s is not a bool: %v", cmd, field, m[field])
+	}
+}
+
+func TestAssistivetouchGet(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) { boolField(t, udid, "AssistiveTouchEnabled", "assistivetouch") })
+}
+
+func TestVoiceoverGet(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) { boolField(t, udid, "VoiceOverTouchEnabled", "voiceover") })
+}
+
+func TestZoomGet(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) { boolField(t, udid, "ZoomTouchEnabled", "zoom") })
+}
+
+// TestDevmodeGet reads Developer Mode. On pre-iOS16 it does not exist as a
+// toggle and is reported disabled, so assert only that the field is a bool —
+// not that it is enabled (unlike the iOS 17+ suites).
+func TestDevmodeGet(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{"DeveloperModeEnabled"}, "devmode", "get")
+		if _, ok := m["DeveloperModeEnabled"].(bool); !ok {
+			t.Fatalf("devmode get: DeveloperModeEnabled is not a bool: %v", m["DeveloperModeEnabled"])
+		}
+	})
+}
+
+func TestTimeformatGet(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		m := smokeObj(t, udid, []string{"TimeFormat"}, "timeformat", "get")
+		switch m["TimeFormat"] {
+		case "12h", "24h":
+		default:
+			t.Fatalf("timeformat get: TimeFormat = %v, want 12h or 24h", m["TimeFormat"])
+		}
+	})
+}
+
+// toggleRoundTrip reads a boolean accessibility setting, flips it, asserts the
+// change, and always restores the original value.
+func toggleRoundTrip(t *testing.T, udid, cmd, field string) {
+	t.Helper()
+	get := func() bool {
+		var m map[string]any
+		if err := json.Unmarshal(runIOSForDevice(t, udid, cmd, "get"), &m); err != nil {
+			t.Fatalf("%s get: parse: %v", cmd, err)
+		}
+		b, ok := m[field].(bool)
+		if !ok {
+			t.Fatalf("%s get: missing bool field %q", cmd, field)
+		}
+		return b
+	}
+	set := func(on bool) {
+		op := "disable"
+		if on {
+			op = "enable"
+		}
+		runIOSForDevice(t, udid, cmd, op)
+	}
+
+	orig := get()
+	defer set(orig)
+	set(!orig)
+	if get() == orig {
+		t.Fatalf("%s: state did not change after setting %v", cmd, !orig)
+	}
+}
+
+func TestAssistivetouchToggle(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) { toggleRoundTrip(t, udid, "assistivetouch", "AssistiveTouchEnabled") })
+}
+
+func TestVoiceoverToggle(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) { toggleRoundTrip(t, udid, "voiceover", "VoiceOverTouchEnabled") })
+}
+
+func TestZoomToggle(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) { toggleRoundTrip(t, udid, "zoom", "ZoomTouchEnabled") })
+}
+
+// TestTimeformatRoundTrip sets the time format to the opposite value, asserts
+// the change, and restores the original.
+func TestTimeformatRoundTrip(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		get := func() string {
+			var m map[string]string
+			if err := json.Unmarshal(runIOSForDevice(t, udid, "timeformat", "get"), &m); err != nil {
+				t.Fatalf("timeformat get: parse: %v", err)
+			}
+			return m["TimeFormat"]
+		}
+		orig := get()
+		other := "24h"
+		if orig == "24h" {
+			other = "12h"
+		}
+		defer runIOSForDevice(t, udid, "timeformat", orig)
+		runIOSForDevice(t, udid, "timeformat", other)
+		if got := get(); got != other {
+			t.Fatalf("timeformat: set %s but got %s", other, got)
+		}
+	})
+}

--- a/test/e2e/preios17/skipped_test.go
+++ b/test/e2e/preios17/skipped_test.go
@@ -1,0 +1,35 @@
+//go:build e2e
+
+package preios17_test
+
+import "testing"
+
+// The commands below are part of the go-ios feature set but cannot be asserted
+// unattended on these pre-iOS17 devices, each for a concrete reason. They are
+// kept here (skipped, with the reason) so the gap is explicit rather than
+// silently absent.
+
+// sysmontap streams CPU/memory samples over instruments. On these old devices
+// it connects but emits no samples within a bounded window (verified: nothing
+// in 15s), so there is nothing deterministic to assert.
+func TestSysmontap(t *testing.T) {
+	t.Skip("sysmontap emits no samples within a bounded window on pre-iOS17 devices")
+}
+
+// instruments notifications only emits on app lifecycle transitions, so it
+// produces nothing without separately driving an app — not unattended-assertable
+// here (launch/kill is covered by TestLaunchKill).
+func TestInstrumentsNotifications(t *testing.T) {
+	t.Skip("instruments notifications only emits on app lifecycle events; nothing to assert unattended")
+}
+
+// pcap/ip depend on the device's pcapd and on live traffic: pcap fails outright
+// on iOS 12.5.7 and ip blocks until it observes the device's IP in the capture.
+// pcap is covered against a modern device in the tunnel-free suite (test/e2e).
+func TestPcap(t *testing.T) {
+	t.Skip("pcap is version/traffic-dependent on pre-iOS17 (fails on iOS 12.5.7); covered in test/e2e")
+}
+
+func TestIP(t *testing.T) {
+	t.Skip("ip blocks until it detects the device IP from live capture; not deterministic unattended")
+}

--- a/test/e2e/preios17/stream_test.go
+++ b/test/e2e/preios17/stream_test.go
@@ -1,0 +1,23 @@
+//go:build e2e
+
+package preios17_test
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSyslog streams the device syslog (lockdown syslog_relay, no tunnel) and
+// asserts output is produced within the window.
+func TestSyslog(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		streamSmoke(t, udid, 8*time.Second, "syslog")
+	})
+}
+
+// TestOstrace streams os_trace_relay logs and asserts output within the window.
+func TestOstrace(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		streamSmoke(t, udid, 8*time.Second, "ostrace")
+	})
+}

--- a/test/e2e/testdata/devices.json
+++ b/test/e2e/testdata/devices.json
@@ -20,5 +20,27 @@
     "ProductName": "iPhone OS",
     "ModelNumber": "MLVH3",
     "ConnectionType": "USB"
+  },
+  "5b98c87e742570f10e22113b7dd8502638011e16": {
+    "ProductType": "iPhone8,4",
+    "ProductVersion": "14.3",
+    "BuildVersion": "18C66",
+    "DeviceClass": "iPhone",
+    "CPUArchitecture": "arm64",
+    "HardwareModel": "N69AP",
+    "ProductName": "iPhone OS",
+    "ModelNumber": "MLM62",
+    "ConnectionType": "USB"
+  },
+  "8a4b8ae031a0565729e92b836e82bccc4540f8fd": {
+    "ProductType": "iPhone6,2",
+    "ProductVersion": "12.5.7",
+    "BuildVersion": "16H81",
+    "DeviceClass": "iPhone",
+    "CPUArchitecture": "arm64",
+    "HardwareModel": "N53AP",
+    "ProductName": "iPhone OS",
+    "ModelNumber": "NE432",
+    "ConnectionType": "USB"
   }
 }


### PR DESCRIPTION
## What

Adds a dedicated real-device e2e suite (`test/e2e/preios17/`) that validates the **entire go-ios feature set** on devices older than iOS 17, which serve everything over **usbmuxd/lockdown with only a mounted Developer Disk Image and no tunnel** — including the instruments/DTX commands (`ps`, `screenshot`, `launch`/`kill`) that require the tunnel on iOS 17+.

Verified end-to-end against the two pre-iOS17 devices now attached to the Linux runner: **iPhone8,4 (iOS 14.3)** and **iPhone6,2 (iOS 12.5.7)**.

## Coverage

| Area | Commands |
|------|----------|
| Identity / info | `info`, `info lockdown`, `lockdown get`, `devicename`, `date`, `lang`, `list`, `list --details` |
| Diagnostics | `diagnostics list`, `mobilegestalt`, `diskspace`, `batterycheck`, `batteryregistry`, `crash ls` |
| Pairing / profiles / images | `readpair`, `profile list`, `image list` |
| Apps / files | `apps --system --list`, `apps --all`, `fsync tree` |
| Settings (get + toggle round-trip) | `assistivetouch`, `voiceover`, `zoom`, `timeformat`, `devmode get` |
| **Instruments (DDI, no tunnel)** | `ps`, `screenshot`, `launch` + `kill` |
| Streaming | `syslog`, `ostrace` |

## Why a separate suite (not just adding the devices to the existing one)

Several command outputs **differ on old iOS**, so the iOS 18 suite's exact-match assertions would break:
- `mobilegestalt` is **not deprecated** — it returns real values (`Status: Success`).
- Developer Mode **doesn't exist** — `devmode get` reports `false`.
- `crash` reports are **not plain `.ips`** (e.g. `Analytics-….ips.ca.synced`).

This suite tunes assertions to that reality. It mounts the DDI in `TestMain` (like the tunnel suite) but starts no tunnel.

## Skipped (documented, device-specific)

`sysmontap` (emits no samples in a bounded window), `instruments notifications` (only fires on app lifecycle events), `pcap`/`ip` (version/traffic-dependent — `pcap` fails on iOS 12.5.7; `ip` blocks until it sees traffic). Each is a `t.Skip` with the reason so the gap is explicit.

## CI

`real-device.yml` gains an **E2E pre-iOS17 (tunnel-free, DDI)** step, gated on a per-OS `GO_IOS_E2E[_LINUX]_PREIOS17_DEVICES` repo variable (skipped when empty). The Linux variable is set to the two devices above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)