### PR TITLE
Add WebInspector CDP bridge

### DIFF
--- a/cmd_device_registry.go
+++ b/cmd_device_registry.go
@@ -77,4 +77,5 @@ var deviceCommands = []command{
 	commandByBool("file", runFileCommand),
 	commandByBool("fsync", runFsyncCommand),
 	commandByBool("devmode", runDevModeCommand),
+	commandByBool("webinspector", runWebInspectorCommand),
 }

--- a/cmd_device_webinspector.go
+++ b/cmd_device_webinspector.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios/webinspector"
+)
+
+func runWebInspectorCommand(cmdCtx commandContext) {
+	timeoutSeconds, _ := cmdCtx.Args.String("--timeout")
+	timeout := parseWebInspectorTimeout(timeoutSeconds)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	client, err := webinspector.New(cmdCtx.Device)
+	exitIfError("failed connecting to webinspector", err)
+	defer client.Close()
+	exitIfError("failed starting webinspector", client.Connect(ctx))
+
+	if list, _ := cmdCtx.Args.Bool("list"); list {
+		pages, err := client.ListPages(ctx, 500*time.Millisecond)
+		exitIfError("failed listing webinspector pages", err)
+		fmt.Println(convertToJSONString(pages))
+		return
+	}
+
+	if eval, _ := cmdCtx.Args.Bool("eval"); eval {
+		pageID, _ := cmdCtx.Args.String("<pageID>")
+		expression, _ := cmdCtx.Args.String("<expression>")
+		app, page := selectWebInspectorPage(ctx, client, pageID)
+		result, err := client.Evaluate(ctx, app, page, expression)
+		exitIfError("failed evaluating JavaScript", err)
+		fmt.Println(convertToJSONString(result))
+		return
+	}
+
+	if cdp, _ := cmdCtx.Args.Bool("cdp"); cdp {
+		host, _ := cmdCtx.Args.String("--host")
+		port, _ := cmdCtx.Args.Int("--port")
+		if port == 0 {
+			port = 9222
+		}
+		server := webinspector.NewCDPServer(client, host, port)
+		slog.Info("webinspector CDP server started", "addr", server.Addr())
+		serverCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		err := server.Serve(serverCtx)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			exitIfError("webinspector CDP server failed", err)
+		}
+		return
+	}
+}
+
+func selectWebInspectorPage(ctx context.Context, client *webinspector.Client, pageID string) (webinspector.Application, webinspector.Page) {
+	if pageID != "" {
+		app, page, ok := client.FindPage(pageID)
+		if ok {
+			return app, page
+		}
+	}
+	pages, err := client.ListPages(ctx, 500*time.Millisecond)
+	exitIfError("failed listing webinspector pages", err)
+	for _, candidate := range pages {
+		if candidate.Page.Type != webinspector.WIRTypeWeb && candidate.Page.Type != webinspector.WIRTypeWebPage && candidate.Page.Type != webinspector.WIRTypeJavaScript {
+			continue
+		}
+		if pageID == "" || candidate.Page.Key == pageID {
+			return candidate.Application, candidate.Page
+		}
+	}
+	exitIfError("failed finding webinspector page", fmt.Errorf("page %q not found", pageID))
+	return webinspector.Application{}, webinspector.Page{}
+}
+
+func parseWebInspectorTimeout(raw string) time.Duration {
+	if raw == "" {
+		return 5 * time.Second
+	}
+	seconds, err := strconv.ParseFloat(raw, 64)
+	if err != nil || seconds <= 0 {
+		return 5 * time.Second
+	}
+	return time.Duration(seconds * float64(time.Second))
+}

--- a/cmd_device_webinspector.go
+++ b/cmd_device_webinspector.go
@@ -27,7 +27,7 @@ func runWebInspectorCommand(cmdCtx commandContext) {
 	client, err := webinspector.New(cmdCtx.Device)
 	exitIfError("failed connecting to webinspector", err)
 	defer client.Close()
-	exitIfError("failed starting webinspector", client.Connect(ctx))
+	exitIfError("failed starting webinspector", webInspectorStartupError(client.Connect(ctx)))
 
 	if list, _ := cmdCtx.Args.Bool("list"); list {
 		pages, err := client.ListPages(ctx, 500*time.Millisecond)
@@ -110,6 +110,13 @@ func runWebInspectorCommand(cmdCtx commandContext) {
 		}
 		return
 	}
+}
+
+func webInspectorStartupError(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("timed out waiting for Web Inspector pages; enable Settings > Safari > Advanced > Web Inspector, then reconnect the device, or retry with --timeout=<seconds>: %w", err)
+	}
+	return err
 }
 
 func selectWebInspectorPage(ctx context.Context, client *webinspector.Client, pageID string, bundleID string) (webinspector.Application, webinspector.Page) {

--- a/cmd_device_webinspector.go
+++ b/cmd_device_webinspector.go
@@ -1,17 +1,21 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/danielpaulus/go-ios/ios/webinspector"
+	"github.com/google/uuid"
 )
 
 func runWebInspectorCommand(cmdCtx commandContext) {
@@ -32,13 +36,61 @@ func runWebInspectorCommand(cmdCtx commandContext) {
 		return
 	}
 
+	if launch, _ := cmdCtx.Args.Bool("launch"); launch {
+		url, _ := cmdCtx.Args.String("<url>")
+		bundleID, _ := cmdCtx.Args.String("--bundle-id")
+		if bundleID == "" {
+			bundleID = webinspector.SafariBundleID
+		}
+		app, err := client.OpenApp(ctx, bundleID)
+		exitIfError("failed launching app", err)
+		session, err := client.AutomationSession(ctx, app)
+		exitIfError("failed starting automation session", err)
+		defer func() {
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer stopCancel()
+			_ = session.Stop(stopCtx)
+		}()
+		exitIfError("failed starting browsing context", session.Start(ctx))
+		exitIfError("failed navigating", session.Navigate(ctx, url))
+		currentURL, _ := session.CurrentURL(ctx)
+		title, _ := session.Title(ctx)
+		fmt.Println(convertToJSONString(map[string]any{"bundleID": bundleID, "url": currentURL, "title": title}))
+		return
+	}
+
 	if eval, _ := cmdCtx.Args.Bool("eval"); eval {
 		pageID, _ := cmdCtx.Args.String("<pageID>")
 		expression, _ := cmdCtx.Args.String("<expression>")
-		app, page := selectWebInspectorPage(ctx, client, pageID)
+		app, page := selectWebInspectorPage(ctx, client, pageID, "")
+		if consoleEnable, _ := cmdCtx.Args.Bool("--console-enable"); consoleEnable {
+			sessionID := strings.ToUpper(uuid.New().String())
+			exitIfError("failed setting up inspector socket", client.SetupInspectorSocket(sessionID, app, page, false))
+			_, _ = client.SendCommand(ctx, sessionID, app, page, int(time.Now().UnixNano()&0x7fffffff), "Console.enable", nil)
+		}
 		result, err := client.Evaluate(ctx, app, page, expression)
 		exitIfError("failed evaluating JavaScript", err)
 		fmt.Println(convertToJSONString(result))
+		return
+	}
+
+	if shell, _ := cmdCtx.Args.Bool("js-shell"); shell {
+		url, _ := cmdCtx.Args.String("<url>")
+		bundleID, _ := cmdCtx.Args.String("--bundle-id")
+		openSafari, _ := cmdCtx.Args.Bool("--open-safari")
+		if openSafari {
+			_, err := client.OpenApp(ctx, webinspector.SafariBundleID)
+			exitIfError("failed opening Safari", err)
+			if bundleID == "" {
+				bundleID = webinspector.SafariBundleID
+			}
+		}
+		app, page := selectWebInspectorPage(ctx, client, "", bundleID)
+		if url != "" {
+			_, err := client.Evaluate(ctx, app, page, fmt.Sprintf("window.location = %q", url))
+			exitIfError("failed navigating", err)
+		}
+		runWebInspectorJSShell(ctx, client, app, page)
 		return
 	}
 
@@ -60,7 +112,7 @@ func runWebInspectorCommand(cmdCtx commandContext) {
 	}
 }
 
