### PR TITLE
ci: notify Discord for releases and merged PRs

### DIFF
--- a/.github/workflows/discord-pr-merged.yml
+++ b/.github/workflows/discord-pr-merged.yml
@@ -1,0 +1,31 @@
+name: Discord PR merged
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          MERGED_BY: ${{ github.event.pull_request.merged_by.login }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL is not set; skipping Discord notification."
+            exit 0
+          fi
+          jq -n \
+            --arg title "Merged PR #${PR_NUMBER}" \
+            --arg desc "**${PR_TITLE}**"$'\n'"Author: @${PR_AUTHOR}"$'\n'"Merged by: @${MERGED_BY}" \
+            --arg url "$PR_URL" \
+            '{embeds: [{title: $title, description: $desc, url: $url, color: 5763719}]}' \
+          | curl -fsS -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/discord-pr-merged.yml
+++ b/.github/workflows/discord-pr-merged.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,3 +270,28 @@ jobs:
           echo "$OUTPUT" | grep -q "\"version\":\"${EXPECTED_VERSION}\"" \
             || { echo "::error::expected version ${EXPECTED_VERSION} not found in 'ios version' output"; exit 1; }
           echo "OK: go-ios@${EXPECTED_VERSION} installed and runs on ${{ matrix.os }}"
+
+  notify_discord:
+    needs: [prepare_version, release_and_publish, verify_install]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          VERSION: ${{ needs.prepare_version.outputs.version }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL is not set; skipping Discord notification."
+            exit 0
+          fi
+          NOTES="$(printf '%s' "$RELEASE_NOTES" | head -c 3500)"
+          jq -n \
+            --arg title "go-ios v${VERSION} released" \
+            --arg desc "$NOTES" \
+            --arg url "https://github.com/${REPO}/releases/tag/v${VERSION}" \
+            '{embeds: [{title: $title, description: $desc, url: $url, color: 3447003}]}' \
+          | curl -fsS -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ on:
 
 name: Release-Go-iOS
 
+permissions:
+  contents: read
+
 jobs:
   prepare_version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds Discord webhook notifications via GitHub Actions.

Changes:
- post a Discord embed when a PR is merged, using pull_request_target without checking out or running PR code
- post release notes to Discord after the release workflow publishes and verify_install succeeds
- read the webhook only from secrets.DISCORD_WEBHOOK_URL; no webhook URL is committed

Setup before/after merge:
- create or rotate the Discord webhook
- set the repository secret DISCORD_WEBHOOK_URL to the fresh webhook URL