### PR TITLE
Run signing e2e every PR via a refreshed shared signing identity

### DIFF
--- a/.github/workflows/real-device.yml
+++ b/.github/workflows/real-device.yml
@@ -61,6 +61,11 @@ jobs:
           GO_IOS_E2E_DEVICES: ${{ vars[matrix.devices] }}
           GO_IOS_E2E_ASC_KEY_ID: ${{ secrets.GO_IOS_E2E_ASC_KEY_ID }}
           GO_IOS_E2E_ASC_ISSUER_ID: ${{ secrets.GO_IOS_E2E_ASC_ISSUER_ID }}
+          # Shared signing identity refreshed by refresh-signing-identity.yml; the
+          # signing tests mint per-bundle profiles against it instead of creating
+          # certificates (Apple allows only one development certificate).
+          GO_IOS_E2E_SIGNING_P12_B64: ${{ secrets.GO_IOS_E2E_SIGNING_P12_B64 }}
+          GO_IOS_E2E_SIGNING_CERT_ID: ${{ secrets.GO_IOS_E2E_SIGNING_CERT_ID }}
           GO_IOS_E2E_WDA_ARTIFACT_URL: ${{ vars.GO_IOS_E2E_WDA_ARTIFACT_URL }}
           GO_IOS_E2E_DEVICEKIT_ARTIFACT_URL: ${{ vars.GO_IOS_E2E_DEVICEKIT_ARTIFACT_URL }}
           GO_IOS_E2E_WDA_BUNDLE_ID: ${{ vars.GO_IOS_E2E_WDA_BUNDLE_ID }}

