### PR TITLE
warn that --pair-record-path=default is TCC-blocked on macOS 26 (Tahoe)

### DIFF
--- a/cmd_tunnel.go
+++ b/cmd_tunnel.go
@@ -43,6 +43,13 @@ func dispatchTunnelCommand(ctx tunnelCommandContext) bool {
 		}
 		if strings.ToLower(pairRecordsPath) == "default" {
 			pairRecordsPath = "/var/db/lockdown/RemotePairing/user_501"
+			slog.Warn("'--pair-record-path=default' reads Apple's own RemotePairing identity, "+
+				"which macOS 26 (Tahoe) and newer block for third-party binaries via TCC "+
+				"('operation not permitted'). If the tunnel fails to read selfIdentity.plist, "+
+				"drop '=default' and pass a stable writable directory instead "+
+				"(e.g. --pair-record-path=/Users/Shared/go-ios); go-ios then manages its own "+
+				"tunnel identity and pairs it on first use. See https://github.com/danielpaulus/go-ios/issues/710",
+				"pairRecordsPath", pairRecordsPath)
 		}
 		startTunnel(context.TODO(), pairRecordsPath, ctx.TunnelInfoHost, ctx.TunnelInfoPort, useUserspaceNetworking)
 	} else if listCommand {

--- a/main.go
+++ b/main.go
@@ -511,6 +511,10 @@ The commands work as following:
                                                                     If the device was not paired with the host yet, device pairing will also be executed.
                                                                     On systems with System Integrity Protection enabled the argument '--pair-record-path=default'
                                                                     can be used to point to /var/db/lockdown/RemotePairing/user_501.
+                                                                    WARNING: macOS 26 (Tahoe) and newer block that path for third-party binaries via TCC
+                                                                    ('operation not permitted'). On those systems do NOT use '=default'; pass a stable
+                                                                    writable directory instead (e.g. --pair-record-path=/Users/Shared/go-ios) and go-ios
+                                                                    will manage its own tunnel identity. See https://github.com/danielpaulus/go-ios/issues/710
                                                                     If nothing is specified, the current dir is used for the pair record.
                                                                     This command needs to be executed with admin privileges.
                                                                     (On MacOS the process 'remoted' must be paused before starting a tunnel,


### PR DESCRIPTION
## What

Adds a runtime warning and a CLI-help note when `ios tunnel start --pair-record-path=default` is used, because that path is blocked on macOS 26+ (Tahoe).

## Why

`--pair-record-path=default` resolves to Apple's own RemotePairing identity at `/var/db/lockdown/RemotePairing/user_501`. On **macOS 26 (Tahoe) and newer**, TCC blocks that path for third-party binaries — even under `sudo` + Full Disk Access — so the tunnel dies with:

```
NewPairRecordManager: failed to get self identity:
readSelfIdentity: could not read file:
open /var/db/lockdown/RemotePairing/user_501/selfIdentity.plist: operation not permitted
```

This is reported in #710 and trips up everyone on Tahoe who copied the `=default` invocation.

Crucially this is **opt-in only**: the device pair record is read over the **usbmuxd socket** (`ReadPairRecord`), never the walled path, and without `=default` go-ios creates/manages its **own** tunnel identity in whatever directory is given. So the fix for affected users is simply to drop `=default` and pass a stable writable directory.

## Change

- `cmd_tunnel.go`: `slog.Warn` when `=default` is selected, explaining the Tahoe TCC block and pointing to the `--pair-record-path=<dir>` alternative and #710.
- `main.go`: matching `WARNING:` block in the `ios tunnel start` help text.

No behavior change — purely a heads-up so users aren't trapped.

## Verification

Reproduced and verified on **macOS 26.5.1 (Tahoe, build 25F80)** with an **iPhone 17 (iOS 26)**:

- `/var/db/lockdown/` → `Operation not permitted` (TCC wall confirmed).
- Plain `ios tunnel start` with a non-`default` pair-record path: `ios list`, `ios info`, and `ios ps` (the last over the iOS-17+ tunnel + RSD) all succeed.
- `go vet .` passes; `gofmt` clean.

Fixes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)