### PR TITLE
fix(tunnel): use golog in UpdateTunnels error cleanup (fix build)

### DIFF
--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -278,8 +278,12 @@ func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 
 	devices, err := m.dl.ListDevices()
 	if err != nil {
+		// ListDevices can fail transiently while a device disconnects/reconnects
+		// (notably on Linux). Tear down the local tunnels so a stale one can't
+		// survive and block the device's next connection; they get recreated on
+		// the next successful update.
 		for udid, tun := range localTunnels {
-			log.WithField("udid", udid).Info("stopping tunnel due to device list error")
+			golog.Info("stopping tunnel due to device list error", "module", logModule, "udid", udid)
 			_ = m.stopTunnel(tun)
 		}
 		return fmt.Errorf("UpdateTunnels: failed to get list of devices: %w", err)


### PR DESCRIPTION
Hotfix: #691 merged with a logrus `log.WithField` call, but `ios/tunnel` is on the golog seam now and doesn't import logrus, so main stopped compiling (`undefined: log`). Switches to `golog` with module/udid attrs. Tunnel package builds and `go test ./ios/tunnel/...` passes.