--- a/.github/workflows/refresh-signing-identity.yml
+++ b/.github/workflows/refresh-signing-identity.yml
@@ -1,0 +1,84 @@
+# Re-provisions the shared App Store Connect signing identity used by the
+# real-device signing e2e and publishes it as repo secrets:
+#   - GO_IOS_E2E_SIGNING_P12_B64  (base64 of the .p12: certificate + private key)
+#   - GO_IOS_E2E_SIGNING_CERT_ID  (the certificate's App Store Connect resource id)
+#
+# Apple permits only one current iOS Development certificate, so creating one per
+# CI run hits a 409. Instead this job creates the single certificate (revoking any
+# existing one first) on a schedule, and the e2e mints per-bundle provisioning
+# profiles against it via `ios sign provision appstoreconnect --certificate-id`
+# — no certificate creation in CI, so the signing tests stay parallel.
+#
+# Runs on a GitHub-hosted runner: minting a certificate needs no device, and the
+# runner has `gh` for writing the secrets. Requires a SIGNING_SECRET_WRITER_PAT
+# secret (a PAT with Secrets: write — the default GITHUB_TOKEN cannot manage
+# secrets). Daily, off-peak, so it won't revoke the certificate while a PR's
+# signing test is using it.
+name: Refresh signing identity
+
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: refresh-signing-identity
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh signing identity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install libusb
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev
+
+      - name: Build ios
+        run: go build -o "$RUNNER_TEMP/ios" .
+
+      - name: Prepare App Store Connect API key
+        env:
+          GO_IOS_E2E_ASC_PRIVATE_KEY_B64: ${{ secrets.GO_IOS_E2E_ASC_PRIVATE_KEY_B64 }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/asc"
+          printf '%s' "$GO_IOS_E2E_ASC_PRIVATE_KEY_B64" | base64 --decode > "$RUNNER_TEMP/asc/AuthKey.p8"
+
+      - name: Provision a fresh signing certificate
+        id: provision
+        env:
+          ASC_KEY_ID: ${{ secrets.GO_IOS_E2E_ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.GO_IOS_E2E_ASC_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          log="$RUNNER_TEMP/provision.log"
+          "$RUNNER_TEMP/ios" sign certificate appstoreconnect \
+            --revoke-existing \
+            --p12password=go-ios-e2e \
+            --p12-output="$RUNNER_TEMP/identity.p12" \
+            --asc-key-id="$ASC_KEY_ID" \
+            --asc-issuer-id="$ASC_ISSUER_ID" \
+            --asc-private-key="$RUNNER_TEMP/asc/AuthKey.p8" 2> "$log"
+          cat "$log"
+          certid="$(grep '"msg":"created signing certificate"' "$log" | tail -1 | sed -E 's/.*"certificateID":"([^"]*)".*/\1/')"
+          if [ -z "$certid" ]; then echo "could not determine certificate id"; exit 1; fi
+          echo "certid=$certid" >> "$GITHUB_OUTPUT"
+
+      - name: Publish identity to repo secrets
+        env:
+          GH_TOKEN: ${{ secrets.SIGNING_SECRET_WRITER_PAT }}
+          CERT_ID: ${{ steps.provision.outputs.certid }}
+        run: |
+          set -euo pipefail
+          base64 -w0 "$RUNNER_TEMP/identity.p12" | gh secret set GO_IOS_E2E_SIGNING_P12_B64 --repo "$GITHUB_REPOSITORY"
+          printf '%s' "$CERT_ID" | gh secret set GO_IOS_E2E_SIGNING_CERT_ID --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,5 +75,8 @@ jobs:
     needs: [lint, test_on_windows, test_on_linux]
     if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/real-device.yml
+    # Pass repo secrets (App Store Connect signing keys etc.) into the reusable
+    # workflow so the opt-in signing e2e actually runs instead of skipping.
+    secrets: inherit
     permissions:
       contents: read

--- a/cmd_device_signing.go
+++ b/cmd_device_signing.go
@@ -18,6 +18,30 @@ func runSignCommand(ctx commandContext) {
 	}
 }
 
+// runSignCertificateAppStoreConnectCommand creates a single iOS Development
+// certificate + P12 through App Store Connect. It needs no device, so it is
+// dispatched as a global command and can run on a hosted CI runner to mint the
+// shared signing identity.
+func runSignCertificateAppStoreConnectCommand(ctx commandContext) {
+	p12Password, _ := ctx.Args.String("--p12password")
+	p12Output, _ := ctx.Args.String("--p12-output")
+	keyID, _ := ctx.Args.String("--asc-key-id")
+	issuerID, _ := ctx.Args.String("--asc-issuer-id")
+	privateKeyPath, _ := ctx.Args.String("--asc-private-key")
+	revokeExisting, _ := ctx.Args.Bool("--revoke-existing")
+	creds, err := signing.LoadAppStoreConnectCredentials(keyID, issuerID, privateKeyPath)
+	exitIfError("failed loading App Store Connect credentials", err)
+
+	result, err := signing.PrepareCertificate(context.Background(), signing.PrepareCertificateOptions{
+		P12Password:    p12Password,
+		P12Output:      p12Output,
+		Credentials:    creds,
+		RevokeExisting: revokeExisting,
+	})
+	exitIfError("failed creating signing certificate", err)
+	slog.Info("created signing certificate", "p12", result.P12Path, "certificateID", result.CertificateID)
+}
+
 func runSignProvisionAppStoreConnectCommand(ctx commandContext) {
 	bundleID, _ := ctx.Args.String("--bundleid")
 	bundleName, _ := ctx.Args.String("--bundle-name")
@@ -30,22 +54,26 @@ func runSignProvisionAppStoreConnectCommand(ctx commandContext) {
 	keyID, _ := ctx.Args.String("--asc-key-id")
 	issuerID, _ := ctx.Args.String("--asc-issuer-id")
 	privateKeyPath, _ := ctx.Args.String("--asc-private-key")
+	revokeExisting, _ := ctx.Args.Bool("--revoke-existing")
+	certificateID, _ := ctx.Args.String("--certificate-id")
 	creds, err := signing.LoadAppStoreConnectCredentials(keyID, issuerID, privateKeyPath)
 	exitIfError("failed loading App Store Connect credentials", err)
 
 	result, err := signing.PrepareSigningAssets(context.Background(), signing.PrepareAssetsOptions{
-		BundleID:    bundleID,
-		BundleName:  bundleName,
-		ProfileName: profileName,
-		DeviceName:  deviceName,
-		P12Password: p12Password,
-		P12Output:   p12Output,
-		ProfileOut:  profileOutput,
-		Credentials: creds,
-		Device:      ctx.Device,
+		BundleID:       bundleID,
+		BundleName:     bundleName,
+		ProfileName:    profileName,
+		DeviceName:     deviceName,
+		P12Password:    p12Password,
+		P12Output:      p12Output,
+		ProfileOut:     profileOutput,
+		Credentials:    creds,
+		Device:         ctx.Device,
+		RevokeExisting: revokeExisting,
+		CertificateID:  certificateID,
 	})
 	exitIfError("failed creating signing assets", err)
-	slog.Info("created signing assets", "bundleID", result.BundleID, "p12", result.P12Path, "profile", result.ProfilePath, "udid", ctx.Device.Properties.SerialNumber)
+	slog.Info("created signing assets", "bundleID", result.BundleID, "p12", result.P12Path, "profile", result.ProfilePath, "certificateID", result.CertificateID, "udid", ctx.Device.Properties.SerialNumber)
 }
 
 func runSignAppCommand(ctx commandContext) {

--- a/cmd_global.go
+++ b/cmd_global.go
@@ -28,6 +28,15 @@ var globalCommands = []command{
 		match: isDeviceListCommand,
 		run:   runDeviceListCommand,
 	},
+	{
+		// `sign certificate appstoreconnect` mints an account-wide certificate and
+		// needs no device, so it is global (dispatched before device resolution).
+		name: "sign certificate",
+		match: func(args docopt.Opts) bool {
+			return boolArg(args, "sign") && boolArg(args, "certificate")
+		},
+		run: runSignCertificateAppStoreConnectCommand,
+	},
 }
 
 func runListenCommand(ctx commandContext) {

--- a/ios/signing/appstoreconnect.go
+++ b/ios/signing/appstoreconnect.go
@@ -169,6 +169,25 @@ func (c *AppStoreConnectClient) CreateCertificate(ctx context.Context, csrPEM []
 	return resp.Data.ID, certDER, nil
 }
 
+// ListDevelopmentCertificates returns the account's IOS_DEVELOPMENT certificates.
+// Apple allows only one current certificate of this type, so listing is used to
+// revoke an existing one before creating a fresh certificate.
+func (c *AppStoreConnectClient) ListDevelopmentCertificates(ctx context.Context) ([]jsonAPIResource, error) {
+	var list jsonAPIListResponse
+	q := url.Values{}
+	q.Set("filter[certificateType]", "IOS_DEVELOPMENT")
+	q.Set("limit", "200")
+	if err := c.do(ctx, http.MethodGet, "/v1/certificates?"+q.Encode(), nil, &list); err != nil {
+		return nil, err
+	}
+	return list.Data, nil
+}
+
+// RevokeCertificate revokes (deletes) the certificate with the given resource ID.
+func (c *AppStoreConnectClient) RevokeCertificate(ctx context.Context, id string) error {
+	return c.do(ctx, http.MethodDelete, "/v1/certificates/"+url.PathEscape(id), nil, nil)
+}
+
 func (c *AppStoreConnectClient) CreateDevelopmentProfile(ctx context.Context, name, bundleID, certID, deviceID string) ([]byte, error) {
 	req := map[string]interface{}{
 		"data": map[string]interface{}{

--- a/ios/signing/signing.go
+++ b/ios/signing/signing.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aluedeke/go-codesign/pkg/codesign"
 	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/golog"
 	"software.sslmate.com/src/go-pkcs12"
 )
 
@@ -41,6 +42,17 @@ type PrepareAssetsOptions struct {
 	ProfileOut  string
 	Credentials AppStoreConnectCredentials
 	Device      ios.DeviceEntry
+	// RevokeExisting revokes every existing iOS Development certificate before
+	// creating a new one. Apple allows only one current certificate of that type,
+	// so without this a second create fails with a 409. Intended for a dedicated
+	// (CI) account where the signing identity is disposable.
+	RevokeExisting bool
+	// CertificateID, when set, provisions a profile against an existing
+	// certificate (by App Store Connect resource id) instead of creating a new
+	// one. No certificate is created or revoked and no P12 is written — the caller
+	// already holds the matching P12. This lets CI mint per-bundle profiles in
+	// parallel against one shared, pre-provisioned certificate.
+	CertificateID string
 }
 
 type PrepareAndSignResult struct {
@@ -54,6 +66,24 @@ type PrepareAssetsResult struct {
 	P12Path     string
 	ProfilePath string
 	BundleID    string
+	// CertificateID is the App Store Connect resource id of the certificate used
+	// (created, or reused via PrepareAssetsOptions.CertificateID). Store it so
+	// later profile-only provisioning can reference the same certificate.
+	CertificateID string
+}
+
+type PrepareCertificateOptions struct {
+	P12Password string
+	P12Output   string
+	Credentials AppStoreConnectCredentials
+	// RevokeExisting revokes every existing iOS Development certificate first; see
+	// PrepareAssetsOptions.RevokeExisting.
+	RevokeExisting bool
+}
+
+type PrepareCertificateResult struct {
+	P12Path       string
+	CertificateID string
 }
 
 type SignWithFilesOptions struct {
@@ -138,10 +168,6 @@ func PrepareSigningAssets(ctx context.Context, opts PrepareAssetsOptions) (Prepa
 		opts.ProfileName = fmt.Sprintf("go-ios %s %s", opts.BundleID, time.Now().UTC().Format("20060102150405"))
 	}
 
-	privateKey, csrPEM, err := GenerateCertificateRequest("go-ios " + opts.BundleID)
-	if err != nil {
-		return PrepareAssetsResult{}, err
-	}
 	client := NewAppStoreConnectClient(opts.Credentials)
 
 	bundleResourceID, err := client.EnsureBundleID(ctx, opts.BundleID, opts.BundleName)
@@ -152,34 +178,109 @@ func PrepareSigningAssets(ctx context.Context, opts PrepareAssetsOptions) (Prepa
 	if err != nil {
 		return PrepareAssetsResult{}, fmt.Errorf("failed ensuring device: %w", err)
 	}
-	certificateResourceID, certDER, err := client.CreateCertificate(ctx, csrPEM)
-	if err != nil {
-		return PrepareAssetsResult{}, fmt.Errorf("failed creating certificate: %w", err)
-	}
-	profile, err := client.CreateDevelopmentProfile(ctx, opts.ProfileName, bundleResourceID, certificateResourceID, deviceResourceID)
-	if err != nil {
-		return PrepareAssetsResult{}, fmt.Errorf("failed creating provisioning profile: %w", err)
+
+	result := PrepareAssetsResult{ProfilePath: opts.ProfileOut, BundleID: opts.BundleID, CertificateID: opts.CertificateID}
+
+	// Reuse mode: provision a profile against an existing certificate. No
+	// certificate is created/revoked and no P12 is written.
+	if opts.CertificateID == "" {
+		privateKey, csrPEM, err := GenerateCertificateRequest("go-ios " + opts.BundleID)
+		if err != nil {
+			return PrepareAssetsResult{}, err
+		}
+		if opts.RevokeExisting {
+			if err := revokeAllDevelopmentCertificates(ctx, client); err != nil {
+				return PrepareAssetsResult{}, fmt.Errorf("failed revoking existing certificates: %w", err)
+			}
+		}
+		certificateResourceID, certDER, err := client.CreateCertificate(ctx, csrPEM)
+		if err != nil {
+			return PrepareAssetsResult{}, fmt.Errorf("failed creating certificate: %w", err)
+		}
+		result.CertificateID = certificateResourceID
+
+		cert, err := x509.ParseCertificate(certDER)
+		if err != nil {
+			return PrepareAssetsResult{}, fmt.Errorf("failed parsing Apple certificate: %w", err)
+		}
+		p12, err := pkcs12.Encode(rand.Reader, privateKey, cert, nil, opts.P12Password)
+		if err != nil {
+			return PrepareAssetsResult{}, fmt.Errorf("failed encoding P12: %w", err)
+		}
+		if err := writeFile(opts.P12Output, p12, 0600); err != nil {
+			return PrepareAssetsResult{}, err
+		}
+		result.P12Path = opts.P12Output
 	}
 
-	cert, err := x509.ParseCertificate(certDER)
+	profile, err := client.CreateDevelopmentProfile(ctx, opts.ProfileName, bundleResourceID, result.CertificateID, deviceResourceID)
 	if err != nil {
-		return PrepareAssetsResult{}, fmt.Errorf("failed parsing Apple certificate: %w", err)
-	}
-	p12, err := pkcs12.Encode(rand.Reader, privateKey, cert, nil, opts.P12Password)
-	if err != nil {
-		return PrepareAssetsResult{}, fmt.Errorf("failed encoding P12: %w", err)
-	}
-	if err := writeFile(opts.P12Output, p12, 0600); err != nil {
-		return PrepareAssetsResult{}, err
+		return PrepareAssetsResult{}, fmt.Errorf("failed creating provisioning profile: %w", err)
 	}
 	if err := writeFile(opts.ProfileOut, profile, 0644); err != nil {
 		return PrepareAssetsResult{}, err
 	}
-	return PrepareAssetsResult{
-		P12Path:     opts.P12Output,
-		ProfilePath: opts.ProfileOut,
-		BundleID:    opts.BundleID,
-	}, nil
+	return result, nil
+}
+
+// PrepareCertificate creates one iOS Development certificate and writes its P12
+// (certificate + private key). Unlike PrepareSigningAssets it needs no device,
+// bundle id, or provisioning profile — it is the account-wide half of signing,
+// used to mint the shared identity that profile-only provisioning
+// (PrepareAssetsOptions.CertificateID) then reuses. Because it needs no device it
+// can run on a hosted CI runner.
+func PrepareCertificate(ctx context.Context, opts PrepareCertificateOptions) (PrepareCertificateResult, error) {
+	if opts.P12Output == "" {
+		opts.P12Output = "identity.p12"
+	}
+	privateKey, csrPEM, err := GenerateCertificateRequest("go-ios signing identity")
+	if err != nil {
+		return PrepareCertificateResult{}, err
+	}
+	client := NewAppStoreConnectClient(opts.Credentials)
+	if opts.RevokeExisting {
+		if err := revokeAllDevelopmentCertificates(ctx, client); err != nil {
+			return PrepareCertificateResult{}, fmt.Errorf("failed revoking existing certificates: %w", err)
+		}
+	}
+	certificateResourceID, certDER, err := client.CreateCertificate(ctx, csrPEM)
+	if err != nil {
+		return PrepareCertificateResult{}, fmt.Errorf("failed creating certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return PrepareCertificateResult{}, fmt.Errorf("failed parsing Apple certificate: %w", err)
+	}
+	p12, err := pkcs12.Encode(rand.Reader, privateKey, cert, nil, opts.P12Password)
+	if err != nil {
+		return PrepareCertificateResult{}, fmt.Errorf("failed encoding P12: %w", err)
+	}
+	if err := writeFile(opts.P12Output, p12, 0600); err != nil {
+		return PrepareCertificateResult{}, err
+	}
+	return PrepareCertificateResult{P12Path: opts.P12Output, CertificateID: certificateResourceID}, nil
+}
+
+// revokeAllDevelopmentCertificates revokes every IOS_DEVELOPMENT certificate on
+// the account. Apple permits only one current certificate of this type, and a
+// leftover one (whatever its name) blocks creating a new one, so a reliable
+// "create a fresh certificate" needs to clear them all first. Only use this on a
+// dedicated signing account — it does not discriminate by name.
+func revokeAllDevelopmentCertificates(ctx context.Context, client *AppStoreConnectClient) error {
+	certs, err := client.ListDevelopmentCertificates(ctx)
+	if err != nil {
+		return err
+	}
+	for _, cert := range certs {
+		name, _ := cert.Attributes["name"].(string)
+		displayName, _ := cert.Attributes["displayName"].(string)
+		golog.Info("revoking existing iOS Development certificate",
+			"module", logModule, "id", cert.ID, "name", name, "displayName", displayName)
+		if err := client.RevokeCertificate(ctx, cert.ID); err != nil {
+			return fmt.Errorf("revoking certificate %s: %w", cert.ID, err)
+		}
+	}
+	return nil
 }
 
 func SignWithFiles(opts SignWithFilesOptions) (SignWithFilesResult, error) {

--- a/main.go
+++ b/main.go
@@ -139,7 +139,8 @@ Usage:
   ios runwda [--bundleid=<bundleid>] [--testrunnerbundleid=<testbundleid>] [--xctestconfig=<xctestconfig>] [--log-output=<file>] [--arg=<a>]... [--env=<e>]... [options]
   ios runxctest [--xctestrun-file-path=<xctestrunFilePath>] [--log-output=<file>] [options]
   ios screenshot [options] [--output=<outfile>] [--stream] [--port=<port>]
-  ios sign provision appstoreconnect --bundleid=<bundleid> --asc-key-id=<keyid> --asc-issuer-id=<issuerid> --asc-private-key=<p8file> --p12-output=<p12file> --profile-output=<mobileprovision> [--p12password=<password>] [--bundle-name=<name>] [--profile-name=<name>] [--device-name=<name>] [options]
+  ios sign certificate appstoreconnect --asc-key-id=<keyid> --asc-issuer-id=<issuerid> --asc-private-key=<p8file> [--p12-output=<p12file>] [--p12password=<password>] [--revoke-existing] [options]
+  ios sign provision appstoreconnect --bundleid=<bundleid> --asc-key-id=<keyid> --asc-issuer-id=<issuerid> --asc-private-key=<p8file> --profile-output=<mobileprovision> [--p12-output=<p12file>] [--certificate-id=<id>] [--revoke-existing] [--p12password=<password>] [--bundle-name=<name>] [--profile-name=<name>] [--device-name=<name>] [options]
   ios sign app --path=<ipaOrAppFolder> --p12file=<p12file> --profile=<mobileprovision> [--p12password=<password>] [--output=<signedPath>] [--bundleid=<bundleid>] [--install] [options]
   ios setlocation [options] [--lat=<lat>] [--lon=<lon>]
   ios setlocationgpx [options] [--gpxfilepath=<gpxfilepath>]
@@ -213,6 +214,8 @@ Options:
                             App Store Connect API issuer id. Can also be set via GO_IOS_ASC_ISSUER_ID.
   --asc-private-key=<p8file>
                             App Store Connect API .p8 private key path. Can also be set via GO_IOS_ASC_PRIVATE_KEY.
+  --revoke-existing         Revoke every existing iOS Development certificate before creating a new one. Apple allows only one current development certificate, so set this to keep provisioning repeatable (use only on a dedicated signing account, e.g. CI).
+  --certificate-id=<id>     Provision a profile against an existing App Store Connect certificate (by resource id) instead of creating one. No certificate is created/revoked and no P12 is written; reuse a pre-provisioned signing identity.
   --p12file=<p12file>       P12 identity file path.
   --profile=<mobileprovision>
                             Provisioning profile path for app signing.
@@ -425,7 +428,7 @@ The commands work as following:
 
     ios sign provision appstoreconnect --bundleid=<bundleid> --asc-key-id=<keyid> --asc-issuer-id=<issuerid> --asc-private-key=<p8file> --p12-output=<p12file> --profile-output=<mobileprovision>
                                                                     Creates an iOS development signing certificate, P12, and provisioning profile through App Store Connect.
-                                                                    This command does not sign an app.
+                                                                    This command does not sign an app. Pass --revoke-existing to revoke a leftover go-ios certificate first (repeatable provisioning).
 
     ios sign app --path=<ipaOrAppFolder> --p12file=<p12file> --profile=<mobileprovision>
                                                                     Resigns the IPA or .app with go-codesign using local signing files,

--- a/test/e2e/wda_ui_test.go
+++ b/test/e2e/wda_ui_test.go
@@ -15,6 +15,7 @@ package e2e_test
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/base64"
 	"io"
 	"net/http"
 	"os"
@@ -246,12 +247,35 @@ func appStoreConnectCredentials(t *testing.T) (string, string, string) {
 	return ascKeyID, ascIssuerID, ascPrivateKey
 }
 
+// provisionSigningAssets returns a (p12, profile) pair for signing/installing
+// the given bundle. It reuses the shared signing identity refreshed by the
+// refresh-signing-identity workflow and published as secrets
+// (GO_IOS_E2E_SIGNING_P12_B64 + GO_IOS_E2E_SIGNING_CERT_ID): the P12 comes
+// straight from the secret and only a per-bundle provisioning profile is minted
+// against that existing certificate. No certificate is created here, so the
+// tests never hit Apple's "one development certificate" limit and run in
+// parallel.
 func provisionSigningAssets(t *testing.T, udid string, bundleID string, label string) (string, string) {
 	t.Helper()
 	ascKeyID, ascIssuerID, ascPrivateKey := appStoreConnectCredentials(t)
+
+	p12B64 := e2eEnv("GO_IOS_E2E_SIGNING_P12_B64")
+	certID := e2eEnv("GO_IOS_E2E_SIGNING_CERT_ID")
+	if p12B64 == "" || certID == "" {
+		t.Skip("set GO_IOS_E2E_SIGNING_P12_B64 and GO_IOS_E2E_SIGNING_CERT_ID (refreshed by the refresh-signing-identity workflow) to run signing e2e")
+	}
+	p12, err := base64.StdEncoding.DecodeString(strings.TrimSpace(p12B64))
+	if err != nil {
+		t.Fatalf("decode GO_IOS_E2E_SIGNING_P12_B64: %v", err)
+	}
+
 	tempDir := t.TempDir()
-	p12Path := filepath.Join(tempDir, strings.ToLower(strings.ReplaceAll(label, " ", "-"))+".p12")
-	profilePath := filepath.Join(tempDir, strings.ToLower(strings.ReplaceAll(label, " ", "-"))+".mobileprovision")
+	slug := strings.ToLower(strings.ReplaceAll(label, " ", "-"))
+	p12Path := filepath.Join(tempDir, slug+".p12")
+	if err := os.WriteFile(p12Path, p12, 0600); err != nil {
+		t.Fatalf("write p12: %v", err)
+	}
+	profilePath := filepath.Join(tempDir, slug+".mobileprovision")
 
 	runIOSForDevice(t, udid,
 		"sign", "provision", "appstoreconnect",
@@ -259,9 +283,8 @@ func provisionSigningAssets(t *testing.T, udid string, bundleID string, label st
 		"--bundle-name=go-ios "+label,
 		"--profile-name=go-ios "+label+" "+time.Now().UTC().Format("20060102150405"),
 		"--device-name=go-ios-e2e-"+udid,
-		"--p12password=go-ios-e2e",
-		"--p12-output="+p12Path,
 		"--profile-output="+profilePath,
+		"--certificate-id="+certID,
 		"--asc-key-id="+ascKeyID,
 		"--asc-issuer-id="+ascIssuerID,
 		"--asc-private-key="+ascPrivateKey,


### PR DESCRIPTION
## What
Make the App Store Connect signing e2e run on **every same-repo PR** (they've been silently skipping — `real-device.yml` was called without `secrets: inherit`), and stop them 409-ing on Apple's "one iOS Development certificate" limit by decoupling CI from certificate creation.

- **New deviceless `ios sign certificate appstoreconnect`** (global command): mints just a cert + P12 (no device/bundle/profile), so it runs on a hosted runner. `--revoke-existing` clears all `IOS_DEVELOPMENT` certs first.
- **`refresh-signing-identity.yml`** (scheduled, `ubuntu-latest`): runs that command and publishes the `.p12` + cert resource id as repo secrets `GO_IOS_E2E_SIGNING_P12_B64` / `GO_IOS_E2E_SIGNING_CERT_ID`. Hosted runner ⇒ `gh` preinstalled, no device needed.
- **`ios sign provision appstoreconnect --certificate-id=<id>`**: mints a profile against an existing cert (no cert created/revoked, no P12). 
- **E2e** pulls the stored `.p12` and only mints a per-bundle profile against the shared cert → creates no certificates, runs **in parallel** (dropped the serializing mutex).
- **`test.yml`** gets `secrets: inherit` (same-repo PRs only; fork PRs still get nothing).

## ⚠️ Required setup (one-time)
1. **`SIGNING_SECRET_WRITER_PAT`** — a PAT with **Secrets: write**, saved as a repo secret (the default `GITHUB_TOKEN` can't write secrets).
2. **Merge this PR**, then run **`refresh-signing-identity`** once (Actions → Run workflow — it must be on the default branch to dispatch). That populates the two signing secrets.

Until the secrets exist the signing tests **skip cleanly** (so this PR's CI stays green without them).

## Validation
Build, `go test ./ios/signing/... .`, `go vet -tags=e2e`, gofmt, and docopt parsing of all modes pass locally; the deviceless command was confirmed not to require a device. The ASC calls themselves are validated by the first `refresh-signing-identity` run + the next PR's signing run.