-func selectWebInspectorPage(ctx context.Context, client *webinspector.Client, pageID string) (webinspector.Application, webinspector.Page) {
+func selectWebInspectorPage(ctx context.Context, client *webinspector.Client, pageID string, bundleID string) (webinspector.Application, webinspector.Page) {
 	if pageID != "" {
 		app, page, ok := client.FindPage(pageID)
 		if ok {
@@ -69,16 +121,58 @@ func selectWebInspectorPage(ctx context.Context, client *webinspector.Client, pa
 	}
 	pages, err := client.ListPages(ctx, 500*time.Millisecond)
 	exitIfError("failed listing webinspector pages", err)
+	var candidates []webinspector.ApplicationPage
 	for _, candidate := range pages {
 		if candidate.Page.Type != webinspector.WIRTypeWeb && candidate.Page.Type != webinspector.WIRTypeWebPage && candidate.Page.Type != webinspector.WIRTypeJavaScript {
 			continue
 		}
-		if pageID == "" || candidate.Page.Key == pageID {
-			return candidate.Application, candidate.Page
+		if bundleID != "" && candidate.Application.BundleID != bundleID {
+			continue
+		}
+		if pageID != "" && candidate.Page.Key != pageID {
+			continue
+		}
+		candidates = append(candidates, candidate)
+	}
+	if len(candidates) == 0 {
+		exitIfError("failed finding webinspector page", fmt.Errorf("no matching page found"))
+	}
+	if len(candidates) > 1 && pageID == "" {
+		if JSONdisabled {
+			for i, candidate := range candidates {
+				fmt.Fprintf(os.Stderr, "[%d] %s %s %s\n", i, candidate.Application.BundleID, candidate.Page.Key, candidate.Page.URL)
+			}
 		}
 	}
-	exitIfError("failed finding webinspector page", fmt.Errorf("page %q not found", pageID))
-	return webinspector.Application{}, webinspector.Page{}
+	return candidates[0].Application, candidates[0].Page
+}
+
+func runWebInspectorJSShell(ctx context.Context, client *webinspector.Client, app webinspector.Application, page webinspector.Page) {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print("> ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				fmt.Println()
+				return
+			}
+			exitIfError("failed reading shell input", err)
+		}
+		expression := strings.TrimSpace(line)
+		if expression == "" {
+			continue
+		}
+		if expression == ".exit" || expression == "exit" || expression == "quit" {
+			return
+		}
+		result, err := client.Evaluate(ctx, app, page, expression)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			continue
+		}
+		fmt.Println(convertToJSONString(result))
+	}
 }
 
 func parseWebInspectorTimeout(raw string) time.Duration {

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 require (
 	github.com/blacktop/go-dwarf v1.0.14 // indirect
 	github.com/blacktop/go-macho v1.1.258 // indirect
+	github.com/gorilla/websocket v1.5.3
 	github.com/vishvananda/netns v0.0.5 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grandcat/zeroconf v1.0.0 h1:uHhahLBKqwWBV6WZUDAT71044vwOTL+McW0mBJvo6kE=
 github.com/grandcat/zeroconf v1.0.0/go.mod h1:lTKmG1zh86XyCoUeIHSA4FJMBwCJiQmGfcP2PdzytEs=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/internal/clihelp/help.yaml
+++ b/internal/clihelp/help.yaml
@@ -261,6 +261,15 @@ commands:
   - path: uninstall
     usage: ios uninstall <bundleID> [options]
     summary: Uninstall app by bundle ID.
+  - path: webinspector list
+    usage: ios webinspector list [--timeout=<seconds>] [options]
+    summary: List inspectable Safari and WebView pages.
+  - path: webinspector eval
+    usage: ios webinspector eval <pageID> <expression> [--timeout=<seconds>] [options]
+    summary: Evaluate JavaScript in an inspectable page.
+  - path: webinspector cdp
+    usage: ios webinspector cdp [--host=<host>] [--port=<port>] [options]
+    summary: Start a Chrome DevTools Protocol bridge.
   - path: version
     usage: ios --version | version [options]
     summary: Print version.

--- a/internal/clihelp/help.yaml
+++ b/internal/clihelp/help.yaml
@@ -264,9 +264,15 @@ commands:
   - path: webinspector list
     usage: ios webinspector list [--timeout=<seconds>] [options]
     summary: List inspectable Safari and WebView pages.
+  - path: webinspector launch
+    usage: ios webinspector launch <url> [--bundle-id=<bundleID>] [--timeout=<seconds>] [options]
+    summary: Launch and navigate Safari or another app by Remote Automation.
   - path: webinspector eval
-    usage: ios webinspector eval <pageID> <expression> [--timeout=<seconds>] [options]
+    usage: ios webinspector eval <pageID> <expression> [--timeout=<seconds>] [--console-enable] [options]
     summary: Evaluate JavaScript in an inspectable page.
+  - path: webinspector js-shell
+    usage: ios webinspector js-shell [<url>] [--bundle-id=<bundleID>] [--open-safari] [--timeout=<seconds>] [--console-enable] [options]
+    summary: Start an interactive JavaScript shell for an inspectable page.
   - path: webinspector cdp
     usage: ios webinspector cdp [--host=<host>] [--port=<port>] [options]
     summary: Start a Chrome DevTools Protocol bridge.

--- a/ios/webinspector/automation.go
+++ b/ios/webinspector/automation.go
@@ -1,0 +1,143 @@
+package webinspector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+type AutomationSession struct {
+	client    *Client
+	app       Application
+	page      Page
+	sessionID string
+	nextID    int
+	topHandle string
+	mu        sync.Mutex
+}
+
+func (s *AutomationSession) ID() string {
+	return s.sessionID
+}
+
+func (s *AutomationSession) Start(ctx context.Context) error {
+	response, err := s.send(ctx, "createBrowsingContext", nil)
+	if err != nil {
+		return err
+	}
+	result, _ := response["result"].(map[string]any)
+	handle, _ := result["handle"].(string)
+	if handle == "" {
+		return fmt.Errorf("automation start: missing browsing context handle: %#v", response)
+	}
+	s.topHandle = handle
+	return nil
+}
+
+func (s *AutomationSession) Stop(ctx context.Context) error {
+	handles, err := s.WindowHandles(ctx)
+	if err != nil {
+		return err
+	}
+	for _, handle := range handles {
+		_, _ = s.send(ctx, "closeBrowsingContext", map[string]any{"handle": handle})
+	}
+	s.topHandle = ""
+	return nil
+}
+
+func (s *AutomationSession) Navigate(ctx context.Context, url string) error {
+	if s.topHandle == "" {
+		if err := s.Start(ctx); err != nil {
+			return err
+		}
+	}
+	_, err := s.send(ctx, "navigateBrowsingContext", map[string]any{
+		"handle":          s.topHandle,
+		"pageLoadTimeout": 3000000,
+		"url":             url,
+	})
+	return err
+}
+
+func (s *AutomationSession) ExecuteScript(ctx context.Context, script string, args ...any) (any, error) {
+	if s.topHandle == "" {
+		if err := s.Start(ctx); err != nil {
+			return nil, err
+		}
+	}
+	encodedArgs := make([]string, 0, len(args))
+	for _, arg := range args {
+		encoded, err := json.Marshal(arg)
+		if err != nil {
+			return nil, err
+		}
+		encodedArgs = append(encodedArgs, string(encoded))
+	}
+	response, err := s.send(ctx, "evaluateJavaScriptFunction", map[string]any{
+		"browsingContextHandle": s.topHandle,
+		"function":              "function(){\n" + script + "\n}",
+		"arguments":             encodedArgs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result, _ := response["result"].(map[string]any)
+	raw, _ := result["result"].(string)
+	if raw == "" {
+		return nil, nil
+	}
+	var value any
+	if err := json.Unmarshal([]byte(raw), &value); err != nil {
+		return raw, nil
+	}
+	return value, nil
+}
+
+func (s *AutomationSession) CurrentURL(ctx context.Context) (string, error) {
+	value, err := s.ExecuteScript(ctx, "return window.location.href")
+	if err != nil {
+		return "", err
+	}
+	url, _ := value.(string)
+	return url, nil
+}
+
+func (s *AutomationSession) Title(ctx context.Context) (string, error) {
+	value, err := s.ExecuteScript(ctx, "return document.title")
+	if err != nil {
+		return "", err
+	}
+	title, _ := value.(string)
+	return title, nil
+}
+
+func (s *AutomationSession) WindowHandles(ctx context.Context) ([]string, error) {
+	response, err := s.send(ctx, "getBrowsingContexts", nil)
+	if err != nil {
+		return nil, err
+	}
+	result, _ := response["result"].(map[string]any)
+	contexts, _ := result["contexts"].([]any)
+	handles := make([]string, 0, len(contexts))
+	for _, rawContext := range contexts {
+		contextMap, _ := rawContext.(map[string]any)
+		handle, _ := contextMap["handle"].(string)
+		if handle != "" {
+			handles = append(handles, handle)
+		}
+	}
+	return handles, nil
+}
+
+func (s *AutomationSession) send(ctx context.Context, method string, params map[string]any) (map[string]any, error) {
+	if params == nil {
+		params = map[string]any{}
+	}
+	s.mu.Lock()
+	id := s.nextID
+	s.nextID++
+	s.mu.Unlock()
+	return s.client.SendCommand(ctx, s.sessionID, s.app, s.page, id, "Automation."+method, params)
+}

--- a/ios/webinspector/cdp.go
+++ b/ios/webinspector/cdp.go
@@ -178,7 +178,7 @@ func (s *CDPServer) forwardBrowserCommands(ctx context.Context, ws *websocket.Co
 		}
 		id, _ := numericInt(message["id"])
 
-		if handled, response, extra := localCDPResponse(message, targetID, sessionID); handled {
+		if handled, response, extra := localCDPResponse(message, targetID, sessionID, page); handled {
 			if err := ws.WriteJSON(response); err != nil {
 				return err
 			}
@@ -218,7 +218,9 @@ func waitForTargetID(ctx context.Context, client *Client, ws *websocket.Conn) st
 			continue
 		}
 		targetID, _ := targetInfo["targetId"].(string)
-		_ = ws.WriteJSON(event)
+		if normalized, drop := normalizeCDPEvent(event); !drop {
+			_ = ws.WriteJSON(normalized)
+		}
 		return targetID
 	}
 }
@@ -242,23 +244,7 @@ func unwrapDispatchMessage(event map[string]any) (map[string]any, bool) {
 	return decoded, true
 }
 
-func shouldReplyLocally(method string) bool {
-	switch method {
-	case "Target.setDiscoverTargets",
-		"Target.setAutoAttach",
-		"Target.setRemoteLocations",
-		"DOM.enable",
-		"Log.enable",
-		"Network.enable",
-		"Page.enable",
-		"Runtime.enable":
-		return true
-	default:
-		return false
-	}
-}
-
-func localCDPResponse(message map[string]any, targetID string, sessionID string) (bool, map[string]any, []map[string]any) {
+func localCDPResponse(message map[string]any, targetID string, sessionID string, page Page) (bool, map[string]any, []map[string]any) {
 	id, _ := numericInt(message["id"])
 	method, _ := message["method"].(string)
 	result := map[string]any{}
@@ -271,6 +257,10 @@ func localCDPResponse(message map[string]any, targetID string, sessionID string)
 				"sessionId": sessionID,
 				"targetInfo": map[string]any{
 					"targetId": targetID,
+					"type":     "page",
+					"title":    page.Title,
+					"url":      page.URL,
+					"attached": true,
 				},
 				"waitingForDebugger": true,
 			},
@@ -312,7 +302,7 @@ func localCDPResponse(message map[string]any, targetID string, sessionID string)
 		result["id"] = 0
 	case "Page.getNavigationHistory":
 		result["currentIndex"] = 0
-		result["entries"] = []map[string]any{{"id": 0, "url": "", "title": ""}}
+		result["entries"] = []map[string]any{{"id": 0, "url": page.URL, "title": page.Title}}
 	default:
 		return false, nil, nil
 	}

--- a/ios/webinspector/cdp.go
+++ b/ios/webinspector/cdp.go
@@ -1,0 +1,277 @@
+package webinspector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+type CDPServer struct {
+	client *Client
+	host   string
+	port   int
+	server *http.Server
+}
+
+type CDPTarget struct {
+	Description          string `json:"description"`
+	ID                   string `json:"id"`
+	Title                string `json:"title"`
+	Type                 string `json:"type"`
+	URL                  string `json:"url"`
+	WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+	DevtoolsFrontendURL  string `json:"devtoolsFrontendUrl"`
+}
+
+func NewCDPServer(client *Client, host string, port int) *CDPServer {
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if port == 0 {
+		port = 9222
+	}
+	return &CDPServer{client: client, host: host, port: port}
+}
+
+func (s *CDPServer) Addr() string {
+	return fmt.Sprintf("%s:%d", s.host, s.port)
+}
+
+func (s *CDPServer) Serve(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/json", s.handleTargets)
+	mux.HandleFunc("/json/list", s.handleTargets)
+	mux.HandleFunc("/json/version", s.handleVersion)
+	mux.HandleFunc("/devtools/page/", s.handlePageWebSocket)
+	s.server = &http.Server{Addr: s.Addr(), Handler: mux}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.server.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.server.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+		return ctx.Err()
+	case err := <-errCh:
+		if err == http.ErrServerClosed {
+			return nil
+		}
+		return err
+	}
+}
+
+func (s *CDPServer) handleTargets(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+	defer cancel()
+
+	pages, err := s.client.ListPages(ctx, 250*time.Millisecond)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	targets := make([]CDPTarget, 0, len(pages))
+	for _, appPage := range pages {
+		page := appPage.Page
+		if page.Type != WIRTypeWeb && page.Type != WIRTypeWebPage {
+			continue
+		}
+		wsURL := fmt.Sprintf("ws://%s/devtools/page/%s", s.Addr(), page.Key)
+		targets = append(targets, CDPTarget{
+			ID:                   page.Key,
+			Title:                page.Title,
+			Type:                 "page",
+			URL:                  page.URL,
+			WebSocketDebuggerURL: wsURL,
+			DevtoolsFrontendURL:  "/devtools/inspector.html?ws=" + s.Addr() + "/devtools/page/" + page.Key,
+		})
+	}
+	writeJSON(w, targets)
+}
+
+func (s *CDPServer) handleVersion(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, map[string]any{
+		"Browser":              "Safari",
+		"Protocol-Version":     "1.1",
+		"User-Agent":           "go-ios",
+		"WebKit-Version":       "",
+		"webSocketDebuggerUrl": fmt.Sprintf("ws://%s/devtools/browser/%s", s.Addr(), s.client.connectionID),
+	})
+}
+
+func (s *CDPServer) handlePageWebSocket(w http.ResponseWriter, r *http.Request) {
+	pageKey := strings.TrimPrefix(r.URL.Path, "/devtools/page/")
+	app, page, ok := s.client.FindPage(pageKey)
+	if !ok {
+		http.Error(w, "page not found", http.StatusNotFound)
+		return
+	}
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer ws.Close()
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	sessionID := strings.ToUpper(uuid.New().String())
+	if err := s.client.SetupInspectorSocket(sessionID, app, page, false); err != nil {
+		_ = ws.WriteJSON(cdpError(0, err))
+		return
+	}
+	targetID := waitForTargetID(ctx, s.client, ws)
+	if targetID == "" {
+		return
+	}
+
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- s.forwardDeviceEvents(ctx, ws)
+	}()
+	go func() {
+		errCh <- s.forwardBrowserCommands(ctx, ws, sessionID, app, page, targetID)
+	}()
+	<-errCh
+}
+
+func (s *CDPServer) forwardDeviceEvents(ctx context.Context, ws *websocket.Conn) error {
+	for {
+		event, err := s.client.NextEvent(ctx)
+		if err != nil {
+			return err
+		}
+		if dispatch, ok := unwrapDispatchMessage(event); ok {
+			if err := ws.WriteJSON(dispatch); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := ws.WriteJSON(event); err != nil {
+			return err
+		}
+	}
+}
+
+func (s *CDPServer) forwardBrowserCommands(ctx context.Context, ws *websocket.Conn, sessionID string, app Application, page Page, targetID string) error {
+	for {
+		var message map[string]any
+		if err := ws.ReadJSON(&message); err != nil {
+			return err
+		}
+		id, _ := numericInt(message["id"])
+		method, _ := message["method"].(string)
+
+		if shouldReplyLocally(method) {
+			if err := ws.WriteJSON(map[string]any{"id": id, "result": map[string]any{}}); err != nil {
+				return err
+			}
+			continue
+		}
+
+		wrapped := map[string]any{
+			"method": "Target.sendMessageToTarget",
+			"params": map[string]any{
+				"targetId": targetID,
+				"message":  mustJSON(message),
+			},
+		}
+		if _, err := s.client.SendCommand(ctx, sessionID, app, page, nextWIRID(), "Target.sendMessageToTarget", wrapped["params"].(map[string]any)); err != nil {
+			if writeErr := ws.WriteJSON(cdpError(id, err)); writeErr != nil {
+				return writeErr
+			}
+		}
+	}
+}
+
+func waitForTargetID(ctx context.Context, client *Client, ws *websocket.Conn) string {
+	for {
+		event, err := client.NextEvent(ctx)
+		if err != nil {
+			_ = ws.WriteJSON(cdpError(0, err))
+			return ""
+		}
+		targetInfo, ok := event["params"].(map[string]any)["targetInfo"].(map[string]any)
+		if !ok {
+			continue
+		}
+		targetID, _ := targetInfo["targetId"].(string)
+		_ = ws.WriteJSON(event)
+		return targetID
+	}
+}
+
+func unwrapDispatchMessage(event map[string]any) (map[string]any, bool) {
+	if event["method"] != "Target.dispatchMessageFromTarget" {
+		return nil, false
+	}
+	params, ok := event["params"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	message, _ := params["message"].(string)
+	if message == "" {
+		return nil, false
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(message), &decoded); err != nil {
+		return nil, false
+	}
+	return decoded, true
+}
+
+func shouldReplyLocally(method string) bool {
+	switch method {
+	case "Target.setDiscoverTargets",
+		"Target.setAutoAttach",
+		"Target.setRemoteLocations",
+		"DOM.enable",
+		"Log.enable",
+		"Network.enable",
+		"Page.enable",
+		"Runtime.enable":
+		return true
+	default:
+		return false
+	}
+}
+
+func cdpError(id int, err error) map[string]any {
+	return map[string]any{
+		"id": id,
+		"error": map[string]any{
+			"code":    -32000,
+			"message": err.Error(),
+		},
+	}
+}
+
+func writeJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func mustJSON(value any) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
+func nextWIRID() int {
+	return int(time.Now().UnixNano() & 0x7fffffff)
+}

--- a/ios/webinspector/cdp.go
+++ b/ios/webinspector/cdp.go
@@ -2,6 +2,7 @@ package webinspector
 
 import (
 	"context"
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -267,8 +268,11 @@ func localCDPResponse(message map[string]any, targetID string, sessionID string,
 		})
 	case "Target.setDiscoverTargets",
 		"Target.setRemoteLocations",
+		"CSS.trackComputedStyleUpdates",
 		"DOM.enable",
 		"DOMDebugger.setBreakOnCSPViolation",
+		"Debugger.setAsyncCallStackDepth",
+		"Debugger.setBlackboxPatterns",
 		"Emulation.setTouchEmulationEnabled",
 		"Emulation.setFocusEmulationEnabled",
 		"Emulation.setEmulatedVisionDeficiency",
@@ -294,6 +298,9 @@ func localCDPResponse(message map[string]any, targetID string, sessionID string,
 		"Page.stopScreencast",
 		"Profiler.enable",
 		"Runtime.runIfWaitingForDebugger":
+		if method == "Debugger.setAsyncCallStackDepth" {
+			result["result"] = true
+		}
 	case "CSS.takeComputedStyleUpdates":
 		result["nodeIds"] = []int{}
 	case "Network.loadNetworkResource":
@@ -353,6 +360,23 @@ func translateCDPCommand(message map[string]any) map[string]any {
 				params["selector"] = strings.Split(rule, "{")[0]
 			}
 		}
+	case "Debugger.setBreakpointByUrl":
+		if params != nil {
+			if condition, ok := params["condition"]; ok {
+				options, _ := params["options"].(map[string]any)
+				if options == nil {
+					options = map[string]any{}
+				}
+				options["condition"] = condition
+				params["options"] = options
+				delete(params, "condition")
+			}
+		}
+	case "Runtime.compileScript":
+		message["method"] = "Runtime.parse"
+		if params != nil {
+			message["params"] = map[string]any{"source": params["expression"]}
+		}
 	}
 	return message
 }
@@ -373,6 +397,31 @@ func normalizeCDPEvent(message map[string]any) (map[string]any, bool) {
 		return message, true
 	case "Debugger.globalObjectCleared":
 		return map[string]any{"method": "DOM.documentUpdated"}, false
+	case "Debugger.paused":
+		if reason := stringValue(params["reason"]); reason != "" {
+			params["reason"] = debuggerPausedReason(reason)
+		}
+		if data, _ := params["data"].(map[string]any); data != nil {
+			if breakpointID := stringValue(data["breakpointId"]); breakpointID != "" {
+				params["hitBreakpoints"] = []string{breakpointID}
+			}
+		}
+	case "Debugger.scriptFailedToParse":
+		source := stringValue(params["scriptSource"])
+		contextID := params["executionContextId"]
+		if contextID == nil {
+			contextID = 0
+		}
+		params["endColumn"] = 0
+		params["endLine"] = params["errorLine"]
+		params["executionContextId"] = contextID
+		params["startColumn"] = 0
+		params["startLine"] = params["startLine"]
+		sourceHash := fmt.Sprintf("%x", sha1.Sum([]byte(source)))
+		params["scriptId"] = sourceHash
+		params["hash"] = sourceHash
+		delete(params, "errorLine")
+		delete(params, "scriptSource")
 	case "Runtime.executionContextCreated":
 		if contextMap, ok := params["context"].(map[string]any); ok {
 			params["context"] = map[string]any{
@@ -445,6 +494,10 @@ func logSource(source string) string {
 		return source
 	case "console-api":
 		return "javascript"
+	case "css":
+		return "rendering"
+	case "content-blocker", "media", "mediasource", "webrtc", "itp-debug", "ad-click-attribution":
+		return "other"
 	default:
 		return "other"
 	}
@@ -471,6 +524,29 @@ func validNetworkResourceType(resourceType string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func debuggerPausedReason(reason string) string {
+	switch reason {
+	case "XHR":
+		return "XHR"
+	case "DOM":
+		return "DOM"
+	case "Listener":
+		return "EventListener"
+	case "exception":
+		return "exception"
+	case "assert":
+		return "assert"
+	case "CSPViolation":
+		return "CSPViolation"
+	case "DebuggerStatement":
+		return "debugCommand"
+	case "Breakpoint", "PauseOnNextStatement":
+		return "instrumentation"
+	default:
+		return "other"
 	}
 }
 

--- a/ios/webinspector/cdp.go
+++ b/ios/webinspector/cdp.go
@@ -155,13 +155,17 @@ func (s *CDPServer) forwardDeviceEvents(ctx context.Context, ws *websocket.Conn)
 			return err
 		}
 		if dispatch, ok := unwrapDispatchMessage(event); ok {
-			if err := ws.WriteJSON(dispatch); err != nil {
-				return err
+			if normalized, drop := normalizeCDPEvent(dispatch); !drop {
+				if err := ws.WriteJSON(normalized); err != nil {
+					return err
+				}
 			}
 			continue
 		}
-		if err := ws.WriteJSON(event); err != nil {
-			return err
+		if normalized, drop := normalizeCDPEvent(event); !drop {
+			if err := ws.WriteJSON(normalized); err != nil {
+				return err
+			}
 		}
 	}
 }
@@ -173,15 +177,20 @@ func (s *CDPServer) forwardBrowserCommands(ctx context.Context, ws *websocket.Co
 			return err
 		}
 		id, _ := numericInt(message["id"])
-		method, _ := message["method"].(string)
 
-		if shouldReplyLocally(method) {
-			if err := ws.WriteJSON(map[string]any{"id": id, "result": map[string]any{}}); err != nil {
+		if handled, response, extra := localCDPResponse(message, targetID, sessionID); handled {
+			if err := ws.WriteJSON(response); err != nil {
 				return err
+			}
+			for _, event := range extra {
+				if err := ws.WriteJSON(event); err != nil {
+					return err
+				}
 			}
 			continue
 		}
 
+		message = translateCDPCommand(message)
 		wrapped := map[string]any{
 			"method": "Target.sendMessageToTarget",
 			"params": map[string]any{
@@ -243,6 +252,232 @@ func shouldReplyLocally(method string) bool {
 		"Network.enable",
 		"Page.enable",
 		"Runtime.enable":
+		return true
+	default:
+		return false
+	}
+}
+
+func localCDPResponse(message map[string]any, targetID string, sessionID string) (bool, map[string]any, []map[string]any) {
+	id, _ := numericInt(message["id"])
+	method, _ := message["method"].(string)
+	result := map[string]any{}
+	var extra []map[string]any
+	switch method {
+	case "Target.setAutoAttach":
+		extra = append(extra, map[string]any{
+			"method": "Target.attachedToTarget",
+			"params": map[string]any{
+				"sessionId": sessionID,
+				"targetInfo": map[string]any{
+					"targetId": targetID,
+				},
+				"waitingForDebugger": true,
+			},
+		})
+	case "Target.setDiscoverTargets",
+		"Target.setRemoteLocations",
+		"DOM.enable",
+		"DOMDebugger.setBreakOnCSPViolation",
+		"Emulation.setTouchEmulationEnabled",
+		"Emulation.setFocusEmulationEnabled",
+		"Emulation.setEmulatedVisionDeficiency",
+		"Emulation.setEmitTouchEventsForMouse",
+		"Emulation.setAutoDarkModeOverride",
+		"HeapProfiler.enable",
+		"Input.dispatchKeyEvent",
+		"Input.emulateTouchFromMouseEvent",
+		"Log.startViolationsReport",
+		"Network.clearAcceptedEncodingsOverride",
+		"Network.setAttachDebugStack",
+		"Overlay.enable",
+		"Overlay.hideHighlight",
+		"Overlay.setPausedInDebuggerMessage",
+		"Overlay.setShowContainerQueryOverlays",
+		"Overlay.setShowFlexOverlays",
+		"Overlay.setShowGridOverlays",
+		"Overlay.setShowIsolatedElements",
+		"Overlay.setShowScrollSnapOverlays",
+		"Overlay.setShowViewportSizeOnResize",
+		"Page.screencastFrameAck",
+		"Page.startScreencast",
+		"Page.stopScreencast",
+		"Profiler.enable",
+		"Runtime.runIfWaitingForDebugger":
+	case "CSS.takeComputedStyleUpdates":
+		result["nodeIds"] = []int{}
+	case "Network.loadNetworkResource":
+		result["resource"] = map[string]any{"success": true}
+	case "Runtime.getIsolateId":
+		result["id"] = 0
+	case "Page.getNavigationHistory":
+		result["currentIndex"] = 0
+		result["entries"] = []map[string]any{{"id": 0, "url": "", "title": ""}}
+	default:
+		return false, nil, nil
+	}
+	return true, map[string]any{"id": id, "result": result}, extra
+}
+
+func translateCDPCommand(message map[string]any) map[string]any {
+	method, _ := message["method"].(string)
+	params, _ := message["params"].(map[string]any)
+	switch method {
+	case "Audits.enable":
+		message["method"] = "Audit.setup"
+	case "DOM.getBoxModel", "Overlay.highlightNode":
+		message["method"] = "DOM.highlightNode"
+		if params != nil && method == "DOM.getBoxModel" {
+			params["highlightConfig"] = map[string]any{
+				"showInfo":     true,
+				"contentColor": map[string]any{"r": 111, "g": 168, "b": 220, "a": 0.66},
+				"paddingColor": map[string]any{"r": 147, "g": 196, "b": 125, "a": 0.55},
+				"borderColor":  map[string]any{"r": 255, "g": 229, "b": 153, "a": 0.66},
+				"marginColor":  map[string]any{"r": 246, "g": 178, "b": 107, "a": 0.66},
+			}
+		}
+	case "Log.clear":
+		message["method"] = "Console.clearMessages"
+	case "Log.disable":
+		message["method"] = "Console.disable"
+	case "Log.enable":
+		message["method"] = "Console.enable"
+	case "Emulation.setEmulatedMedia":
+		message["method"] = "Page.setEmulatedMedia"
+	case "Emulation.setAutoDarkModeOverride":
+		message["method"] = "Page.setForcedAppearance"
+		if params != nil {
+			enabled, _ := params["enabled"].(bool)
+			message["params"] = map[string]any{"appearance": map[bool]string{true: "Dark", false: "Light"}[enabled]}
+		}
+	case "Network.setCacheDisabled":
+		message["method"] = "Network.setResourceCachingDisabled"
+		if params != nil {
+			message["params"] = map[string]any{"disabled": params["cacheDisabled"]}
+		}
+	case "ServiceWorker.enable":
+		message["method"] = "Worker.enable"
+	case "CSS.addRule":
+		if params != nil {
+			if rule, _ := params["ruleText"].(string); rule != "" {
+				params["selector"] = strings.Split(rule, "{")[0]
+			}
+		}
+	}
+	return message
+}
+
+func normalizeCDPEvent(message map[string]any) (map[string]any, bool) {
+	method, _ := message["method"].(string)
+	params, _ := message["params"].(map[string]any)
+	switch method {
+	case "Target.targetCreated":
+		message["method"] = "Target.targetInfoChanged"
+		if targetInfo, ok := params["targetInfo"].(map[string]any); ok {
+			if provisional, ok := targetInfo["isProvisional"]; ok {
+				targetInfo["attached"] = provisional
+				delete(targetInfo, "isProvisional")
+			}
+		}
+	case "Target.didCommitProvisionalTarget", "Page.defaultAppearanceDidChange":
+		return message, true
+	case "Debugger.globalObjectCleared":
+		return map[string]any{"method": "DOM.documentUpdated"}, false
+	case "Runtime.executionContextCreated":
+		if contextMap, ok := params["context"].(map[string]any); ok {
+			params["context"] = map[string]any{
+				"id":       contextMap["id"],
+				"origin":   "default",
+				"name":     "",
+				"uniqueId": contextMap["frameId"],
+			}
+		}
+	case "Console.messageAdded":
+		entry := map[string]any{"source": "javascript", "level": "info", "timestamp": float64(time.Now().UnixMilli()) / 1000}
+		if consoleMessage, ok := params["message"].(map[string]any); ok {
+			entry["source"] = logSource(stringValue(consoleMessage["source"]))
+			entry["level"] = logLevel(stringValue(consoleMessage["level"]))
+			entry["text"] = consoleMessage["text"]
+			if url := stringValue(consoleMessage["url"]); url != "" {
+				entry["url"] = url
+			}
+			if line, ok := numericInt(consoleMessage["line"]); ok {
+				entry["lineNumber"] = line
+			}
+			if requestID := stringValue(consoleMessage["networkRequestId"]); requestID != "" {
+				entry["networkRequestId"] = requestID
+			}
+		}
+		return map[string]any{"method": "Log.entryAdded", "params": map[string]any{"entry": entry}}, false
+	case "Network.responseReceived":
+		if response, ok := params["response"].(map[string]any); ok {
+			resourceType := stringValue(params["type"])
+			if !validNetworkResourceType(resourceType) {
+				resourceType = "Other"
+			}
+			normalized := map[string]any{
+				"loaderId":  params["loaderId"],
+				"requestId": params["requestId"],
+				"timestamp": params["timestamp"],
+				"type":      resourceType,
+				"response": map[string]any{
+					"url":               response["url"],
+					"status":            response["status"],
+					"statusText":        response["statusText"],
+					"headers":           response["headers"],
+					"mimeType":          response["mimeType"],
+					"connectionReused":  false,
+					"encodedDataLength": 0,
+					"securityState":     "unknown",
+				},
+			}
+			if frameID := params["frameId"]; frameID != nil {
+				normalized["frameId"] = frameID
+			}
+			message["params"] = normalized
+		}
+	case "Network.loadingFinished":
+		metrics, _ := params["metrics"].(map[string]any)
+		headerSize, _ := numericInt(metrics["responseHeaderBytesReceived"])
+		bodySize, _ := numericInt(metrics["responseBodyBytesReceived"])
+		message["params"] = map[string]any{
+			"encodedDataLength": headerSize + bodySize,
+			"requestId":         params["requestId"],
+			"timestamp":         params["timestamp"],
+		}
+	}
+	return message, false
+}
+
+func logSource(source string) string {
+	switch source {
+	case "xml", "javascript", "network", "storage", "appcache", "rendering", "security", "deprecation", "worker", "violation", "intervention", "recommendation", "other":
+		return source
+	case "console-api":
+		return "javascript"
+	default:
+		return "other"
+	}
+}
+
+func logLevel(level string) string {
+	switch level {
+	case "log", "info":
+		return "info"
+	case "warning":
+		return "warning"
+	case "error":
+		return "error"
+	case "debug":
+		return "verbose"
+	default:
+		return "info"
+	}
+}
+
+func validNetworkResourceType(resourceType string) bool {
+	switch resourceType {
+	case "Document", "Stylesheet", "Image", "Media", "Font", "Script", "TextTrack", "XHR", "Fetch", "EventSource", "WebSocket", "Manifest", "SignedExchange", "Ping", "CSPViolationReport", "Preflight", "Other":
 		return true
 	default:
 		return false

--- a/ios/webinspector/cdp.go
+++ b/ios/webinspector/cdp.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -28,6 +29,38 @@ type CDPTarget struct {
 	URL                  string `json:"url"`
 	WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
 	DevtoolsFrontendURL  string `json:"devtoolsFrontendUrl"`
+}
+
+type cdpPageSession struct {
+	server    *CDPServer
+	ws        *websocket.Conn
+	sessionID string
+	app       Application
+	page      Page
+	targetID  string
+
+	writeMu sync.Mutex
+	sendMu  sync.Mutex
+
+	pendingMu sync.Mutex
+	pending   map[int]chan map[string]any
+
+	frame              map[string]any
+	defaultExecutionID any
+	screencast         *cdpScreencast
+}
+
+type cdpScreencast struct {
+	format     string
+	quality    int
+	maxWidth   int
+	maxHeight  int
+	deviceW    int
+	deviceH    int
+	scale      float64
+	frameID    int
+	lastAck    int
+	cancelFunc context.CancelFunc
 }
 
 func NewCDPServer(client *Client, host string, port int) *CDPServer {
@@ -139,52 +172,80 @@ func (s *CDPServer) handlePageWebSocket(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	session := &cdpPageSession{
+		server:    s,
+		ws:        ws,
+		sessionID: sessionID,
+		app:       app,
+		page:      page,
+		targetID:  targetID,
+		pending:   make(map[int]chan map[string]any),
+	}
 	errCh := make(chan error, 2)
 	go func() {
-		errCh <- s.forwardDeviceEvents(ctx, ws)
+		errCh <- session.forwardDeviceEvents(ctx)
 	}()
 	go func() {
-		errCh <- s.forwardBrowserCommands(ctx, ws, sessionID, app, page, targetID)
+		errCh <- session.forwardBrowserCommands(ctx)
 	}()
 	<-errCh
 }
 
-func (s *CDPServer) forwardDeviceEvents(ctx context.Context, ws *websocket.Conn) error {
+func (s *cdpPageSession) writeJSON(value any) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.ws.WriteJSON(value)
+}
+
+func (s *cdpPageSession) forwardDeviceEvents(ctx context.Context) error {
 	for {
-		event, err := s.client.NextEvent(ctx)
+		event, err := s.server.client.NextEvent(ctx)
 		if err != nil {
 			return err
 		}
 		if dispatch, ok := unwrapDispatchMessage(event); ok {
-			if normalized, drop := normalizeCDPEvent(dispatch); !drop {
-				if err := ws.WriteJSON(normalized); err != nil {
+			if s.resolvePending(dispatch) {
+				continue
+			}
+			if normalized, drop := s.normalizeCDPEvent(dispatch); !drop {
+				if err := s.writeJSON(normalized); err != nil {
 					return err
 				}
 			}
 			continue
 		}
-		if normalized, drop := normalizeCDPEvent(event); !drop {
-			if err := ws.WriteJSON(normalized); err != nil {
+		if normalized, drop := s.normalizeCDPEvent(event); !drop {
+			if err := s.writeJSON(normalized); err != nil {
 				return err
 			}
 		}
 	}
 }
 
-func (s *CDPServer) forwardBrowserCommands(ctx context.Context, ws *websocket.Conn, sessionID string, app Application, page Page, targetID string) error {
+func (s *cdpPageSession) forwardBrowserCommands(ctx context.Context) error {
 	for {
 		var message map[string]any
-		if err := ws.ReadJSON(&message); err != nil {
+		if err := s.ws.ReadJSON(&message); err != nil {
 			return err
 		}
 		id, _ := numericInt(message["id"])
 
-		if handled, response, extra := localCDPResponse(message, targetID, sessionID, page); handled {
-			if err := ws.WriteJSON(response); err != nil {
+		if handled, response, err := s.handleSpecialCommand(ctx, message); handled {
+			if err != nil {
+				response = cdpError(id, err)
+			}
+			if err := s.writeJSON(response); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if handled, response, extra := localCDPResponse(message, s.targetID, s.sessionID, s.page); handled {
+			if err := s.writeJSON(response); err != nil {
 				return err
 			}
 			for _, event := range extra {
-				if err := ws.WriteJSON(event); err != nil {
+				if err := s.writeJSON(event); err != nil {
 					return err
 				}
 			}
@@ -195,12 +256,12 @@ func (s *CDPServer) forwardBrowserCommands(ctx context.Context, ws *websocket.Co
 		wrapped := map[string]any{
 			"method": "Target.sendMessageToTarget",
 			"params": map[string]any{
-				"targetId": targetID,
+				"targetId": s.targetID,
 				"message":  mustJSON(message),
 			},
 		}
-		if _, err := s.client.SendCommand(ctx, sessionID, app, page, nextWIRID(), "Target.sendMessageToTarget", wrapped["params"].(map[string]any)); err != nil {
-			if writeErr := ws.WriteJSON(cdpError(id, err)); writeErr != nil {
+		if _, err := s.server.client.SendCommand(ctx, s.sessionID, s.app, s.page, nextWIRID(), "Target.sendMessageToTarget", wrapped["params"].(map[string]any)); err != nil {
+			if writeErr := s.writeJSON(cdpError(id, err)); writeErr != nil {
 				return writeErr
 			}
 		}
@@ -243,6 +304,476 @@ func unwrapDispatchMessage(event map[string]any) (map[string]any, bool) {
 		return nil, false
 	}
 	return decoded, true
+}
+
+func (s *cdpPageSession) resolvePending(message map[string]any) bool {
+	id, ok := numericInt(message["id"])
+	if !ok {
+		return false
+	}
+	s.pendingMu.Lock()
+	ch := s.pending[id]
+	s.pendingMu.Unlock()
+	if ch == nil {
+		return false
+	}
+	select {
+	case ch <- message:
+	default:
+	}
+	return true
+}
+
+func (s *cdpPageSession) sendInner(ctx context.Context, message map[string]any) error {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	_, err := s.server.client.SendCommand(ctx, s.sessionID, s.app, s.page, nextWIRID(), "Target.sendMessageToTarget", map[string]any{
+		"targetId": s.targetID,
+		"message":  mustJSON(message),
+	})
+	return err
+}
+
+func (s *cdpPageSession) sendInnerWait(ctx context.Context, message map[string]any) (map[string]any, error) {
+	id, ok := numericInt(message["id"])
+	if !ok || id == 0 {
+		id = nextWIRID()
+		message["id"] = id
+	}
+	ch := make(chan map[string]any, 1)
+	s.pendingMu.Lock()
+	s.pending[id] = ch
+	s.pendingMu.Unlock()
+	defer func() {
+		s.pendingMu.Lock()
+		delete(s.pending, id)
+		s.pendingMu.Unlock()
+	}()
+
+	if err := s.sendInner(ctx, message); err != nil {
+		return nil, err
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case response := <-ch:
+		if errValue, ok := response["error"]; ok {
+			return response, fmt.Errorf("cdp inner command error: %v", errValue)
+		}
+		return response, nil
+	}
+}
+
+func (s *cdpPageSession) evaluate(ctx context.Context, id int, expression string, returnByValue bool) (map[string]any, error) {
+	response, err := s.sendInnerWait(ctx, map[string]any{
+		"id":     id,
+		"method": "Runtime.evaluate",
+		"params": map[string]any{
+			"expression":                  expression,
+			"objectGroup":                 "console",
+			"includeCommandLineAPI":       true,
+			"returnByValue":               returnByValue,
+			"generatePreview":             true,
+			"userGesture":                 true,
+			"awaitPromise":                false,
+			"replMode":                    true,
+			"allowUnsafeEvalBlockedByCSP": false,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	result, _ := response["result"].(map[string]any)
+	remote, _ := result["result"].(map[string]any)
+	return remote, nil
+}
+
+func (s *cdpPageSession) handleSpecialCommand(ctx context.Context, message map[string]any) (bool, map[string]any, error) {
+	id, _ := numericInt(message["id"])
+	method, _ := message["method"].(string)
+	params, _ := message["params"].(map[string]any)
+	switch method {
+	case "DOM.getNodeForLocation":
+		response, err := s.domGetNodeForLocation(ctx, id, params)
+		return true, response, err
+	case "DOM.getNodesForSubtreeByStyle":
+		response, err := s.domGetNodesForSubtreeByStyle(ctx, id, params)
+		return true, response, err
+	case "DOMDebugger.getEventListeners":
+		response, err := s.domDebuggerGetEventListeners(ctx, id, params)
+		return true, response, err
+	case "Page.getResourceTree":
+		response, err := s.pageGetResourceTree(ctx, message)
+		return true, response, err
+	case "Page.startScreencast":
+		response, err := s.pageStartScreencast(ctx, id, params)
+		return true, response, err
+	case "Page.stopScreencast":
+		return true, s.pageStopScreencast(id), nil
+	case "Page.screencastFrameAck":
+		return true, s.pageScreencastFrameAck(id, params), nil
+	case "Input.emulateTouchFromMouseEvent":
+		response, err := s.inputEmulateTouchFromMouseEvent(ctx, id, params)
+		return true, response, err
+	case "Input.dispatchKeyEvent":
+		response, err := s.inputDispatchKeyEvent(ctx, id, params)
+		return true, response, err
+	default:
+		return false, nil, nil
+	}
+}
+
+func (s *cdpPageSession) domGetNodeForLocation(ctx context.Context, id int, params map[string]any) (map[string]any, error) {
+	x, _ := numericInt(params["x"])
+	y, _ := numericInt(params["y"])
+	remote, err := s.evaluate(ctx, id, fmt.Sprintf("document.elementFromPoint(%d,%d)", x, y), false)
+	if err != nil {
+		return nil, err
+	}
+	objectID := stringValue(remote["objectId"])
+	if objectID == "" {
+		return cdpResult(id, map[string]any{}), nil
+	}
+	node, err := s.objectIDToNodeID(ctx, id, objectID)
+	if err != nil {
+		return nil, err
+	}
+	return cdpResult(id, map[string]any{"nodeId": node}), nil
+}
+
+func (s *cdpPageSession) objectIDToNodeID(ctx context.Context, id int, objectID string) (int, error) {
+	response, err := s.sendInnerWait(ctx, map[string]any{
+		"id":     id,
+		"method": "DOM.requestNode",
+		"params": map[string]any{"objectId": objectID},
+	})
+	if err != nil {
+		return 0, err
+	}
+	result, _ := response["result"].(map[string]any)
+	nodeID, _ := numericInt(result["nodeId"])
+	return nodeID, nil
+}
+
+func (s *cdpPageSession) domGetNodesForSubtreeByStyle(ctx context.Context, id int, params map[string]any) (map[string]any, error) {
+	resolve, err := s.sendInnerWait(ctx, map[string]any{
+		"id":     id,
+		"method": "DOM.resolveNode",
+		"params": map[string]any{"nodeId": params["nodeId"]},
+	})
+	if err != nil {
+		return nil, err
+	}
+	resolveResult, _ := resolve["result"].(map[string]any)
+	object, _ := resolveResult["object"].(map[string]any)
+	objectID := stringValue(object["objectId"])
+	if objectID == "" {
+		return cdpResult(id, map[string]any{"nodeIds": []int{}}), nil
+	}
+	call, err := s.sendInnerWait(ctx, map[string]any{
+		"id":     id,
+		"method": "Runtime.callFunctionOn",
+		"params": map[string]any{
+			"objectId":            objectID,
+			"functionDeclaration": "function(styles) { const result = new Set(); var all = this.getElementsByTagName('*'); for (var elem_i = 0; elem_i < all.length; elem_i++) { for (var style_i in styles) { if (window.getComputedStyle(all[elem_i]).getPropertyValue(styles[style_i].name) === styles[style_i].value) { result.add(all[elem_i]); break; } } } return result; }",
+			"arguments":           []map[string]any{{"value": params["computedStyles"]}},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	callResult, _ := call["result"].(map[string]any)
+	remote, _ := callResult["result"].(map[string]any)
+	collectionID := stringValue(remote["objectId"])
+	if collectionID == "" {
+		return cdpResult(id, map[string]any{"nodeIds": []int{}}), nil
+	}
+	entries, err := s.sendInnerWait(ctx, map[string]any{
+		"id":     id,
+		"method": "Runtime.getCollectionEntries",
+		"params": map[string]any{"objectId": collectionID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	entriesResult, _ := entries["result"].(map[string]any)
+	rawEntries, _ := entriesResult["entries"].([]any)
+	nodeIDs := make([]int, 0, len(rawEntries))
+	for _, rawEntry := range rawEntries {
+		entry, _ := rawEntry.(map[string]any)
+		value, _ := entry["value"].(map[string]any)
+		nodeObjectID := stringValue(value["objectId"])
+		if nodeObjectID == "" {
+			continue
+		}
+		nodeID, err := s.objectIDToNodeID(ctx, id, nodeObjectID)
+		if err == nil && nodeID != 0 {
+			nodeIDs = append(nodeIDs, nodeID)
+		}
+	}
+	return cdpResult(id, map[string]any{"nodeIds": nodeIDs}), nil
+}
+
+func (s *cdpPageSession) domDebuggerGetEventListeners(ctx context.Context, id int, params map[string]any) (map[string]any, error) {
+	objectID := stringValue(params["objectId"])
+	nodeID, err := s.objectIDToNodeID(ctx, id, objectID)
+	if err != nil {
+		return nil, err
+	}
+	response, err := s.sendInnerWait(ctx, map[string]any{
+		"id":     id,
+		"method": "DOM.getEventListenersForNode",
+		"params": map[string]any{"nodeId": nodeID},
+	})
+	if err != nil {
+		return cdpResult(id, map[string]any{"listeners": []map[string]any{}}), nil
+	}
+	result, _ := response["result"].(map[string]any)
+	rawListeners, _ := result["listeners"].([]any)
+	listeners := make([]map[string]any, 0, len(rawListeners))
+	for _, rawListener := range rawListeners {
+		listener, _ := rawListener.(map[string]any)
+		out := map[string]any{
+			"type":       listener["type"],
+			"useCapture": listener["useCapture"],
+			"passive":    boolValue(listener["passive"]),
+			"once":       boolValue(listener["once"]),
+		}
+		if location, _ := listener["location"].(map[string]any); location != nil {
+			out["scriptId"] = location["scriptId"]
+			out["lineNumber"] = location["lineNumber"]
+			out["columnNumber"] = location["columnNumber"]
+		}
+		listeners = append(listeners, out)
+	}
+	return cdpResult(id, map[string]any{"listeners": listeners}), nil
+}
+
+func (s *cdpPageSession) pageGetResourceTree(ctx context.Context, message map[string]any) (map[string]any, error) {
+	response, err := s.sendInnerWait(ctx, message)
+	if err != nil {
+		return nil, err
+	}
+	result, _ := response["result"].(map[string]any)
+	frameTree, _ := result["frameTree"].(map[string]any)
+	s.frame, _ = frameTree["frame"].(map[string]any)
+	return response, nil
+}
+
+func (s *cdpPageSession) pageStartScreencast(ctx context.Context, id int, params map[string]any) (map[string]any, error) {
+	s.pageStopScreencast(id)
+	format := stringValue(params["format"])
+	if format == "" {
+		format = "jpeg"
+	}
+	quality, _ := numericInt(params["quality"])
+	maxWidth, _ := numericInt(params["maxWidth"])
+	maxHeight, _ := numericInt(params["maxHeight"])
+	if maxWidth == 0 {
+		maxWidth = 1024
+	}
+	if maxHeight == 0 {
+		maxHeight = 768
+	}
+	remote, err := s.evaluate(ctx, id, "(window.innerWidth > 0 ? window.innerWidth : screen.width) + ',' + (window.innerHeight > 0 ? window.innerHeight : screen.height) + ',' + window.devicePixelRatio", true)
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(stringValue(remote["value"]), ",")
+	cast := &cdpScreencast{format: format, quality: quality, maxWidth: maxWidth, maxHeight: maxHeight, frameID: 1, lastAck: 0, scale: 1}
+	if len(parts) == 3 {
+		cast.deviceW = atoi(parts[0])
+		cast.deviceH = atoi(parts[1])
+		cast.scale = float64(atoi(parts[2]))
+		if cast.scale == 0 {
+			cast.scale = 1
+		}
+	}
+	castCtx, cancel := context.WithCancel(ctx)
+	cast.cancelFunc = cancel
+	s.screencast = cast
+	go s.screencastLoop(castCtx, id, cast)
+	return cdpResult(id, map[string]any{}), nil
+}
+
+func (s *cdpPageSession) pageStopScreencast(id int) map[string]any {
+	if s.screencast != nil && s.screencast.cancelFunc != nil {
+		s.screencast.cancelFunc()
+	}
+	s.screencast = nil
+	return cdpResult(id, map[string]any{})
+}
+
+func (s *cdpPageSession) pageScreencastFrameAck(id int, params map[string]any) map[string]any {
+	if s.screencast != nil {
+		ack, _ := numericInt(params["sessionId"])
+		s.screencast.lastAck = ack
+	}
+	return cdpResult(id, map[string]any{})
+}
+
+func (s *cdpPageSession) screencastLoop(ctx context.Context, id int, cast *cdpScreencast) {
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		if cast.frameID > 1 && cast.lastAck < cast.frameID-1 {
+			continue
+		}
+		offsetTop, scrollX, scrollY := s.screencastOffsets(ctx, id)
+		response, err := s.sendInnerWait(ctx, map[string]any{
+			"id":     id,
+			"method": "Page.snapshotRect",
+			"params": map[string]any{
+				"x":                0,
+				"y":                0,
+				"width":            cast.deviceW,
+				"height":           cast.deviceH,
+				"coordinateSystem": "Viewport",
+			},
+		})
+		if err != nil {
+			continue
+		}
+		result, _ := response["result"].(map[string]any)
+		dataURL := stringValue(result["dataURL"])
+		data := dataURL
+		if _, encoded, ok := strings.Cut(dataURL, "base64,"); ok {
+			data = encoded
+		}
+		frameID := cast.frameID
+		cast.frameID++
+		_ = s.writeJSON(map[string]any{
+			"method": "Page.screencastFrame",
+			"params": map[string]any{
+				"data":      data,
+				"sessionId": frameID,
+				"metadata": map[string]any{
+					"pageScaleFactor": cast.scale,
+					"offsetTop":       offsetTop,
+					"deviceWidth":     scaledDimension(cast.deviceW, cast.scale, cast.maxWidth),
+					"deviceHeight":    scaledDimension(cast.deviceH, cast.scale, cast.maxHeight),
+					"scrollOffsetX":   scrollX,
+					"scrollOffsetY":   scrollY,
+					"timestamp":       float64(time.Now().UnixMilli()) / 1000,
+				},
+			},
+		})
+	}
+}
+
+func (s *cdpPageSession) screencastOffsets(ctx context.Context, id int) (int, int, int) {
+	remote, err := s.evaluate(ctx, id, "window.document.body.offsetTop + ',' + window.pageXOffset + ',' + window.pageYOffset", true)
+	if err != nil {
+		return 0, 0, 0
+	}
+	parts := strings.Split(stringValue(remote["value"]), ",")
+	if len(parts) != 3 {
+		return 0, 0, 0
+	}
+	return atoi(parts[0]), atoi(parts[1]), atoi(parts[2])
+}
+
+func (s *cdpPageSession) inputEmulateTouchFromMouseEvent(ctx context.Context, id int, params map[string]any) (map[string]any, error) {
+	eventType := stringValue(params["type"])
+	scale := 1.0
+	if s.screencast != nil && s.screencast.scale > 0 {
+		scale = s.screencast.scale
+	}
+	x := int(float64(intValue(params["x"])) / scale)
+	y := int(float64(intValue(params["y"])) / scale)
+	switch eventType {
+	case "mouseWheel":
+		deltaX := int(float64(intValue(params["deltaX"])) / scale)
+		deltaY := int(float64(intValue(params["deltaY"])) / scale)
+		_, err := s.evaluate(ctx, id, fmt.Sprintf("window.scrollBy(%d, %d)", -deltaX, -deltaY), true)
+		return cdpResult(id, map[string]any{}), err
+	case "mouseReleased":
+		return cdpResult(id, map[string]any{}), nil
+	default:
+		modifiers, _ := numericInt(params["modifiers"])
+		button := stringValue(params["button"])
+		domType := map[string]string{"mousePressed": "click", "mouseMoved": "mousemove"}[eventType]
+		if domType == "" {
+			domType = "click"
+		}
+		eventParams := map[string]any{
+			"screenX":    x,
+			"screenY":    y,
+			"clientX":    x,
+			"clientY":    y,
+			"altKey":     modifiers&1 != 0,
+			"ctrlKey":    modifiers&2 != 0,
+			"metaKey":    modifiers&4 != 0,
+			"shiftKey":   modifiers&8 != 0,
+			"button":     button,
+			"bubbles":    true,
+			"cancelable": false,
+		}
+		eventJSON := mustJSON(eventParams)
+		script := fmt.Sprintf(`(function(type){ const element = document.elementFromPoint(%d, %d); if (!element) return false; const e = new MouseEvent(type, %s); element.dispatchEvent(e); if (element.focus) element.focus(); return true; })(%s)`, x, y, eventJSON, quoteJS(domType))
+		if _, err := s.evaluate(ctx, id, script, true); err != nil {
+			return nil, err
+		}
+		if domType == "click" {
+			_, _ = s.evaluate(ctx, id, fmt.Sprintf(`(function(){ const element = document.elementFromPoint(%d, %d); if (!element) return false; element.dispatchEvent(new MouseEvent("mouseup", %s)); return true; })()`, x, y, eventJSON), true)
+		}
+		return cdpResult(id, map[string]any{}), nil
+	}
+}
+
+func (s *cdpPageSession) inputDispatchKeyEvent(ctx context.Context, id int, params map[string]any) (map[string]any, error) {
+	keyType := stringValue(params["type"])
+	key := stringValue(params["key"])
+	text := stringValue(params["text"])
+	var manipulation string
+	switch {
+	case keyType == "keyUp" && key == "Backspace":
+		manipulation = "document.activeElement.value = document.activeElement.value.slice(0, -1);"
+	case keyType == "char" && key == "Enter":
+		manipulation = `var tagName = document.activeElement.tagName.toLowerCase(); if (tagName === "textarea" || document.activeElement.isContentEditable) { document.activeElement.value = document.activeElement.value + "\n"; } else { const result = document.evaluate("./ancestor-or-self::form", document.activeElement, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null); if (result.singleNodeValue) { const e = result.singleNodeValue.ownerDocument.createEvent("Event"); e.initEvent("submit", true, true); if (result.singleNodeValue.dispatchEvent(e)) { result.singleNodeValue.submit(); } } }`
+	case keyType == "char":
+		manipulation = "document.activeElement.value = document.activeElement.value + " + quoteJS(text) + ";"
+	default:
+		return cdpResult(id, map[string]any{}), nil
+	}
+	script := "function isEditable(element) { if (!element || element.disabled || element.readOnly) return false; var tagName = element.tagName.toLowerCase(); if (tagName === 'textarea' || element.isContentEditable) return true; if (tagName !== 'input') return false; switch (element.type) { case 'color': case 'date': case 'datetime-local': case 'email': case 'file': case 'month': case 'number': case 'password': case 'range': case 'search': case 'tel': case 'text': case 'time': case 'url': case 'week': return true; } return false; } if (isEditable(document.activeElement)) { " + manipulation + " }"
+	_, err := s.evaluate(ctx, id, script, true)
+	return cdpResult(id, map[string]any{}), err
+}
+
+func (s *cdpPageSession) normalizeCDPEvent(message map[string]any) (map[string]any, bool) {
+	method, _ := message["method"].(string)
+	if method == "Runtime.executionContextCreated" {
+		params, _ := message["params"].(map[string]any)
+		contextMap, _ := params["context"].(map[string]any)
+		if stringValue(contextMap["type"]) == "normal" {
+			s.defaultExecutionID = contextMap["id"]
+		}
+	}
+	if method == "Target.targetCreated" {
+		params, _ := message["params"].(map[string]any)
+		targetInfo, _ := params["targetInfo"].(map[string]any)
+		s.targetID = stringValue(targetInfo["targetId"])
+		if s.page.URL != "" {
+			targetInfo["url"] = s.page.URL
+		}
+		if s.page.Title != "" {
+			targetInfo["title"] = s.page.Title
+		}
+	}
+	if method == "Target.targetDestroyed" {
+		if s.frame != nil {
+			_ = s.writeJSON(map[string]any{"method": "Page.frameNavigated", "params": map[string]any{"frame": s.frame}})
+			_ = s.writeJSON(map[string]any{"method": "Page.loadEventFired", "params": map[string]any{"timestamp": float64(time.Now().UnixMilli()) / 1000}})
+		}
+		return map[string]any{"method": "DOM.documentUpdated"}, false
+	}
+	return normalizeCDPEvent(message)
 }
 
 func localCDPResponse(message map[string]any, targetID string, sessionID string, page Page) (bool, map[string]any, []map[string]any) {
@@ -525,6 +1056,41 @@ func validNetworkResourceType(resourceType string) bool {
 	default:
 		return false
 	}
+}
+
+func cdpResult(id int, result map[string]any) map[string]any {
+	if result == nil {
+		result = map[string]any{}
+	}
+	return map[string]any{"id": id, "result": result}
+}
+
+func quoteJS(value string) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return `""`
+	}
+	return string(encoded)
+}
+
+func atoi(value string) int {
+	var out int
+	_, _ = fmt.Sscanf(strings.TrimSpace(value), "%d", &out)
+	return out
+}
+
+func scaledDimension(value int, scale float64, maxValue int) int {
+	if value <= 0 {
+		return 0
+	}
+	scaled := int(float64(value) * scale)
+	if maxValue > 0 && scaled > maxValue {
+		return maxValue
+	}
+	if scaled <= 0 {
+		return value
+	}
+	return scaled
 }
 
 func debuggerPausedReason(reason string) string {

--- a/ios/webinspector/cdp.go
+++ b/ios/webinspector/cdp.go
@@ -402,6 +402,17 @@ func (s *cdpPageSession) handleSpecialCommand(ctx context.Context, message map[s
 	case "DOMDebugger.getEventListeners":
 		response, err := s.domDebuggerGetEventListeners(ctx, id, params)
 		return true, response, err
+	case "Debugger.setBlackboxPatterns":
+		response, err := s.debuggerSetBlackboxPatterns(ctx, id, params)
+		return true, response, err
+	case "Runtime.compileScript":
+		response, err := s.runtimeCompileScript(ctx, id, params)
+		return true, response, err
+	case "Runtime.getIsolateId":
+		return true, s.runtimeGetIsolateID(id), nil
+	case "Page.getNavigationHistory":
+		response, err := s.pageGetNavigationHistory(ctx, id)
+		return true, response, err
 	case "Page.getResourceTree":
 		response, err := s.pageGetResourceTree(ctx, message)
 		return true, response, err
@@ -547,6 +558,90 @@ func (s *cdpPageSession) domDebuggerGetEventListeners(ctx context.Context, id in
 		listeners = append(listeners, out)
 	}
 	return cdpResult(id, map[string]any{"listeners": listeners}), nil
+}
+
+func (s *cdpPageSession) debuggerSetBlackboxPatterns(ctx context.Context, id int, params map[string]any) (map[string]any, error) {
+	patterns, _ := params["patterns"].([]any)
+	for _, rawPattern := range patterns {
+		pattern := stringValue(rawPattern)
+		if pattern == "" {
+			continue
+		}
+		_, err := s.sendInnerWait(ctx, map[string]any{
+			"id":     id,
+			"method": "Debugger.setShouldBlackboxURL",
+			"params": map[string]any{"url": pattern, "shouldBlackbox": true},
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return cdpResult(id, map[string]any{}), nil
+}
+
+func (s *cdpPageSession) runtimeCompileScript(ctx context.Context, id int, params map[string]any) (map[string]any, error) {
+	expression := stringValue(params["expression"])
+	response, err := s.sendInnerWait(ctx, map[string]any{
+		"id":     id,
+		"method": "Runtime.parse",
+		"params": map[string]any{"source": expression},
+	})
+	if err != nil {
+		return nil, err
+	}
+	result, _ := response["result"].(map[string]any)
+	if result["result"] == "none" {
+		return cdpResult(id, map[string]any{"result": nil}), nil
+	}
+	parseRange, _ := result["range"].(map[string]any)
+	endOffset, _ := numericInt(parseRange["endOffset"])
+	if endOffset < 0 || endOffset > len(expression) {
+		endOffset = len(expression)
+	}
+	lines := strings.Split(expression[:endOffset], "\n")
+	lineNumber := len(lines) - 1
+	columnNumber := 0
+	if len(lines) > 0 {
+		columnNumber = len(lines[len(lines)-1]) - 1
+		if columnNumber < 0 {
+			columnNumber = 0
+		}
+	}
+	return cdpResult(id, map[string]any{
+		"exceptionDetails": map[string]any{
+			"exceptionId":  1,
+			"text":         result["message"],
+			"lineNumber":   lineNumber,
+			"columnNumber": columnNumber,
+		},
+	}), nil
+}
+
+func (s *cdpPageSession) runtimeGetIsolateID(id int) map[string]any {
+	executionID := s.defaultExecutionID
+	if executionID == nil {
+		executionID = 0
+	}
+	return cdpResult(id, map[string]any{"id": executionID})
+}
+
+func (s *cdpPageSession) pageGetNavigationHistory(ctx context.Context, id int) (map[string]any, error) {
+	href, err := s.evaluate(ctx, id, "window.location.href", true)
+	if err != nil {
+		return nil, err
+	}
+	title, err := s.evaluate(ctx, id, "document.title", true)
+	if err != nil {
+		return nil, err
+	}
+	return cdpResult(id, map[string]any{
+		"currentIndex": 0,
+		"entries": []map[string]any{{
+			"id":    0,
+			"url":   href["value"],
+			"title": title["value"],
+		}},
+	}), nil
 }
 
 func (s *cdpPageSession) pageGetResourceTree(ctx context.Context, message map[string]any) (map[string]any, error) {
@@ -803,12 +898,10 @@ func localCDPResponse(message map[string]any, targetID string, sessionID string,
 		"DOM.enable",
 		"DOMDebugger.setBreakOnCSPViolation",
 		"Debugger.setAsyncCallStackDepth",
-		"Debugger.setBlackboxPatterns",
 		"Emulation.setTouchEmulationEnabled",
 		"Emulation.setFocusEmulationEnabled",
 		"Emulation.setEmulatedVisionDeficiency",
 		"Emulation.setEmitTouchEventsForMouse",
-		"Emulation.setAutoDarkModeOverride",
 		"HeapProfiler.enable",
 		"Input.dispatchKeyEvent",
 		"Input.emulateTouchFromMouseEvent",
@@ -836,11 +929,6 @@ func localCDPResponse(message map[string]any, targetID string, sessionID string,
 		result["nodeIds"] = []int{}
 	case "Network.loadNetworkResource":
 		result["resource"] = map[string]any{"success": true}
-	case "Runtime.getIsolateId":
-		result["id"] = 0
-	case "Page.getNavigationHistory":
-		result["currentIndex"] = 0
-		result["entries"] = []map[string]any{{"id": 0, "url": page.URL, "title": page.Title}}
 	default:
 		return false, nil, nil
 	}
@@ -902,11 +990,6 @@ func translateCDPCommand(message map[string]any) map[string]any {
 				params["options"] = options
 				delete(params, "condition")
 			}
-		}
-	case "Runtime.compileScript":
-		message["method"] = "Runtime.parse"
-		if params != nil {
-			message["params"] = map[string]any{"source": params["expression"]}
 		}
 	}
 	return message

--- a/ios/webinspector/cdp_test.go
+++ b/ios/webinspector/cdp_test.go
@@ -44,6 +44,37 @@ func TestTranslateCDPCommand(t *testing.T) {
 	}
 }
 
+func TestTranslateDebuggerBreakpointCondition(t *testing.T) {
+	message := translateCDPCommand(map[string]any{
+		"id":     2,
+		"method": "Debugger.setBreakpointByUrl",
+		"params": map[string]any{"condition": "x > 1"},
+	})
+	params := message["params"].(map[string]any)
+	options := params["options"].(map[string]any)
+	if options["condition"] != "x > 1" {
+		t.Fatalf("unexpected options: %#v", options)
+	}
+	if _, ok := params["condition"]; ok {
+		t.Fatalf("condition should be moved into options: %#v", params)
+	}
+}
+
+func TestTranslateRuntimeCompileScript(t *testing.T) {
+	message := translateCDPCommand(map[string]any{
+		"id":     3,
+		"method": "Runtime.compileScript",
+		"params": map[string]any{"expression": "let x = 1"},
+	})
+	if message["method"] != "Runtime.parse" {
+		t.Fatalf("unexpected method: %#v", message["method"])
+	}
+	params := message["params"].(map[string]any)
+	if params["source"] != "let x = 1" {
+		t.Fatalf("unexpected params: %#v", params)
+	}
+}
+
 func TestNormalizeConsoleEvent(t *testing.T) {
 	normalized, drop := normalizeCDPEvent(map[string]any{
 		"method": "Console.messageAdded",
@@ -60,5 +91,26 @@ func TestNormalizeConsoleEvent(t *testing.T) {
 	}
 	if normalized["method"] != "Log.entryAdded" {
 		t.Fatalf("unexpected normalized method: %#v", normalized)
+	}
+}
+
+func TestNormalizeDebuggerPaused(t *testing.T) {
+	normalized, drop := normalizeCDPEvent(map[string]any{
+		"method": "Debugger.paused",
+		"params": map[string]any{
+			"reason": "Listener",
+			"data":   map[string]any{"breakpointId": "bp-1"},
+		},
+	})
+	if drop {
+		t.Fatal("expected debugger paused event to be emitted")
+	}
+	params := normalized["params"].(map[string]any)
+	if params["reason"] != "EventListener" {
+		t.Fatalf("unexpected reason: %#v", params["reason"])
+	}
+	breakpoints := params["hitBreakpoints"].([]string)
+	if breakpoints[0] != "bp-1" {
+		t.Fatalf("unexpected hit breakpoints: %#v", breakpoints)
 	}
 }

--- a/ios/webinspector/cdp_test.go
+++ b/ios/webinspector/cdp_test.go
@@ -3,7 +3,7 @@ package webinspector
 import "testing"
 
 func TestLocalCDPResponse(t *testing.T) {
-	handled, response, extra := localCDPResponse(map[string]any{"id": 4, "method": "Runtime.getIsolateId"}, "target-1", "session-1")
+	handled, response, extra := localCDPResponse(map[string]any{"id": 4, "method": "Runtime.getIsolateId"}, "target-1", "session-1", Page{})
 	if !handled {
 		t.Fatal("expected Runtime.getIsolateId to be handled locally")
 	}
@@ -13,6 +13,19 @@ func TestLocalCDPResponse(t *testing.T) {
 	}
 	if len(extra) != 0 {
 		t.Fatalf("unexpected extra events: %#v", extra)
+	}
+}
+
+func TestLocalCDPNavigationHistoryUsesPageMetadata(t *testing.T) {
+	page := Page{URL: "https://example.test/", Title: "Example"}
+	handled, response, _ := localCDPResponse(map[string]any{"id": 5, "method": "Page.getNavigationHistory"}, "target-1", "session-1", page)
+	if !handled {
+		t.Fatal("expected Page.getNavigationHistory to be handled locally")
+	}
+	result := response["result"].(map[string]any)
+	entries := result["entries"].([]map[string]any)
+	if entries[0]["url"] != page.URL || entries[0]["title"] != page.Title {
+		t.Fatalf("unexpected navigation entry: %#v", entries[0])
 	}
 }
 

--- a/ios/webinspector/cdp_test.go
+++ b/ios/webinspector/cdp_test.go
@@ -1,0 +1,51 @@
+package webinspector
+
+import "testing"
+
+func TestLocalCDPResponse(t *testing.T) {
+	handled, response, extra := localCDPResponse(map[string]any{"id": 4, "method": "Runtime.getIsolateId"}, "target-1", "session-1")
+	if !handled {
+		t.Fatal("expected Runtime.getIsolateId to be handled locally")
+	}
+	result := response["result"].(map[string]any)
+	if result["id"] != 0 {
+		t.Fatalf("unexpected isolate id result: %#v", response)
+	}
+	if len(extra) != 0 {
+		t.Fatalf("unexpected extra events: %#v", extra)
+	}
+}
+
+func TestTranslateCDPCommand(t *testing.T) {
+	message := translateCDPCommand(map[string]any{
+		"id":     1,
+		"method": "Network.setCacheDisabled",
+		"params": map[string]any{"cacheDisabled": true},
+	})
+	if message["method"] != "Network.setResourceCachingDisabled" {
+		t.Fatalf("unexpected method: %#v", message["method"])
+	}
+	params := message["params"].(map[string]any)
+	if params["disabled"] != true {
+		t.Fatalf("unexpected params: %#v", params)
+	}
+}
+
+func TestNormalizeConsoleEvent(t *testing.T) {
+	normalized, drop := normalizeCDPEvent(map[string]any{
+		"method": "Console.messageAdded",
+		"params": map[string]any{
+			"message": map[string]any{
+				"source": "console-api",
+				"level":  "debug",
+				"text":   "hello",
+			},
+		},
+	})
+	if drop {
+		t.Fatal("expected console event to be emitted")
+	}
+	if normalized["method"] != "Log.entryAdded" {
+		t.Fatalf("unexpected normalized method: %#v", normalized)
+	}
+}

--- a/ios/webinspector/cdp_test.go
+++ b/ios/webinspector/cdp_test.go
@@ -3,29 +3,33 @@ package webinspector
 import "testing"
 
 func TestLocalCDPResponse(t *testing.T) {
-	handled, response, extra := localCDPResponse(map[string]any{"id": 4, "method": "Runtime.getIsolateId"}, "target-1", "session-1", Page{})
+	handled, response, extra := localCDPResponse(map[string]any{"id": 4, "method": "CSS.takeComputedStyleUpdates"}, "target-1", "session-1", Page{})
 	if !handled {
-		t.Fatal("expected Runtime.getIsolateId to be handled locally")
+		t.Fatal("expected CSS.takeComputedStyleUpdates to be handled locally")
 	}
 	result := response["result"].(map[string]any)
-	if result["id"] != 0 {
-		t.Fatalf("unexpected isolate id result: %#v", response)
+	nodeIDs := result["nodeIds"].([]int)
+	if len(nodeIDs) != 0 {
+		t.Fatalf("unexpected node id result: %#v", response)
 	}
 	if len(extra) != 0 {
 		t.Fatalf("unexpected extra events: %#v", extra)
 	}
 }
 
-func TestLocalCDPNavigationHistoryUsesPageMetadata(t *testing.T) {
-	page := Page{URL: "https://example.test/", Title: "Example"}
-	handled, response, _ := localCDPResponse(map[string]any{"id": 5, "method": "Page.getNavigationHistory"}, "target-1", "session-1", page)
-	if !handled {
-		t.Fatal("expected Page.getNavigationHistory to be handled locally")
+func TestLocalCDPResponseDoesNotSwallowStatefulCommands(t *testing.T) {
+	statefulMethods := []string{
+		"Debugger.setBlackboxPatterns",
+		"Emulation.setAutoDarkModeOverride",
+		"Page.getNavigationHistory",
+		"Runtime.compileScript",
+		"Runtime.getIsolateId",
 	}
-	result := response["result"].(map[string]any)
-	entries := result["entries"].([]map[string]any)
-	if entries[0]["url"] != page.URL || entries[0]["title"] != page.Title {
-		t.Fatalf("unexpected navigation entry: %#v", entries[0])
+	for _, method := range statefulMethods {
+		handled, _, _ := localCDPResponse(map[string]any{"id": 5, "method": method}, "target-1", "session-1", Page{})
+		if handled {
+			t.Fatalf("%s should be routed through the stateful CDP session", method)
+		}
 	}
 }
 
@@ -60,18 +64,27 @@ func TestTranslateDebuggerBreakpointCondition(t *testing.T) {
 	}
 }
 
-func TestTranslateRuntimeCompileScript(t *testing.T) {
+func TestTranslateEmulationAutoDarkMode(t *testing.T) {
 	message := translateCDPCommand(map[string]any{
 		"id":     3,
-		"method": "Runtime.compileScript",
-		"params": map[string]any{"expression": "let x = 1"},
+		"method": "Emulation.setAutoDarkModeOverride",
+		"params": map[string]any{"enabled": true},
 	})
-	if message["method"] != "Runtime.parse" {
+	if message["method"] != "Page.setForcedAppearance" {
 		t.Fatalf("unexpected method: %#v", message["method"])
 	}
 	params := message["params"].(map[string]any)
-	if params["source"] != "let x = 1" {
+	if params["appearance"] != "Dark" {
 		t.Fatalf("unexpected params: %#v", params)
+	}
+}
+
+func TestRuntimeGetIsolateIDUsesDefaultExecutionContext(t *testing.T) {
+	session := &cdpPageSession{defaultExecutionID: 42}
+	response := session.runtimeGetIsolateID(7)
+	result := response["result"].(map[string]any)
+	if result["id"] != 42 {
+		t.Fatalf("unexpected isolate id result: %#v", response)
 	}
 }
 

--- a/ios/webinspector/webinspector.go
+++ b/ios/webinspector/webinspector.go
@@ -1,0 +1,631 @@
+package webinspector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/golog"
+	"github.com/google/uuid"
+)
+
+const logModule = "go-ios/webinspector"
+
+const (
+	ServiceName    = "com.apple.webinspector"
+	ShimService    = "com.apple.webinspector.shim.remote"
+	SafariBundleID = "com.apple.mobilesafari"
+)
+
+type WIRType string
+
+const (
+	WIRTypeAutomation WIRType = "WIRTypeAutomation"
+	WIRTypeJavaScript WIRType = "WIRTypeJavaScript"
+	WIRTypeWeb        WIRType = "WIRTypeWeb"
+	WIRTypeWebPage    WIRType = "WIRTypeWebPage"
+)
+
+type Application struct {
+	ID           string `json:"id"`
+	BundleID     string `json:"bundleId"`
+	PID          int    `json:"pid"`
+	Name         string `json:"name"`
+	Availability string `json:"automationAvailability"`
+	Active       bool   `json:"active"`
+	Proxy        bool   `json:"proxy"`
+	Ready        bool   `json:"ready"`
+	Host         string `json:"host,omitempty"`
+}
+
+type Page struct {
+	ID                     int     `json:"id"`
+	Key                    string  `json:"key"`
+	Type                   WIRType `json:"type"`
+	URL                    string  `json:"url,omitempty"`
+	Title                  string  `json:"title,omitempty"`
+	AutomationIsPaired     bool    `json:"automationIsPaired,omitempty"`
+	AutomationName         string  `json:"automationName,omitempty"`
+	AutomationVersion      string  `json:"automationVersion,omitempty"`
+	AutomationSessionID    string  `json:"automationSessionId,omitempty"`
+	AutomationConnectionID string  `json:"automationConnectionId,omitempty"`
+}
+
+type ApplicationPage struct {
+	Application Application `json:"application"`
+	Page        Page        `json:"page"`
+}
+
+type Client struct {
+	device ios.DeviceEntry
+	conn   ios.DeviceConnectionInterface
+	plist  ios.PlistCodecReadWriter
+
+	connectionID string
+	writeMu      sync.Mutex
+	stateMu      sync.Mutex
+	state        string
+	apps         map[string]Application
+	pages        map[string]map[string]Page
+
+	resultMu sync.Mutex
+	results  map[int]chan map[string]any
+	events   chan map[string]any
+
+	done chan struct{}
+	errs chan error
+}
+
+func New(device ios.DeviceEntry) (*Client, error) {
+	var (
+		conn ios.DeviceConnectionInterface
+		err  error
+	)
+	if device.SupportsRsd() {
+		conn, err = ios.ConnectToShimService(device, ShimService)
+	} else {
+		conn, err = ios.ConnectToService(device, ServiceName)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return NewWithConnection(device, conn), nil
+}
+
+func NewWithConnection(device ios.DeviceEntry, conn ios.DeviceConnectionInterface) *Client {
+	return &Client{
+		device:       device,
+		conn:         conn,
+		plist:        ios.NewPlistCodecReadWriter(conn.Reader(), conn.Writer()),
+		connectionID: strings.ToUpper(uuid.New().String()),
+		apps:         make(map[string]Application),
+		pages:        make(map[string]map[string]Page),
+		results:      make(map[int]chan map[string]any),
+		events:       make(chan map[string]any, 256),
+		done:         make(chan struct{}),
+		errs:         make(chan error, 1),
+	}
+}
+
+func (c *Client) Connect(ctx context.Context) error {
+	if err := c.sendMessage("_rpc_reportIdentifier:", nil); err != nil {
+		return err
+	}
+	go c.readLoop()
+	return c.GetConnectedApplications(ctx)
+}
+
+func (c *Client) Close() error {
+	select {
+	case <-c.done:
+	default:
+		close(c.done)
+	}
+	if c.conn == nil {
+		return nil
+	}
+	return c.conn.Close()
+}
+
+func (c *Client) State() string {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return c.state
+}
+
+func (c *Client) GetConnectedApplications(ctx context.Context) error {
+	if err := c.sendMessage("_rpc_getConnectedApplications:", map[string]any{}); err != nil {
+		return err
+	}
+	return c.waitFor(ctx, func() bool {
+		c.stateMu.Lock()
+		defer c.stateMu.Unlock()
+		return len(c.apps) > 0 || c.state != ""
+	})
+}
+
+func (c *Client) OpenApp(ctx context.Context, bundleID string) (Application, error) {
+	if err := c.sendMessage("_rpc_requestApplicationLaunch:", map[string]any{
+		"WIRApplicationBundleIdentifierKey": bundleID,
+	}); err != nil {
+		return Application{}, err
+	}
+	var app Application
+	err := c.waitFor(ctx, func() bool {
+		c.stateMu.Lock()
+		defer c.stateMu.Unlock()
+		for _, candidate := range c.apps {
+			if candidate.BundleID == bundleID {
+				app = candidate
+				return true
+			}
+		}
+		return false
+	})
+	return app, err
+}
+
+func (c *Client) ListPages(ctx context.Context, wait time.Duration) ([]ApplicationPage, error) {
+	if err := c.GetConnectedApplications(ctx); err != nil {
+		return nil, err
+	}
+	if wait > 0 {
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+
+	var out []ApplicationPage
+	for appID, appPages := range c.pages {
+		app, ok := c.apps[appID]
+		if !ok {
+			continue
+		}
+		for _, page := range appPages {
+			out = append(out, ApplicationPage{Application: app, Page: page})
+		}
+	}
+	return out, nil
+}
+
+func (c *Client) FindPage(pageKey string) (Application, Page, bool) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	for appID, appPages := range c.pages {
+		page, ok := appPages[pageKey]
+		if !ok {
+			continue
+		}
+		app, ok := c.apps[appID]
+		return app, page, ok
+	}
+	return Application{}, Page{}, false
+}
+
+func (c *Client) SetupInspectorSocket(sessionID string, app Application, page Page, pause bool) error {
+	message := map[string]any{
+		"WIRApplicationIdentifierKey":         app.ID,
+		"WIRPageIdentifierKey":                page.ID,
+		"WIRSenderKey":                        sessionID,
+		"WIRMessageDataTypeChunkSupportedKey": 0,
+	}
+	if !pause {
+		message["WIRAutomaticallyPause"] = false
+	}
+	return c.sendMessage("_rpc_forwardSocketSetup:", message)
+}
+
+func (c *Client) SendSocketData(sessionID string, app Application, page Page, data map[string]any) error {
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return c.sendMessage("_rpc_forwardSocketData:", map[string]any{
+		"WIRApplicationIdentifierKey": app.ID,
+		"WIRPageIdentifierKey":        page.ID,
+		"WIRSessionIdentifierKey":     sessionID,
+		"WIRSenderKey":                sessionID,
+		"WIRSocketDataKey":            encoded,
+	})
+}
+
+func (c *Client) SendCommand(ctx context.Context, sessionID string, app Application, page Page, id int, method string, params map[string]any) (map[string]any, error) {
+	result := make(chan map[string]any, 1)
+	c.resultMu.Lock()
+	c.results[id] = result
+	c.resultMu.Unlock()
+	defer func() {
+		c.resultMu.Lock()
+		delete(c.results, id)
+		c.resultMu.Unlock()
+	}()
+
+	if err := c.SendSocketData(sessionID, app, page, map[string]any{
+		"method": method,
+		"params": params,
+		"id":     id,
+	}); err != nil {
+		return nil, err
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case response := <-result:
+		if errValue, ok := response["error"]; ok {
+			return response, fmt.Errorf("webinspector command error: %v", errValue)
+		}
+		return response, nil
+	}
+}
+
+func (c *Client) Evaluate(ctx context.Context, app Application, page Page, expression string) (any, error) {
+	sessionID := strings.ToUpper(uuid.New().String())
+	if err := c.SetupInspectorSocket(sessionID, app, page, false); err != nil {
+		return nil, err
+	}
+
+	var targetID string
+	for targetID == "" {
+		event, err := c.NextEvent(ctx)
+		if err != nil {
+			return nil, err
+		}
+		params, _ := event["params"].(map[string]any)
+		targetInfo, _ := params["targetInfo"].(map[string]any)
+		targetID, _ = targetInfo["targetId"].(string)
+	}
+
+	inner := map[string]any{
+		"id":     1,
+		"method": "Runtime.evaluate",
+		"params": map[string]any{
+			"expression":                  expression,
+			"objectGroup":                 "console",
+			"includeCommandLineAPI":       true,
+			"returnByValue":               true,
+			"generatePreview":             true,
+			"userGesture":                 true,
+			"awaitPromise":                false,
+			"replMode":                    true,
+			"allowUnsafeEvalBlockedByCSP": false,
+		},
+	}
+	if _, err := c.SendCommand(ctx, sessionID, app, page, int(time.Now().UnixNano()&0x7fffffff), "Target.sendMessageToTarget", map[string]any{
+		"targetId": targetID,
+		"message":  mustMarshalString(inner),
+	}); err != nil {
+		return nil, err
+	}
+
+	for {
+		event, err := c.NextEvent(ctx)
+		if err != nil {
+			return nil, err
+		}
+		message, ok := decodeDispatchMessage(event)
+		if !ok {
+			continue
+		}
+		id, _ := numericInt(message["id"])
+		if id != 1 {
+			continue
+		}
+		return parseEvaluateResult(message)
+	}
+}
+
+func (c *Client) NextEvent(ctx context.Context) (map[string]any, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case err := <-c.errs:
+		return nil, err
+	case event := <-c.events:
+		return event, nil
+	}
+}
+
+func (c *Client) readLoop() {
+	for {
+		select {
+		case <-c.done:
+			return
+		default:
+		}
+		var message map[string]any
+		if err := c.plist.Read(&message); err != nil {
+			if !errors.Is(err, io.EOF) {
+				golog.Error("webinspector read failed", "module", logModule, "udid", c.device.Properties.SerialNumber, "error", err)
+			}
+			select {
+			case c.errs <- err:
+			default:
+			}
+			return
+		}
+		if err := c.handleMessage(message); err != nil {
+			golog.Warn("webinspector message ignored", "module", logModule, "udid", c.device.Properties.SerialNumber, "error", err, "message", fmt.Sprintf("%#v", message))
+		}
+	}
+}
+
+func (c *Client) handleMessage(message map[string]any) error {
+	selector, _ := message["__selector"].(string)
+	arg, _ := message["__argument"].(map[string]any)
+	switch selector {
+	case "_rpc_reportCurrentState:":
+		c.stateMu.Lock()
+		c.state, _ = arg["WIRAutomationAvailabilityKey"].(string)
+		c.stateMu.Unlock()
+	case "_rpc_reportConnectedApplicationList:":
+		appDict, _ := arg["WIRApplicationDictionaryKey"].(map[string]any)
+		c.stateMu.Lock()
+		c.apps = make(map[string]Application)
+		for key, rawApp := range appDict {
+			app, err := parseApplication(rawApp)
+			if err != nil {
+				c.stateMu.Unlock()
+				return err
+			}
+			c.apps[key] = app
+			go func(appID string) {
+				if err := c.forwardGetListing(appID); err != nil {
+					golog.Warn("webinspector listing request failed", "module", logModule, "udid", c.device.Properties.SerialNumber, "appID", appID, "error", err)
+				}
+			}(app.ID)
+		}
+		c.stateMu.Unlock()
+	case "_rpc_applicationConnected:", "_rpc_applicationUpdated:":
+		app, err := parseApplication(arg)
+		if err != nil {
+			return err
+		}
+		c.stateMu.Lock()
+		c.apps[app.ID] = app
+		c.stateMu.Unlock()
+		if err := c.forwardGetListing(app.ID); err != nil {
+			return err
+		}
+	case "_rpc_applicationDisconnected:":
+		appID, _ := arg["WIRApplicationIdentifierKey"].(string)
+		c.stateMu.Lock()
+		delete(c.apps, appID)
+		delete(c.pages, appID)
+		c.stateMu.Unlock()
+	case "_rpc_applicationSentListing:":
+		appID, _ := arg["WIRApplicationIdentifierKey"].(string)
+		listing, _ := arg["WIRListingKey"].(map[string]any)
+		c.stateMu.Lock()
+		if c.pages[appID] == nil {
+			c.pages[appID] = make(map[string]Page)
+		}
+		for key, rawPage := range listing {
+			page, err := parsePage(key, rawPage)
+			if err != nil {
+				c.stateMu.Unlock()
+				return err
+			}
+			c.pages[appID][key] = page
+		}
+		c.stateMu.Unlock()
+	case "_rpc_applicationSentData:":
+		return c.handleApplicationData(arg)
+	case "_rpc_reportConnectedDriverList:":
+	default:
+		return fmt.Errorf("unknown selector %q", selector)
+	}
+	return nil
+}
+
+func (c *Client) handleApplicationData(arg map[string]any) error {
+	rawData := arg["WIRMessageDataKey"]
+	var jsonBytes []byte
+	switch value := rawData.(type) {
+	case []byte:
+		jsonBytes = value
+	case string:
+		jsonBytes = []byte(value)
+	default:
+		return fmt.Errorf("unexpected WIRMessageDataKey type %T", rawData)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(jsonBytes, &payload); err != nil {
+		return err
+	}
+	if id, ok := numericInt(payload["id"]); ok {
+		c.resultMu.Lock()
+		result := c.results[id]
+		c.resultMu.Unlock()
+		if result != nil {
+			select {
+			case result <- payload:
+			default:
+			}
+			return nil
+		}
+	}
+	select {
+	case c.events <- payload:
+	default:
+		golog.Warn("webinspector event queue full", "module", logModule, "udid", c.device.Properties.SerialNumber)
+	}
+	return nil
+}
+
+func (c *Client) forwardGetListing(appID string) error {
+	return c.sendMessage("_rpc_forwardGetListing:", map[string]any{"WIRApplicationIdentifierKey": appID})
+}
+
+func (c *Client) sendMessage(selector string, args map[string]any) error {
+	if args == nil {
+		args = make(map[string]any)
+	}
+	args["WIRConnectionIdentifierKey"] = c.connectionID
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return c.plist.Write(map[string]any{"__selector": selector, "__argument": args})
+}
+
+func (c *Client) waitFor(ctx context.Context, predicate func() bool) error {
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if predicate() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-c.errs:
+			return err
+		case <-ticker.C:
+		}
+	}
+}
+
+func parseApplication(raw any) (Application, error) {
+	appDict, ok := raw.(map[string]any)
+	if !ok {
+		return Application{}, fmt.Errorf("application is %T", raw)
+	}
+	id, _ := appDict["WIRApplicationIdentifierKey"].(string)
+	return Application{
+		ID:           id,
+		BundleID:     stringValue(appDict["WIRApplicationBundleIdentifierKey"]),
+		PID:          pidFromApplicationID(id),
+		Name:         stringValue(appDict["WIRApplicationNameKey"]),
+		Availability: stringValue(appDict["WIRAutomationAvailabilityKey"]),
+		Active:       boolValue(appDict["WIRIsApplicationActiveKey"]),
+		Proxy:        boolValue(appDict["WIRIsApplicationProxyKey"]),
+		Ready:        boolValue(appDict["WIRIsApplicationReadyKey"]),
+		Host:         stringValue(appDict["WIRHostApplicationIdentifierKey"]),
+	}, nil
+}
+
+func parsePage(key string, raw any) (Page, error) {
+	pageDict, ok := raw.(map[string]any)
+	if !ok {
+		return Page{}, fmt.Errorf("page is %T", raw)
+	}
+	page := Page{
+		ID:   intValue(pageDict["WIRPageIdentifierKey"]),
+		Key:  key,
+		Type: WIRType(stringValue(pageDict["WIRTypeKey"])),
+	}
+	if page.Type == WIRTypeWeb || page.Type == WIRTypeWebPage {
+		page.Title = stringValue(pageDict["WIRTitleKey"])
+		page.URL = stringValue(pageDict["WIRURLKey"])
+	}
+	if page.Type == WIRTypeAutomation {
+		page.AutomationIsPaired = boolValue(pageDict["WIRAutomationTargetIsPairedKey"])
+		page.AutomationName = stringValue(pageDict["WIRAutomationTargetNameKey"])
+		page.AutomationVersion = stringValue(pageDict["WIRAutomationTargetVersionKey"])
+		page.AutomationSessionID = stringValue(pageDict["WIRSessionIdentifierKey"])
+		page.AutomationConnectionID = stringValue(pageDict["WIRConnectionIdentifierKey"])
+	}
+	return page, nil
+}
+
+func decodeDispatchMessage(event map[string]any) (map[string]any, bool) {
+	if event["method"] != "Target.dispatchMessageFromTarget" {
+		return nil, false
+	}
+	params, ok := event["params"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	message, _ := params["message"].(string)
+	if message == "" {
+		return nil, false
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(message), &decoded); err != nil {
+		return nil, false
+	}
+	return decoded, true
+}
+
+func parseEvaluateResult(message map[string]any) (any, error) {
+	if errValue, ok := message["error"]; ok {
+		return nil, fmt.Errorf("webinspector evaluate error: %v", errValue)
+	}
+	result, _ := message["result"].(map[string]any)
+	remote, _ := result["result"].(map[string]any)
+	if subtype, _ := remote["subtype"].(string); subtype == "error" {
+		return nil, fmt.Errorf("webinspector evaluate error: %v", remote["description"])
+	}
+	if value, ok := remote["value"]; ok {
+		return value, nil
+	}
+	if description, ok := remote["description"].(string); ok {
+		return description, nil
+	}
+	return nil, nil
+}
+
+func mustMarshalString(value any) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
+func pidFromApplicationID(id string) int {
+	_, suffix, ok := strings.Cut(id, ":")
+	if !ok {
+		return 0
+	}
+	pid, _ := strconv.Atoi(suffix)
+	return pid
+}
+
+func stringValue(value any) string {
+	s, _ := value.(string)
+	return s
+}
+
+func boolValue(value any) bool {
+	if b, ok := value.(bool); ok {
+		return b
+	}
+	if i, ok := numericInt(value); ok {
+		return i != 0
+	}
+	return false
+}
+
+func intValue(value any) int {
+	i, _ := numericInt(value)
+	return i
+}
+
+func numericInt(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case uint64:
+		return int(v), true
+	case uint:
+		return int(v), true
+	case float64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}

--- a/ios/webinspector/webinspector.go
+++ b/ios/webinspector/webinspector.go
@@ -131,10 +131,10 @@ func NewWithConnection(device ios.DeviceEntry, conn ios.DeviceConnectionInterfac
 func (c *Client) Connect(ctx context.Context) error {
 	c.watchDisabledNotification()
 	if err := c.sendMessage("_rpc_reportIdentifier:", nil); err != nil {
-		return err
+		return normalizeStartupError(err)
 	}
 	go c.readLoop()
-	return c.GetConnectedApplications(ctx)
+	return normalizeStartupError(c.GetConnectedApplications(ctx))
 }
 
 func (c *Client) Close() error {
@@ -459,7 +459,8 @@ func (c *Client) readLoop() {
 		}
 		var message map[string]any
 		if err := c.plist.Read(&message); err != nil {
-			if !errors.Is(err, io.EOF) {
+			err = normalizeStartupError(err)
+			if !errors.Is(err, io.EOF) && !errors.Is(err, ErrWebInspectorDisabled) {
 				golog.Error("webinspector read failed", "module", logModule, "udid", c.device.Properties.SerialNumber, "error", err)
 			}
 			select {
@@ -472,6 +473,19 @@ func (c *Client) readLoop() {
 			golog.Warn("webinspector message ignored", "module", logModule, "udid", c.device.Properties.SerialNumber, "error", err, "message", fmt.Sprintf("%#v", message))
 		}
 	}
+}
+
+func normalizeStartupError(err error) error {
+	if err == nil {
+		return nil
+	}
+	message := strings.ToLower(err.Error())
+	if errors.Is(err, io.EOF) ||
+		strings.Contains(message, "failed to read message length: eof") ||
+		strings.Contains(message, "only 0 bytes were written") {
+		return ErrWebInspectorDisabled
+	}
+	return err
 }
 
 func (c *Client) handleMessage(message map[string]any) error {

--- a/ios/webinspector/webinspector.go
+++ b/ios/webinspector/webinspector.go
@@ -668,10 +668,45 @@ func parseEvaluateResult(message map[string]any) (any, error) {
 	if value, ok := remote["value"]; ok {
 		return value, nil
 	}
+	if remote["type"] == "object" {
+		if preview, ok := remote["preview"].(map[string]any); ok {
+			return formatObjectPreview(stringValue(remote["className"]), preview), nil
+		}
+	}
 	if description, ok := remote["description"].(string); ok {
 		return description, nil
 	}
 	return nil, nil
+}
+
+func formatObjectPreview(className string, preview map[string]any) string {
+	if className == "" {
+		className = "Object"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "[object %s]\n{", className)
+	properties, _ := preview["properties"].([]any)
+	for _, rawProperty := range properties {
+		property, _ := rawProperty.(map[string]any)
+		name := stringValue(property["name"])
+		if name == "" {
+			continue
+		}
+		value := stringValue(property["value"])
+		if value == "" {
+			value = "NOT_SUPPORTED_FOR_PREVIEW"
+		}
+		propertyType := stringValue(property["type"])
+		fmt.Fprintf(&b, "\n\t%s: %s", name, value)
+		if propertyType != "" {
+			fmt.Fprintf(&b, ", // %s", propertyType)
+		}
+	}
+	if boolValue(preview["overflow"]) {
+		b.WriteString("\n\t// ...")
+	}
+	b.WriteString("\n}")
+	return b.String()
 }
 
 func mustMarshalString(value any) string {

--- a/ios/webinspector/webinspector.go
+++ b/ios/webinspector/webinspector.go
@@ -40,6 +40,11 @@ const (
 	AutomationNotAvailable = "WIRAutomationAvailabilityNotAvailable"
 )
 
+var (
+	ErrWebInspectorDisabled     = errors.New("web inspector is not enabled on the device; enable Settings > Safari > Advanced > Web Inspector, then reconnect the device")
+	ErrRemoteAutomationDisabled = errors.New("remote automation is not enabled on the device; enable Settings > Safari > Advanced > Remote Automation, then retry")
+)
+
 type Application struct {
 	ID           string `json:"id"`
 	BundleID     string `json:"bundleId"`
@@ -305,7 +310,7 @@ func (c *Client) SendCommand(ctx context.Context, sessionID string, app Applicat
 
 func (c *Client) AutomationSession(ctx context.Context, app Application) (*AutomationSession, error) {
 	if c.State() == AutomationNotAvailable {
-		return nil, errors.New("remote automation is not enabled on the device")
+		return nil, ErrRemoteAutomationDisabled
 	}
 	sessionID := strings.ToUpper(uuid.New().String())
 	if err := c.RequestAutomationSession(sessionID, app); err != nil {
@@ -420,11 +425,14 @@ func (c *Client) waitForAutomationPage(ctx context.Context, sessionID string) (P
 		}
 		return false
 	})
+	if errors.Is(err, context.DeadlineExceeded) {
+		err = fmt.Errorf("timed out waiting for remote automation page; %w", ErrRemoteAutomationDisabled)
+	}
 	return page, err
 }
 
 func (c *Client) waitForAutomationConnection(ctx context.Context, sessionID string) error {
-	return c.waitFor(ctx, func() bool {
+	err := c.waitFor(ctx, func() bool {
 		c.stateMu.Lock()
 		defer c.stateMu.Unlock()
 		for _, appPages := range c.pages {
@@ -436,6 +444,10 @@ func (c *Client) waitForAutomationConnection(ctx context.Context, sessionID stri
 		}
 		return false
 	})
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("timed out waiting for remote automation connection; %w", ErrRemoteAutomationDisabled)
+	}
+	return err
 }
 
 func (c *Client) readLoop() {
@@ -608,7 +620,7 @@ func (c *Client) watchDisabledNotification() {
 		err = conn.Observe(DisabledNotification, 10*time.Second)
 		if err == nil {
 			select {
-			case c.disabled <- errors.New("web inspector is not enabled on the device"):
+			case c.disabled <- ErrWebInspectorDisabled:
 			default:
 			}
 		}

--- a/ios/webinspector/webinspector.go
+++ b/ios/webinspector/webinspector.go
@@ -33,6 +33,11 @@ const (
 	WIRTypeWebPage    WIRType = "WIRTypeWebPage"
 )
 
+const (
+	AutomationAvailable    = "WIRAutomationAvailabilityAvailable"
+	AutomationNotAvailable = "WIRAutomationAvailabilityNotAvailable"
+)
+
 type Application struct {
 	ID           string `json:"id"`
 	BundleID     string `json:"bundleId"`
@@ -172,6 +177,17 @@ func (c *Client) OpenApp(ctx context.Context, bundleID string) (Application, err
 	return app, err
 }
 
+func (c *Client) ApplicationByBundleID(bundleID string) (Application, bool) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	for _, app := range c.apps {
+		if app.BundleID == bundleID {
+			return app, true
+		}
+	}
+	return Application{}, false
+}
+
 func (c *Client) ListPages(ctx context.Context, wait time.Duration) ([]ApplicationPage, error) {
 	if err := c.GetConnectedApplications(ctx); err != nil {
 		return nil, err
@@ -228,6 +244,17 @@ func (c *Client) SetupInspectorSocket(sessionID string, app Application, page Pa
 	return c.sendMessage("_rpc_forwardSocketSetup:", message)
 }
 
+func (c *Client) RequestAutomationSession(sessionID string, app Application) error {
+	return c.sendMessage("_rpc_forwardAutomationSessionRequest:", map[string]any{
+		"WIRApplicationIdentifierKey": app.ID,
+		"WIRSessionCapabilitiesKey": map[string]any{
+			"org.webkit.webdriver.webrtc.allow-insecure-media-capture":     true,
+			"org.webkit.webdriver.webrtc.suppress-ice-candidate-filtering": false,
+		},
+		"WIRSessionIdentifierKey": sessionID,
+	})
+}
+
 func (c *Client) SendSocketData(sessionID string, app Application, page Page, data map[string]any) error {
 	encoded, err := json.Marshal(data)
 	if err != nil {
@@ -269,6 +296,33 @@ func (c *Client) SendCommand(ctx context.Context, sessionID string, app Applicat
 		}
 		return response, nil
 	}
+}
+
+func (c *Client) AutomationSession(ctx context.Context, app Application) (*AutomationSession, error) {
+	if c.State() == AutomationNotAvailable {
+		return nil, errors.New("remote automation is not enabled on the device")
+	}
+	sessionID := strings.ToUpper(uuid.New().String())
+	if err := c.RequestAutomationSession(sessionID, app); err != nil {
+		return nil, err
+	}
+	if err := c.forwardGetListing(app.ID); err != nil {
+		return nil, err
+	}
+	page, err := c.waitForAutomationPage(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.SetupInspectorSocket(sessionID, app, page, true); err != nil {
+		return nil, err
+	}
+	return &AutomationSession{
+		client:    c,
+		app:       app,
+		page:      page,
+		sessionID: sessionID,
+		nextID:    1,
+	}, nil
 }
 
 func (c *Client) Evaluate(ctx context.Context, app Application, page Page, expression string) (any, error) {
@@ -336,6 +390,24 @@ func (c *Client) NextEvent(ctx context.Context) (map[string]any, error) {
 	case event := <-c.events:
 		return event, nil
 	}
+}
+
+func (c *Client) waitForAutomationPage(ctx context.Context, sessionID string) (Page, error) {
+	var page Page
+	err := c.waitFor(ctx, func() bool {
+		c.stateMu.Lock()
+		defer c.stateMu.Unlock()
+		for _, appPages := range c.pages {
+			for _, candidate := range appPages {
+				if candidate.Type == WIRTypeAutomation && candidate.AutomationSessionID == sessionID {
+					page = candidate
+					return true
+				}
+			}
+		}
+		return false
+	})
+	return page, err
 }
 
 func (c *Client) readLoop() {

--- a/ios/webinspector/webinspector.go
+++ b/ios/webinspector/webinspector.go
@@ -13,15 +13,17 @@ import (
 
 	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/golog"
+	"github.com/danielpaulus/go-ios/ios/notificationproxy"
 	"github.com/google/uuid"
 )
 
 const logModule = "go-ios/webinspector"
 
 const (
-	ServiceName    = "com.apple.webinspector"
-	ShimService    = "com.apple.webinspector.shim.remote"
-	SafariBundleID = "com.apple.mobilesafari"
+	ServiceName          = "com.apple.webinspector"
+	ShimService          = "com.apple.webinspector.shim.remote"
+	SafariBundleID       = "com.apple.mobilesafari"
+	DisabledNotification = "com.apple.webinspectord.disabled"
 )
 
 type WIRType string
@@ -84,8 +86,9 @@ type Client struct {
 	results  map[int]chan map[string]any
 	events   chan map[string]any
 
-	done chan struct{}
-	errs chan error
+	done     chan struct{}
+	errs     chan error
+	disabled chan error
 }
 
 func New(device ios.DeviceEntry) (*Client, error) {
@@ -116,10 +119,12 @@ func NewWithConnection(device ios.DeviceEntry, conn ios.DeviceConnectionInterfac
 		events:       make(chan map[string]any, 256),
 		done:         make(chan struct{}),
 		errs:         make(chan error, 1),
+		disabled:     make(chan error, 1),
 	}
 }
 
 func (c *Client) Connect(ctx context.Context) error {
+	c.watchDisabledNotification()
 	if err := c.sendMessage("_rpc_reportIdentifier:", nil); err != nil {
 		return err
 	}
@@ -387,6 +392,8 @@ func (c *Client) NextEvent(ctx context.Context) (map[string]any, error) {
 		return nil, ctx.Err()
 	case err := <-c.errs:
 		return nil, err
+	case err := <-c.disabled:
+		return nil, err
 	case event := <-c.events:
 		return event, nil
 	}
@@ -563,9 +570,28 @@ func (c *Client) waitFor(ctx context.Context, predicate func() bool) error {
 			return ctx.Err()
 		case err := <-c.errs:
 			return err
+		case err := <-c.disabled:
+			return err
 		case <-ticker.C:
 		}
 	}
+}
+
+func (c *Client) watchDisabledNotification() {
+	go func() {
+		conn, err := notificationproxy.New(c.device)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		err = conn.Observe(DisabledNotification, 10*time.Second)
+		if err == nil {
+			select {
+			case c.disabled <- errors.New("web inspector is not enabled on the device"):
+			default:
+			}
+		}
+	}()
 }
 
 func parseApplication(raw any) (Application, error) {

--- a/ios/webinspector/webinspector.go
+++ b/ios/webinspector/webinspector.go
@@ -321,6 +321,12 @@ func (c *Client) AutomationSession(ctx context.Context, app Application) (*Autom
 	if err := c.SetupInspectorSocket(sessionID, app, page, true); err != nil {
 		return nil, err
 	}
+	if err := c.forwardGetListing(app.ID); err != nil {
+		return nil, err
+	}
+	if err := c.waitForAutomationConnection(ctx, sessionID); err != nil {
+		return nil, err
+	}
 	return &AutomationSession{
 		client:    c,
 		app:       app,
@@ -415,6 +421,21 @@ func (c *Client) waitForAutomationPage(ctx context.Context, sessionID string) (P
 		return false
 	})
 	return page, err
+}
+
+func (c *Client) waitForAutomationConnection(ctx context.Context, sessionID string) error {
+	return c.waitFor(ctx, func() bool {
+		c.stateMu.Lock()
+		defer c.stateMu.Unlock()
+		for _, appPages := range c.pages {
+			for _, candidate := range appPages {
+				if candidate.Type == WIRTypeAutomation && candidate.AutomationSessionID == sessionID && candidate.AutomationConnectionID != "" {
+					return true
+				}
+			}
+		}
+		return false
+	})
 }
 
 func (c *Client) readLoop() {

--- a/ios/webinspector/webinspector_test.go
+++ b/ios/webinspector/webinspector_test.go
@@ -1,6 +1,9 @@
 package webinspector
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseApplication(t *testing.T) {
 	app, err := parseApplication(map[string]any{
@@ -67,5 +70,28 @@ func TestParseEvaluateResult(t *testing.T) {
 	}
 	if value != "hello" {
 		t.Fatalf("expected hello, got %#v", value)
+	}
+}
+
+func TestParseEvaluateResultObjectPreview(t *testing.T) {
+	value, err := parseEvaluateResult(map[string]any{
+		"result": map[string]any{
+			"result": map[string]any{
+				"type":      "object",
+				"className": "Object",
+				"preview": map[string]any{
+					"properties": []any{
+						map[string]any{"name": "answer", "value": "42", "type": "number"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("parse evaluate result: %v", err)
+	}
+	text, _ := value.(string)
+	if !strings.Contains(text, "answer: 42") {
+		t.Fatalf("expected object preview, got %#v", value)
 	}
 }

--- a/ios/webinspector/webinspector_test.go
+++ b/ios/webinspector/webinspector_test.go
@@ -1,0 +1,54 @@
+package webinspector
+
+import "testing"
+
+func TestParseApplication(t *testing.T) {
+	app, err := parseApplication(map[string]any{
+		"WIRApplicationIdentifierKey":       "PID:123",
+		"WIRApplicationBundleIdentifierKey": "com.apple.mobilesafari",
+		"WIRApplicationNameKey":             "Safari",
+		"WIRAutomationAvailabilityKey":      "WIRAutomationAvailabilityAvailable",
+		"WIRIsApplicationActiveKey":         true,
+		"WIRIsApplicationProxyKey":          false,
+		"WIRIsApplicationReadyKey":          true,
+	})
+	if err != nil {
+		t.Fatalf("parse application: %v", err)
+	}
+	if app.PID != 123 {
+		t.Fatalf("expected pid 123, got %d", app.PID)
+	}
+	if app.BundleID != "com.apple.mobilesafari" {
+		t.Fatalf("unexpected bundle id: %s", app.BundleID)
+	}
+}
+
+func TestParseWebPage(t *testing.T) {
+	page, err := parsePage("1", map[string]any{
+		"WIRPageIdentifierKey": uint64(1),
+		"WIRTypeKey":           "WIRTypeWebPage",
+		"WIRTitleKey":          "Example",
+		"WIRURLKey":            "https://example.test/",
+	})
+	if err != nil {
+		t.Fatalf("parse page: %v", err)
+	}
+	if page.ID != 1 || page.Type != WIRTypeWebPage || page.Title != "Example" {
+		t.Fatalf("unexpected page: %#v", page)
+	}
+}
+
+func TestDecodeDispatchMessage(t *testing.T) {
+	decoded, ok := decodeDispatchMessage(map[string]any{
+		"method": "Target.dispatchMessageFromTarget",
+		"params": map[string]any{
+			"message": `{"id":7,"result":{"ok":true}}`,
+		},
+	})
+	if !ok {
+		t.Fatal("expected dispatch message to decode")
+	}
+	if id, _ := numericInt(decoded["id"]); id != 7 {
+		t.Fatalf("expected id 7, got %d", id)
+	}
+}

--- a/ios/webinspector/webinspector_test.go
+++ b/ios/webinspector/webinspector_test.go
@@ -128,3 +128,23 @@ func TestAutomationSessionTimeoutErrorIsActionable(t *testing.T) {
 		t.Fatalf("error should include enablement instructions: %v", err)
 	}
 }
+
+func TestNormalizeStartupErrorMapsReadEOFToWebInspectorDisabled(t *testing.T) {
+	err := normalizeStartupError(errors.New("Read: failed to read message length: EOF"))
+	if !errors.Is(err, ErrWebInspectorDisabled) {
+		t.Fatalf("expected Web Inspector disabled error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Settings > Safari > Advanced > Web Inspector") {
+		t.Fatalf("error should include enablement instructions: %v", err)
+	}
+}
+
+func TestNormalizeStartupErrorMapsShortWriteToWebInspectorDisabled(t *testing.T) {
+	err := normalizeStartupError(errors.New("Write: only 0 bytes were written instead of 372"))
+	if !errors.Is(err, ErrWebInspectorDisabled) {
+		t.Fatalf("expected Web Inspector disabled error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Settings > Safari > Advanced > Web Inspector") {
+		t.Fatalf("error should include enablement instructions: %v", err)
+	}
+}

--- a/ios/webinspector/webinspector_test.go
+++ b/ios/webinspector/webinspector_test.go
@@ -1,8 +1,11 @@
 package webinspector
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseApplication(t *testing.T) {
@@ -93,5 +96,35 @@ func TestParseEvaluateResultObjectPreview(t *testing.T) {
 	text, _ := value.(string)
 	if !strings.Contains(text, "answer: 42") {
 		t.Fatalf("expected object preview, got %#v", value)
+	}
+}
+
+func TestAutomationSessionDisabledErrorIsActionable(t *testing.T) {
+	client := &Client{state: AutomationNotAvailable}
+	_, err := client.AutomationSession(context.Background(), Application{})
+	if !errors.Is(err, ErrRemoteAutomationDisabled) {
+		t.Fatalf("expected remote automation disabled error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Settings > Safari > Advanced > Remote Automation") {
+		t.Fatalf("error should include enablement instructions: %v", err)
+	}
+}
+
+func TestAutomationSessionTimeoutErrorIsActionable(t *testing.T) {
+	client := &Client{
+		apps:     make(map[string]Application),
+		pages:    make(map[string]map[string]Page),
+		errs:     make(chan error),
+		disabled: make(chan error),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+
+	_, err := client.waitForAutomationPage(ctx, "missing-session")
+	if !errors.Is(err, ErrRemoteAutomationDisabled) {
+		t.Fatalf("expected remote automation disabled error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Settings > Safari > Advanced > Remote Automation") {
+		t.Fatalf("error should include enablement instructions: %v", err)
 	}
 }

--- a/ios/webinspector/webinspector_test.go
+++ b/ios/webinspector/webinspector_test.go
@@ -52,3 +52,20 @@ func TestDecodeDispatchMessage(t *testing.T) {
 		t.Fatalf("expected id 7, got %d", id)
 	}
 }
+
+func TestParseEvaluateResult(t *testing.T) {
+	value, err := parseEvaluateResult(map[string]any{
+		"result": map[string]any{
+			"result": map[string]any{
+				"type":  "string",
+				"value": "hello",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("parse evaluate result: %v", err)
+	}
+	if value != "hello" {
+		t.Fatalf("expected hello, got %#v", value)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -171,6 +171,9 @@ Usage:
   ios ui app foreground [--driver=<driver>] [--devicekit-url=<url>] [options]
   ios ui stream (mjpeg | h264) [--fps=<fps>] [--quality=<quality>] [--scale=<scale>] [--bitrate=<bitrate>] [--driver=<driver>] [--wda-url=<url>] [--devicekit-url=<url>] [options]
   ios uninstall <bundleID> [options]
+  ios webinspector list [--timeout=<seconds>] [options]
+  ios webinspector eval <pageID> <expression> [--timeout=<seconds>] [options]
+  ios webinspector cdp [--host=<host>] [--port=<port>] [options]
   ios voiceover (enable | disable | toggle | get) [--force] [options]
   ios zoom (enable | disable | toggle | get) [--force] [options]
 
@@ -510,6 +513,13 @@ The commands work as following:
                                                                     This command needs to be executed with admin privileges.
                                                                     (On MacOS the process 'remoted' must be paused before starting a tunnel,
                                                                     is possible 'sudo pkill -SIGSTOP remoted', and 'sudo pkill -SIGCONT remoted' to resume)
+
+    ios webinspector list [--timeout=<seconds>] [options]           List inspectable Safari/WebView pages.
+
+    ios webinspector eval <pageID> <expression> [--timeout=<seconds>] [options]
+                                                                    Evaluate JavaScript in an inspectable page.
+
+    ios webinspector cdp [--host=<host>] [--port=<port>] [options]  Start a Chrome DevTools Protocol bridge.
 
     ios voiceover (enable | disable | toggle | get) [--force] [options] Enables, disables, toggles, or returns the state of the "VoiceOver" software home-screen button.
                                                                     iOS 11+ only (Use --force to try on older versions).

--- a/main.go
+++ b/main.go
@@ -172,7 +172,9 @@ Usage:
   ios ui stream (mjpeg | h264) [--fps=<fps>] [--quality=<quality>] [--scale=<scale>] [--bitrate=<bitrate>] [--driver=<driver>] [--wda-url=<url>] [--devicekit-url=<url>] [options]
   ios uninstall <bundleID> [options]
   ios webinspector list [--timeout=<seconds>] [options]
-  ios webinspector eval <pageID> <expression> [--timeout=<seconds>] [options]
+  ios webinspector launch <url> [--bundle-id=<bundleID>] [--timeout=<seconds>] [options]
+  ios webinspector eval <pageID> <expression> [--timeout=<seconds>] [--console-enable] [options]
+  ios webinspector js-shell [<url>] [--bundle-id=<bundleID>] [--open-safari] [--timeout=<seconds>] [--console-enable] [options]
   ios webinspector cdp [--host=<host>] [--port=<port>] [options]
   ios voiceover (enable | disable | toggle | get) [--force] [options]
   ios zoom (enable | disable | toggle | get) [--force] [options]
@@ -516,8 +518,14 @@ The commands work as following:
 
     ios webinspector list [--timeout=<seconds>] [options]           List inspectable Safari/WebView pages.
 
-    ios webinspector eval <pageID> <expression> [--timeout=<seconds>] [options]
+    ios webinspector launch <url> [--bundle-id=<bundleID>] [--timeout=<seconds>] [options]
+                                                                    Launch Safari or another app and navigate by Remote Automation.
+
+    ios webinspector eval <pageID> <expression> [--timeout=<seconds>] [--console-enable] [options]
                                                                     Evaluate JavaScript in an inspectable page.
+
+    ios webinspector js-shell [<url>] [--bundle-id=<bundleID>] [--open-safari] [--timeout=<seconds>] [--console-enable] [options]
+                                                                    Start an interactive JavaScript shell for an inspectable page.
 
     ios webinspector cdp [--host=<host>] [--port=<port>] [options]  Start a Chrome DevTools Protocol bridge.
 

--- a/test/e2e/harness/webinspector.go
+++ b/test/e2e/harness/webinspector.go
@@ -1,0 +1,380 @@
+//go:build e2e
+
+package harness
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/webinspector"
+	"github.com/gorilla/websocket"
+)
+
+// RunWebInspectorBrowserControl exercises Safari WebInspector, the local CDP
+// bridge, browser input, DOM helpers, and screencast against one real device.
+func RunWebInspectorBrowserControl(t *testing.T, udid string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	client, app, page := openWebInspectorFixture(t, ctx, udid)
+
+	value, err := client.Evaluate(ctx, app, page, "document.title")
+	if err != nil {
+		t.Fatalf("webinspector evaluate document.title: %v", err)
+	}
+	if value != "go-ios-e2e" {
+		t.Fatalf("document.title = %#v, want go-ios-e2e", value)
+	}
+
+	port := freeTCPPort(t)
+	server := webinspector.NewCDPServer(client, "127.0.0.1", port)
+	serverCtx, stopServer := context.WithCancel(ctx)
+	defer stopServer()
+	errCh := make(chan error, 1)
+	go func() { errCh <- server.Serve(serverCtx) }()
+	waitForCDPServer(t, server.Addr())
+	assertCDPListsFixturePage(t, server.Addr(), page.Key)
+
+	ws := connectCDPPage(t, server.Addr(), page.Key)
+	defer ws.Close()
+
+	cdpCommand(t, ws, 1, "Runtime.evaluate", map[string]any{
+		"expression":    `document.body.innerHTML = '<input id="agent" value=""><button id="tap" style="position:absolute;left:0;top:0;width:120px;height:48px;color:rgb(1, 2, 3)">tap</button>'; window.clicked = 0; document.getElementById("tap").addEventListener("click", () => { window.clicked += 1; }); document.getElementById("agent").focus();`,
+		"returnByValue": true,
+	})
+	cdpCommand(t, ws, 2, "Input.dispatchKeyEvent", map[string]any{
+		"type": "char",
+		"key":  "a",
+		"text": "a",
+	})
+	valueResponse := cdpCommand(t, ws, 3, "Runtime.evaluate", map[string]any{
+		"expression":    `document.getElementById("agent").value`,
+		"returnByValue": true,
+	})
+	if got := cdpEvaluateValue(valueResponse); got != "a" {
+		t.Fatalf("input value after CDP key event = %#v, want a", got)
+	}
+
+	cdpCommand(t, ws, 4, "Input.emulateTouchFromMouseEvent", map[string]any{
+		"type":      "mousePressed",
+		"x":         10,
+		"y":         10,
+		"button":    "left",
+		"modifiers": 0,
+	})
+	clickedResponse := cdpCommand(t, ws, 5, "Runtime.evaluate", map[string]any{
+		"expression":    `window.clicked`,
+		"returnByValue": true,
+	})
+	if got := cdpEvaluateValue(clickedResponse); got != float64(1) {
+		t.Fatalf("window.clicked after CDP mouse event = %#v, want 1", got)
+	}
+
+	nodeResponse := cdpCommand(t, ws, 6, "DOM.getNodeForLocation", map[string]any{"x": 10, "y": 10})
+	nodeResult, _ := nodeResponse["result"].(map[string]any)
+	if nodeID, ok := numeric(nodeResult["nodeId"]); !ok || nodeID == 0 {
+		t.Fatalf("DOM.getNodeForLocation returned no nodeId: %#v", nodeResponse)
+	}
+
+	bodyResponse := cdpCommand(t, ws, 7, "Runtime.evaluate", map[string]any{"expression": `document.body`})
+	bodyID := cdpEvaluateObjectID(bodyResponse)
+	if bodyID == "" {
+		t.Fatalf("Runtime.evaluate document.body returned no objectId: %#v", bodyResponse)
+	}
+	bodyNodeResponse := cdpCommand(t, ws, 8, "DOM.requestNode", map[string]any{"objectId": bodyID})
+	bodyNodeResult, _ := bodyNodeResponse["result"].(map[string]any)
+	bodyNodeID, ok := numeric(bodyNodeResult["nodeId"])
+	if !ok || bodyNodeID == 0 {
+		t.Fatalf("DOM.requestNode returned no body nodeId: %#v", bodyNodeResponse)
+	}
+	styleResponse := cdpCommand(t, ws, 9, "DOM.getNodesForSubtreeByStyle", map[string]any{
+		"nodeId": bodyNodeID,
+		"computedStyles": []map[string]any{
+			{"name": "color", "value": "rgb(1, 2, 3)"},
+		},
+	})
+	styleResult, _ := styleResponse["result"].(map[string]any)
+	styleNodeIDs, _ := styleResult["nodeIds"].([]any)
+	if len(styleNodeIDs) == 0 {
+		t.Fatalf("DOM.getNodesForSubtreeByStyle returned no matching nodes: %#v", styleResponse)
+	}
+
+	objectResponse := cdpCommand(t, ws, 10, "Runtime.evaluate", map[string]any{"expression": `document.getElementById("agent")`})
+	objectID := cdpEvaluateObjectID(objectResponse)
+	if objectID == "" {
+		t.Fatalf("Runtime.evaluate returned no objectId: %#v", objectResponse)
+	}
+	listenersResponse := cdpCommand(t, ws, 11, "DOMDebugger.getEventListeners", map[string]any{"objectId": objectID})
+	listenersResult, _ := listenersResponse["result"].(map[string]any)
+	listeners, ok := listenersResult["listeners"].([]any)
+	if !ok {
+		t.Fatalf("DOMDebugger.getEventListeners returned no listeners array: %#v", listenersResponse)
+	}
+	if !hasEventListener(listeners, "click") {
+		t.Fatalf("DOMDebugger.getEventListeners did not report the click listener: %#v", listenersResponse)
+	}
+
+	resourceTree := cdpCommand(t, ws, 12, "Page.getResourceTree", map[string]any{})
+	resourceResult, _ := resourceTree["result"].(map[string]any)
+	if _, ok := resourceResult["frameTree"].(map[string]any); !ok {
+		t.Fatalf("Page.getResourceTree returned no frameTree: %#v", resourceTree)
+	}
+
+	cdpCommand(t, ws, 13, "Page.startScreencast", map[string]any{
+		"format":    "jpeg",
+		"quality":   80,
+		"maxWidth":  400,
+		"maxHeight": 400,
+	})
+	frame := cdpEvent(t, ws, "Page.screencastFrame")
+	frameParams, _ := frame["params"].(map[string]any)
+	if data, _ := frameParams["data"].(string); data == "" {
+		t.Fatalf("Page.screencastFrame has empty data: %#v", frame)
+	} else if format, width, height, ok := decodeScreencastImage(data); !ok {
+		t.Fatalf("Page.screencastFrame data is not a decodable PNG/JPEG payload")
+	} else if width == 0 || height == 0 {
+		t.Fatalf("Page.screencastFrame decoded as %s with invalid dimensions %dx%d", format, width, height)
+	}
+	sessionID, _ := numeric(frameParams["sessionId"])
+	cdpCommand(t, ws, 14, "Page.screencastFrameAck", map[string]any{"sessionId": sessionID})
+	cdpCommand(t, ws, 15, "Page.stopScreencast", map[string]any{})
+
+	_ = ws.Close()
+	stopServer()
+	select {
+	case err := <-errCh:
+		if err != nil && !strings.Contains(err.Error(), "context canceled") {
+			t.Fatalf("cdp server: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("cdp server did not stop")
+	}
+}
+
+func openWebInspectorFixture(t *testing.T, ctx context.Context, udid string) (*webinspector.Client, webinspector.Application, webinspector.Page) {
+	t.Helper()
+
+	device, err := ios.GetDevice(udid)
+	if err != nil {
+		t.Fatalf("get device: %v", err)
+	}
+	client, err := webinspector.New(device)
+	if err != nil {
+		t.Fatalf("connect webinspector service: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	if err := client.Connect(ctx); err != nil {
+		skipWebInspectorSetting(t, err)
+		t.Fatalf("start webinspector: %v", err)
+	}
+
+	app, err := client.OpenApp(ctx, webinspector.SafariBundleID)
+	if err != nil {
+		t.Fatalf("open Safari: %v", err)
+	}
+	session, err := client.AutomationSession(ctx, app)
+	if err != nil {
+		skipWebInspectorSetting(t, err)
+		t.Fatalf("start remote automation: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = session.Stop(stopCtx)
+	})
+	if err := session.Start(ctx); err != nil {
+		t.Fatalf("start browsing context: %v", err)
+	}
+	url := "data:text/html,%3Ctitle%3Ego-ios-e2e%3C/title%3E%3Cinput%20id%3Dagent%20value%3D%22%22%3E"
+	if err := session.Navigate(ctx, url); err != nil {
+		t.Fatalf("navigate fixture page: %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		pages, err := client.ListPages(ctx, 500*time.Millisecond)
+		if err != nil {
+			t.Fatalf("list webinspector pages: %v", err)
+		}
+		for _, candidate := range pages {
+			if candidate.Application.BundleID != webinspector.SafariBundleID {
+				continue
+			}
+			if candidate.Page.Type != webinspector.WIRTypeWeb && candidate.Page.Type != webinspector.WIRTypeWebPage {
+				continue
+			}
+			if strings.Contains(candidate.Page.URL, "go-ios-e2e") || candidate.Page.Title == "go-ios-e2e" {
+				return client, candidate.Application, candidate.Page
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("fixture page did not appear in WebInspector listing")
+	return nil, webinspector.Application{}, webinspector.Page{}
+}
+
+func skipWebInspectorSetting(t *testing.T, err error) {
+	t.Helper()
+	message := strings.ToLower(err.Error())
+	if strings.Contains(message, "web inspector is not enabled") ||
+		strings.Contains(message, "remote automation is not enabled") {
+		t.Skip(err)
+	}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on free port: %v", err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForCDPServer(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://" + addr + "/json/version")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("cdp server %s did not become ready", addr)
+}
+
+func assertCDPListsFixturePage(t *testing.T, addr string, pageKey string) {
+	t.Helper()
+	resp, err := http.Get("http://" + addr + "/json/list")
+	if err != nil {
+		t.Fatalf("get CDP target list: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CDP target list status = %d", resp.StatusCode)
+	}
+	var targets []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&targets); err != nil {
+		t.Fatalf("decode CDP target list: %v", err)
+	}
+	for _, target := range targets {
+		if target["id"] == pageKey && target["type"] == "page" && target["webSocketDebuggerUrl"] != "" {
+			return
+		}
+	}
+	t.Fatalf("CDP target list did not include page %s: %#v", pageKey, targets)
+}
+
+func connectCDPPage(t *testing.T, addr string, pageKey string) *websocket.Conn {
+	t.Helper()
+	ws, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/devtools/page/"+pageKey, nil)
+	if err != nil {
+		t.Fatalf("connect CDP websocket: %v", err)
+	}
+	return ws
+}
+
+func cdpCommand(t *testing.T, ws *websocket.Conn, id int, method string, params map[string]any) map[string]any {
+	t.Helper()
+	if err := ws.WriteJSON(map[string]any{"id": id, "method": method, "params": params}); err != nil {
+		t.Fatalf("write CDP command %s: %v", method, err)
+	}
+	for {
+		message := readCDPMessage(t, ws)
+		if gotID, ok := numeric(message["id"]); ok && gotID == id {
+			if errValue, ok := message["error"]; ok {
+				t.Fatalf("CDP command %s failed: %#v", method, errValue)
+			}
+			return message
+		}
+	}
+}
+
+func cdpEvent(t *testing.T, ws *websocket.Conn, method string) map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		message := readCDPMessage(t, ws)
+		if message["method"] == method {
+			return message
+		}
+	}
+	t.Fatalf("timed out waiting for CDP event %s", method)
+	return nil
+}
+
+func readCDPMessage(t *testing.T, ws *websocket.Conn) map[string]any {
+	t.Helper()
+	_ = ws.SetReadDeadline(time.Now().Add(10 * time.Second))
+	var message map[string]any
+	if err := ws.ReadJSON(&message); err != nil {
+		t.Fatalf("read CDP message: %v", err)
+	}
+	return message
+}
+
+func cdpEvaluateValue(response map[string]any) any {
+	result, _ := response["result"].(map[string]any)
+	remote, _ := result["result"].(map[string]any)
+	return remote["value"]
+}
+
+func cdpEvaluateObjectID(response map[string]any) string {
+	result, _ := response["result"].(map[string]any)
+	remote, _ := result["result"].(map[string]any)
+	objectID, _ := remote["objectId"].(string)
+	return objectID
+}
+
+func hasEventListener(listeners []any, listenerType string) bool {
+	for _, rawListener := range listeners {
+		listener, _ := rawListener.(map[string]any)
+		if listener["type"] == listenerType {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeScreencastImage(data string) (string, int, int, bool) {
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil || len(decoded) < 8 {
+		return "", 0, 0, false
+	}
+	config, format, err := image.DecodeConfig(bytes.NewReader(decoded))
+	if err != nil {
+		return "", 0, 0, false
+	}
+	if format != "jpeg" && format != "png" {
+		return format, config.Width, config.Height, false
+	}
+	return format, config.Width, config.Height, true
+}
+
+func numeric(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case float64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}

--- a/test/e2e/preios17/webinspector_test.go
+++ b/test/e2e/preios17/webinspector_test.go
@@ -1,6 +1,6 @@
 //go:build e2e
 
-package tunnel_test
+package preios17_test
 
 import (
 	"testing"

--- a/test/e2e/tunnel/webinspector_test.go
+++ b/test/e2e/tunnel/webinspector_test.go
@@ -1,0 +1,281 @@
+//go:build e2e
+
+package tunnel_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/webinspector"
+	"github.com/gorilla/websocket"
+)
+
+func TestWebInspectorBrowserControl(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+
+		client, app, page := openWebInspectorFixture(t, ctx, udid)
+
+		value, err := client.Evaluate(ctx, app, page, "document.title")
+		if err != nil {
+			t.Fatalf("webinspector evaluate document.title: %v", err)
+		}
+		if value != "go-ios-e2e" {
+			t.Fatalf("document.title = %#v, want go-ios-e2e", value)
+		}
+
+		port := freeTCPPort(t)
+		server := webinspector.NewCDPServer(client, "127.0.0.1", port)
+		serverCtx, stopServer := context.WithCancel(ctx)
+		defer stopServer()
+		errCh := make(chan error, 1)
+		go func() { errCh <- server.Serve(serverCtx) }()
+		waitForCDPServer(t, server.Addr())
+
+		ws := connectCDPPage(t, server.Addr(), page.Key)
+		defer ws.Close()
+
+		cdpCommand(t, ws, 1, "Runtime.evaluate", map[string]any{
+			"expression":    `document.body.innerHTML = '<input id="agent" value="">'; document.getElementById("agent").focus();`,
+			"returnByValue": true,
+		})
+		cdpCommand(t, ws, 2, "Input.dispatchKeyEvent", map[string]any{
+			"type": "char",
+			"key":  "a",
+			"text": "a",
+		})
+		valueResponse := cdpCommand(t, ws, 3, "Runtime.evaluate", map[string]any{
+			"expression":    `document.getElementById("agent").value`,
+			"returnByValue": true,
+		})
+		if got := cdpEvaluateValue(valueResponse); got != "a" {
+			t.Fatalf("input value after CDP key event = %#v, want a", got)
+		}
+
+		nodeResponse := cdpCommand(t, ws, 4, "DOM.getNodeForLocation", map[string]any{"x": 1, "y": 1})
+		nodeResult, _ := nodeResponse["result"].(map[string]any)
+		if nodeID, ok := numeric(nodeResult["nodeId"]); !ok || nodeID == 0 {
+			t.Fatalf("DOM.getNodeForLocation returned no nodeId: %#v", nodeResponse)
+		}
+
+		objectResponse := cdpCommand(t, ws, 5, "Runtime.evaluate", map[string]any{
+			"expression": `document.getElementById("agent")`,
+		})
+		objectID := cdpEvaluateObjectID(objectResponse)
+		if objectID == "" {
+			t.Fatalf("Runtime.evaluate returned no objectId: %#v", objectResponse)
+		}
+		listenersResponse := cdpCommand(t, ws, 6, "DOMDebugger.getEventListeners", map[string]any{"objectId": objectID})
+		listenersResult, _ := listenersResponse["result"].(map[string]any)
+		if _, ok := listenersResult["listeners"].([]any); !ok {
+			t.Fatalf("DOMDebugger.getEventListeners returned no listeners array: %#v", listenersResponse)
+		}
+
+		resourceTree := cdpCommand(t, ws, 7, "Page.getResourceTree", map[string]any{})
+		resourceResult, _ := resourceTree["result"].(map[string]any)
+		if _, ok := resourceResult["frameTree"].(map[string]any); !ok {
+			t.Fatalf("Page.getResourceTree returned no frameTree: %#v", resourceTree)
+		}
+
+		cdpCommand(t, ws, 8, "Page.startScreencast", map[string]any{
+			"format":    "jpeg",
+			"quality":   80,
+			"maxWidth":  400,
+			"maxHeight": 400,
+		})
+		frame := cdpEvent(t, ws, "Page.screencastFrame")
+		frameParams, _ := frame["params"].(map[string]any)
+		if data, _ := frameParams["data"].(string); data == "" {
+			t.Fatalf("Page.screencastFrame has empty data: %#v", frame)
+		}
+		sessionID, _ := numeric(frameParams["sessionId"])
+		cdpCommand(t, ws, 9, "Page.screencastFrameAck", map[string]any{"sessionId": sessionID})
+		cdpCommand(t, ws, 10, "Page.stopScreencast", map[string]any{})
+
+		_ = ws.Close()
+		stopServer()
+		select {
+		case err := <-errCh:
+			if err != nil && !strings.Contains(err.Error(), "context canceled") {
+				t.Fatalf("cdp server: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("cdp server did not stop")
+		}
+	})
+}
+
+func openWebInspectorFixture(t *testing.T, ctx context.Context, udid string) (*webinspector.Client, webinspector.Application, webinspector.Page) {
+	t.Helper()
+
+	device, err := ios.GetDevice(udid)
+	if err != nil {
+		t.Fatalf("get device: %v", err)
+	}
+	client, err := webinspector.New(device)
+	if err != nil {
+		t.Fatalf("connect webinspector service: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+	if err := client.Connect(ctx); err != nil {
+		skipWebInspectorSetting(t, err)
+		t.Fatalf("start webinspector: %v", err)
+	}
+
+	app, err := client.OpenApp(ctx, webinspector.SafariBundleID)
+	if err != nil {
+		t.Fatalf("open Safari: %v", err)
+	}
+	session, err := client.AutomationSession(ctx, app)
+	if err != nil {
+		skipWebInspectorSetting(t, err)
+		t.Fatalf("start remote automation: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = session.Stop(stopCtx)
+	})
+	if err := session.Start(ctx); err != nil {
+		t.Fatalf("start browsing context: %v", err)
+	}
+	url := "data:text/html,%3Ctitle%3Ego-ios-e2e%3C/title%3E%3Cinput%20id%3Dagent%20value%3D%22%22%3E"
+	if err := session.Navigate(ctx, url); err != nil {
+		t.Fatalf("navigate fixture page: %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		pages, err := client.ListPages(ctx, 500*time.Millisecond)
+		if err != nil {
+			t.Fatalf("list webinspector pages: %v", err)
+		}
+		for _, candidate := range pages {
+			if candidate.Application.BundleID != webinspector.SafariBundleID {
+				continue
+			}
+			if candidate.Page.Type != webinspector.WIRTypeWeb && candidate.Page.Type != webinspector.WIRTypeWebPage {
+				continue
+			}
+			if strings.Contains(candidate.Page.URL, "go-ios-e2e") || candidate.Page.Title == "go-ios-e2e" {
+				return client, candidate.Application, candidate.Page
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("fixture page did not appear in WebInspector listing")
+	return nil, webinspector.Application{}, webinspector.Page{}
+}
+
+func skipWebInspectorSetting(t *testing.T, err error) {
+	t.Helper()
+	message := strings.ToLower(err.Error())
+	if strings.Contains(message, "web inspector is not enabled") ||
+		strings.Contains(message, "remote automation is not enabled") {
+		t.Skip(err)
+	}
+}
+
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on free port: %v", err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForCDPServer(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://" + addr + "/json/version")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("cdp server %s did not become ready", addr)
+}
+
+func connectCDPPage(t *testing.T, addr string, pageKey string) *websocket.Conn {
+	t.Helper()
+	ws, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/devtools/page/"+pageKey, nil)
+	if err != nil {
+		t.Fatalf("connect CDP websocket: %v", err)
+	}
+	return ws
+}
+
+func cdpCommand(t *testing.T, ws *websocket.Conn, id int, method string, params map[string]any) map[string]any {
+	t.Helper()
+	if err := ws.WriteJSON(map[string]any{"id": id, "method": method, "params": params}); err != nil {
+		t.Fatalf("write CDP command %s: %v", method, err)
+	}
+	for {
+		message := readCDPMessage(t, ws)
+		if gotID, ok := numeric(message["id"]); ok && gotID == id {
+			if errValue, ok := message["error"]; ok {
+				t.Fatalf("CDP command %s failed: %#v", method, errValue)
+			}
+			return message
+		}
+	}
+}
+
+func cdpEvent(t *testing.T, ws *websocket.Conn, method string) map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		message := readCDPMessage(t, ws)
+		if message["method"] == method {
+			return message
+		}
+	}
+	t.Fatalf("timed out waiting for CDP event %s", method)
+	return nil
+}
+
+func readCDPMessage(t *testing.T, ws *websocket.Conn) map[string]any {
+	t.Helper()
+	_ = ws.SetReadDeadline(time.Now().Add(10 * time.Second))
+	var message map[string]any
+	if err := ws.ReadJSON(&message); err != nil {
+		t.Fatalf("read CDP message: %v", err)
+	}
+	return message
+}
+
+func cdpEvaluateValue(response map[string]any) any {
+	result, _ := response["result"].(map[string]any)
+	remote, _ := result["result"].(map[string]any)
+	return remote["value"]
+}
+
+func cdpEvaluateObjectID(response map[string]any) string {
+	result, _ := response["result"].(map[string]any)
+	remote, _ := result["result"].(map[string]any)
+	objectID, _ := remote["objectId"].(string)
+	return objectID
+}
+
+func numeric(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case float64:
+		return int(v), true
+	default:
+		return 0, false
+	}
+}

--- a/test/e2e/tunnel/webinspector_test.go
+++ b/test/e2e/tunnel/webinspector_test.go
@@ -4,6 +4,8 @@ package tunnel_test
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"net"
 	"net/http"
 	"strings"
@@ -37,12 +39,13 @@ func TestWebInspectorBrowserControl(t *testing.T) {
 		errCh := make(chan error, 1)
 		go func() { errCh <- server.Serve(serverCtx) }()
 		waitForCDPServer(t, server.Addr())
+		assertCDPListsFixturePage(t, server.Addr(), page.Key)
 
 		ws := connectCDPPage(t, server.Addr(), page.Key)
 		defer ws.Close()
 
 		cdpCommand(t, ws, 1, "Runtime.evaluate", map[string]any{
-			"expression":    `document.body.innerHTML = '<input id="agent" value="">'; document.getElementById("agent").focus();`,
+			"expression":    `document.body.innerHTML = '<input id="agent" value=""><button id="tap" style="position:absolute;left:0;top:0;width:120px;height:48px;color:rgb(1, 2, 3)">tap</button>'; window.clicked = 0; document.getElementById("tap").addEventListener("click", () => { window.clicked += 1; }); document.getElementById("agent").focus();`,
 			"returnByValue": true,
 		})
 		cdpCommand(t, ws, 2, "Input.dispatchKeyEvent", map[string]any{
@@ -58,32 +61,72 @@ func TestWebInspectorBrowserControl(t *testing.T) {
 			t.Fatalf("input value after CDP key event = %#v, want a", got)
 		}
 
-		nodeResponse := cdpCommand(t, ws, 4, "DOM.getNodeForLocation", map[string]any{"x": 1, "y": 1})
+		cdpCommand(t, ws, 4, "Input.emulateTouchFromMouseEvent", map[string]any{
+			"type":      "mousePressed",
+			"x":         10,
+			"y":         10,
+			"button":    "left",
+			"modifiers": 0,
+		})
+		clickedResponse := cdpCommand(t, ws, 5, "Runtime.evaluate", map[string]any{
+			"expression":    `window.clicked`,
+			"returnByValue": true,
+		})
+		if got := cdpEvaluateValue(clickedResponse); got != float64(1) {
+			t.Fatalf("window.clicked after CDP mouse event = %#v, want 1", got)
+		}
+
+		nodeResponse := cdpCommand(t, ws, 6, "DOM.getNodeForLocation", map[string]any{"x": 10, "y": 10})
 		nodeResult, _ := nodeResponse["result"].(map[string]any)
 		if nodeID, ok := numeric(nodeResult["nodeId"]); !ok || nodeID == 0 {
 			t.Fatalf("DOM.getNodeForLocation returned no nodeId: %#v", nodeResponse)
 		}
 
-		objectResponse := cdpCommand(t, ws, 5, "Runtime.evaluate", map[string]any{
+		bodyResponse := cdpCommand(t, ws, 7, "Runtime.evaluate", map[string]any{
+			"expression": `document.body`,
+		})
+		bodyID := cdpEvaluateObjectID(bodyResponse)
+		if bodyID == "" {
+			t.Fatalf("Runtime.evaluate document.body returned no objectId: %#v", bodyResponse)
+		}
+		bodyNodeResponse := cdpCommand(t, ws, 8, "DOM.requestNode", map[string]any{"objectId": bodyID})
+		bodyNodeResult, _ := bodyNodeResponse["result"].(map[string]any)
+		bodyNodeID, ok := numeric(bodyNodeResult["nodeId"])
+		if !ok || bodyNodeID == 0 {
+			t.Fatalf("DOM.requestNode returned no body nodeId: %#v", bodyNodeResponse)
+		}
+		styleResponse := cdpCommand(t, ws, 9, "DOM.getNodesForSubtreeByStyle", map[string]any{
+			"nodeId": bodyNodeID,
+			"computedStyles": []map[string]any{
+				{"name": "color", "value": "rgb(1, 2, 3)"},
+			},
+		})
+		styleResult, _ := styleResponse["result"].(map[string]any)
+		styleNodeIDs, _ := styleResult["nodeIds"].([]any)
+		if len(styleNodeIDs) == 0 {
+			t.Fatalf("DOM.getNodesForSubtreeByStyle returned no matching nodes: %#v", styleResponse)
+		}
+
+		objectResponse := cdpCommand(t, ws, 10, "Runtime.evaluate", map[string]any{
 			"expression": `document.getElementById("agent")`,
 		})
 		objectID := cdpEvaluateObjectID(objectResponse)
 		if objectID == "" {
 			t.Fatalf("Runtime.evaluate returned no objectId: %#v", objectResponse)
 		}
-		listenersResponse := cdpCommand(t, ws, 6, "DOMDebugger.getEventListeners", map[string]any{"objectId": objectID})
+		listenersResponse := cdpCommand(t, ws, 11, "DOMDebugger.getEventListeners", map[string]any{"objectId": objectID})
 		listenersResult, _ := listenersResponse["result"].(map[string]any)
 		if _, ok := listenersResult["listeners"].([]any); !ok {
 			t.Fatalf("DOMDebugger.getEventListeners returned no listeners array: %#v", listenersResponse)
 		}
 
-		resourceTree := cdpCommand(t, ws, 7, "Page.getResourceTree", map[string]any{})
+		resourceTree := cdpCommand(t, ws, 12, "Page.getResourceTree", map[string]any{})
 		resourceResult, _ := resourceTree["result"].(map[string]any)
 		if _, ok := resourceResult["frameTree"].(map[string]any); !ok {
 			t.Fatalf("Page.getResourceTree returned no frameTree: %#v", resourceTree)
 		}
 
-		cdpCommand(t, ws, 8, "Page.startScreencast", map[string]any{
+		cdpCommand(t, ws, 13, "Page.startScreencast", map[string]any{
 			"format":    "jpeg",
 			"quality":   80,
 			"maxWidth":  400,
@@ -93,10 +136,12 @@ func TestWebInspectorBrowserControl(t *testing.T) {
 		frameParams, _ := frame["params"].(map[string]any)
 		if data, _ := frameParams["data"].(string); data == "" {
 			t.Fatalf("Page.screencastFrame has empty data: %#v", frame)
+		} else if !validScreencastImage(data) {
+			t.Fatalf("Page.screencastFrame data is not a decodable PNG/JPEG payload")
 		}
 		sessionID, _ := numeric(frameParams["sessionId"])
-		cdpCommand(t, ws, 9, "Page.screencastFrameAck", map[string]any{"sessionId": sessionID})
-		cdpCommand(t, ws, 10, "Page.stopScreencast", map[string]any{})
+		cdpCommand(t, ws, 14, "Page.screencastFrameAck", map[string]any{"sessionId": sessionID})
+		cdpCommand(t, ws, 15, "Page.stopScreencast", map[string]any{})
 
 		_ = ws.Close()
 		stopServer()
@@ -208,6 +253,28 @@ func waitForCDPServer(t *testing.T, addr string) {
 	t.Fatalf("cdp server %s did not become ready", addr)
 }
 
+func assertCDPListsFixturePage(t *testing.T, addr string, pageKey string) {
+	t.Helper()
+	resp, err := http.Get("http://" + addr + "/json/list")
+	if err != nil {
+		t.Fatalf("get CDP target list: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CDP target list status = %d", resp.StatusCode)
+	}
+	var targets []map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&targets); err != nil {
+		t.Fatalf("decode CDP target list: %v", err)
+	}
+	for _, target := range targets {
+		if target["id"] == pageKey && target["type"] == "page" && target["webSocketDebuggerUrl"] != "" {
+			return
+		}
+	}
+	t.Fatalf("CDP target list did not include page %s: %#v", pageKey, targets)
+}
+
 func connectCDPPage(t *testing.T, addr string, pageKey string) *websocket.Conn {
 	t.Helper()
 	ws, _, err := websocket.DefaultDialer.Dial("ws://"+addr+"/devtools/page/"+pageKey, nil)
@@ -267,6 +334,16 @@ func cdpEvaluateObjectID(response map[string]any) string {
 	remote, _ := result["result"].(map[string]any)
 	objectID, _ := remote["objectId"].(string)
 	return objectID
+}
+
+func validScreencastImage(data string) bool {
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil || len(decoded) < 8 {
+		return false
+	}
+	isJPEG := decoded[0] == 0xff && decoded[1] == 0xd8
+	isPNG := string(decoded[:8]) == "\x89PNG\r\n\x1a\n"
+	return isJPEG || isPNG
 }
 
 func numeric(value any) (int, bool) {

--- a/testdata/help/global.golden
+++ b/testdata/help/global.golden
@@ -100,6 +100,9 @@ Commands:
   uninstall                       Uninstall app by bundle ID.
   version                         Print version.
   voiceover                       Manage VoiceOver state.
+  webinspector cdp                Start a Chrome DevTools Protocol bridge.
+  webinspector eval               Evaluate JavaScript in an inspectable page.
+  webinspector list               List inspectable Safari and WebView pages.
   wifi                            Install or remove a Wi-Fi auto-connect profile (supervised + setup = silent, else confirm on device).
   zoom                            Manage Zoom state.
 

--- a/testdata/help/global.golden
+++ b/testdata/help/global.golden
@@ -102,6 +102,8 @@ Commands:
   voiceover                       Manage VoiceOver state.
   webinspector cdp                Start a Chrome DevTools Protocol bridge.
   webinspector eval               Evaluate JavaScript in an inspectable page.
+  webinspector js-shell           Start an interactive JavaScript shell for an inspectable page.
+  webinspector launch             Launch and navigate Safari or another app by Remote Automation.
   webinspector list               List inspectable Safari and WebView pages.
   wifi                            Install or remove a Wi-Fi auto-connect profile (supervised + setup = silent, else confirm on device).
   zoom                            Manage Zoom state.


### PR DESCRIPTION
## Summary
- add an `ios/webinspector` client for Safari/WebView inspection, JS evaluation, Remote Automation, and WebInspector message handling
- add `ios webinspector` commands for `list`, `launch`, `eval`, `js-shell`, and a local CDP bridge
- add CDP compatibility shims for target metadata, runtime/debugger/DOM/network/log events, input, and screencast support
- add actionable setup errors for disabled Web Inspector / Remote Automation settings
- add unit tests and real-device e2e coverage for browser control across tunnel and pre-iOS17 suites

## New commands
- `ios webinspector list [--timeout=<seconds>] [options]` lists inspectable Safari/WebView pages.
- `ios webinspector launch <url> [--bundle-id=<bundleID>] [--timeout=<seconds>] [options]` opens Safari by default, or another app via `--bundle-id`, starts Remote Automation, and navigates to the URL.
- `ios webinspector eval <pageID> <expression> [--timeout=<seconds>] [--console-enable] [options]` evaluates JavaScript in a specific inspectable page.
- `ios webinspector js-shell [<url>] [--bundle-id=<bundleID>] [--open-safari] [--timeout=<seconds>] [--console-enable] [options]` starts an interactive JavaScript shell against an inspectable page.
- `ios webinspector cdp [--host=<host>] [--port=<port>] [options]` starts a local Chrome DevTools Protocol bridge, defaulting to `127.0.0.1:9222`.

## Credit
- Kudos to the pymobiledevice3 project: this WebInspector/CDP work was analyzed and backported from their implementation and recent changes.

## Verification
- `go test . ./internal/clihelp ./ios/webinspector`
- `go test -tags=e2e ./test/e2e/tunnel -run TestWebInspectorBrowserControl -count=0`
- `go test -tags=e2e ./test/e2e/preios17 -run TestWebInspectorBrowserControl -count=0`

## Note
- `make build` is blocked locally because `pkg-config` is missing for `github.com/google/gousb` in this environment.