### PR TITLE
fix: limit automatic tunnel lookup to RSD commands

### DIFF
--- a/cli_device_resolution.go
+++ b/cli_device_resolution.go
@@ -60,6 +60,10 @@ func resolveDevice(arguments docopt.Opts, tunnelInfo tunnelInfoConfig) ios.Devic
 		return deviceWithRsdProvider(device, udid, address, rsdPort)
 	}
 
+	if !needsAutomaticTunnelInfo(arguments) {
+		return device
+	}
+
 	info, err := tunnel.TunnelInfoForDevice(device.Properties.SerialNumber, tunnelInfo.Host, tunnelInfo.Port)
 	if err == nil {
 		device.UserspaceTUNPort = info.UserspaceTUNPort
@@ -70,4 +74,36 @@ func resolveDevice(arguments docopt.Opts, tunnelInfo tunnelInfoConfig) ios.Devic
 
 	slog.Warn("failed to get tunnel info", "udid", device.Properties.SerialNumber)
 	return device
+}
+
+func needsAutomaticTunnelInfo(args docopt.Opts) bool {
+	if boolArg(args, "rsd") || boolArg(args, "file") || boolArg(args, "webinspector") {
+		return true
+	}
+	if boolArg(args, "info") && boolArg(args, "display") {
+		return true
+	}
+
+	for _, commandName := range []string{
+		"debug",
+		"instruments",
+		"kill",
+		"launch",
+		"memlimitoff",
+		"ostrace",
+		"ps",
+		"runwda",
+		"runxctest",
+		"runtest",
+		"screenshot",
+		"setlocation",
+		"syslog",
+		"sysmontap",
+	} {
+		if boolArg(args, commandName) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/command_registry_test.go
+++ b/command_registry_test.go
@@ -57,3 +57,30 @@ func TestTunnelCommandMatcher(t *testing.T) {
 		t.Fatal("non-tunnel command matched")
 	}
 }
+
+func TestNeedsAutomaticTunnelInfo(t *testing.T) {
+	testCases := []struct {
+		name string
+		args docopt.Opts
+		want bool
+	}{
+		{name: "zoom stays tunnel-free", args: docopt.Opts{"zoom": true}, want: false},
+		{name: "voiceover stays tunnel-free", args: docopt.Opts{"voiceover": true}, want: false},
+		{name: "assistivetouch stays tunnel-free", args: docopt.Opts{"assistivetouch": true}, want: false},
+		{name: "timeformat stays tunnel-free", args: docopt.Opts{"timeformat": true}, want: false},
+		{name: "file needs tunnel", args: docopt.Opts{"file": true}, want: true},
+		{name: "rsd needs tunnel", args: docopt.Opts{"rsd": true}, want: true},
+		{name: "display info needs tunnel", args: docopt.Opts{"info": true, "display": true}, want: true},
+		{name: "plain info stays tunnel-free", args: docopt.Opts{"info": true}, want: false},
+		{name: "syslog needs tunnel when available", args: docopt.Opts{"syslog": true}, want: true},
+		{name: "runtest needs tunnel on iOS 17", args: docopt.Opts{"runtest": true}, want: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := needsAutomaticTunnelInfo(testCase.args); got != testCase.want {
+				t.Fatalf("needsAutomaticTunnelInfo() = %t, want %t", got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes a real CLI flake found by Linux real-device e2e.

Problem:
- resolveDevice opportunistically attached tunnel-agent RSD metadata to every device command.
- Lockdown/usbmux commands such as zoom could then inherit stale tunnel metadata.
- In PR #751 Linux e2e, TestZoomToggle failed because zoom enable tried to connect to a stale RSD endpoint ([fde1:b7b2:2888::1]:50003) and timed out.

Change:
- keep explicit --address/--rsd-port behavior unchanged
- only query the tunnel-info agent automatically for commands that actually use RSD/CoreDevice paths
- keep tunnel-free commands such as zoom, voiceover, assistivetouch, timeformat, and plain info on the usbmux path
- add unit coverage for the command classifier

Verification:
- go test .
- go test ./... passed before this was split onto the clean branch