### PR TITLE
fix(tunnel): devicestate/resetlocation/setlocationgpx need automatic tunnel info

### DIFF
--- a/cli_device_resolution.go
+++ b/cli_device_resolution.go
@@ -86,17 +86,20 @@ func needsAutomaticTunnelInfo(args docopt.Opts) bool {
 
 	for _, commandName := range []string{
 		"debug",
+		"devicestate",
 		"instruments",
 		"kill",
 		"launch",
 		"memlimitoff",
 		"ostrace",
 		"ps",
+		"resetlocation",
 		"runwda",
 		"runxctest",
 		"runtest",
 		"screenshot",
 		"setlocation",
+		"setlocationgpx",
 		"syslog",
 		"sysmontap",
 	} {

--- a/command_registry_test.go
+++ b/command_registry_test.go
@@ -74,6 +74,9 @@ func TestNeedsAutomaticTunnelInfo(t *testing.T) {
 		{name: "plain info stays tunnel-free", args: docopt.Opts{"info": true}, want: false},
 		{name: "syslog needs tunnel when available", args: docopt.Opts{"syslog": true}, want: true},
 		{name: "runtest needs tunnel on iOS 17", args: docopt.Opts{"runtest": true}, want: true},
+		{name: "devicestate needs tunnel (instruments)", args: docopt.Opts{"devicestate": true}, want: true},
+		{name: "resetlocation needs tunnel (instruments)", args: docopt.Opts{"resetlocation": true}, want: true},
+		{name: "setlocationgpx needs tunnel (instruments)", args: docopt.Opts{"setlocationgpx": true}, want: true},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Follow-up to #753. Its `needsAutomaticTunnelInfo` allow-list omitted three instruments-backed commands that need the tunnel on iOS 17+, so they regressed:
- `devicestate` (`instruments.NewDeviceStateControl`) — broke `devicestate list`/`enable` (exit status 1, caught by e2e)
- `resetlocation` and `setlocationgpx` (simlocation / LocationSimulation), siblings of `setlocation` which was already in the list

Adds them and extends `TestNeedsAutomaticTunnelInfo`.