### PR TITLE
forward: race-free teardown + concurrent -race tests

### DIFF
--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -101,20 +101,46 @@ func StartNewProxyConnection(ctx context.Context, clientConn io.ReadWriteCloser,
 	golog.Info("connected to port", "module", logModule, "deviceID", deviceID, "conn", fmt.Sprintf("%#v", clientConn), "phonePort", phonePort)
 	deviceConn := usbmuxConn.ReleaseDeviceConnection()
 
-	// proxyConn := iosproxy{clientConn, deviceConn}
-	ctx2, cancel := context.WithCancel(ctx)
-	var wg sync.WaitGroup
+	proxyConns(ctx, clientConn, deviceConn, deviceID, phonePort)
+	return nil
+}
 
-	closed := false
-	copyAndClose := func(dst io.Writer, src io.Reader, msg string) {
-		defer wg.Done()
-		_, err := io.Copy(dst, src)
-		if ctx2.Err() == nil {
+// deviceRWConn is the subset of ios.DeviceConnectionInterface that the proxy
+// pump needs. Narrowing it to this lets proxyConns be exercised with in-memory
+// pipes in tests, without standing up a usbmux/device connection.
+type deviceRWConn interface {
+	Reader() io.Reader
+	Writer() io.Writer
+	Close() error
+}
+
+// proxyConns is the device-free core of the forward: it pumps bytes in both
+// directions between clientConn and deviceConn until either side closes (or ctx
+// is cancelled), then tears both down exactly once and waits for both copy
+// goroutines to finish. Teardown is funnelled through a sync.Once so the two
+// copiers and the ctx watcher can all race to close without a data race or a
+// double-close, and so it returns with no goroutines left running.
+func proxyConns(ctx context.Context, clientConn io.ReadWriteCloser, deviceConn deviceRWConn, deviceID int, phonePort uint16) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Closing the conns unblocks whichever io.Copy is still parked in a read,
+	// and cancel() releases the watcher below. sync.Once makes this safe to
+	// call from all three goroutines concurrently.
+	var once sync.Once
+	teardown := func() {
+		once.Do(func() {
 			cancel()
 			clientConn.Close()
 			deviceConn.Close()
-			closed = true
-		}
+		})
+	}
+
+	var wg sync.WaitGroup
+	copyAndClose := func(dst io.Writer, src io.Reader, msg string) {
+		defer wg.Done()
+		_, err := io.Copy(dst, src)
+		teardown()
 
 		if err == nil || errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
 			golog.Debug(msg, "module", logModule, "deviceID", deviceID, "phonePort", phonePort)
@@ -123,20 +149,13 @@ func StartNewProxyConnection(ctx context.Context, clientConn io.ReadWriteCloser,
 		}
 	}
 
-	wg.Add(1)
+	wg.Add(2)
 	go copyAndClose(clientConn, deviceConn.Reader(), "forward: close clientConn <-- deviceConn")
-
-	wg.Add(1)
 	go copyAndClose(deviceConn.Writer(), clientConn, "forward: close clientConn --> deviceConn")
 
-	<-ctx2.Done()
-	if !closed {
-		clientConn.Close()
-		deviceConn.Close()
-	}
-
+	<-ctx.Done()
+	teardown()
 	wg.Wait()
-	return nil
 }
 
 func (proxyConn *iosproxy) Close() {

--- a/ios/forward/forward_test.go
+++ b/ios/forward/forward_test.go
@@ -1,0 +1,211 @@
+package forward
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeDeviceConn adapts a net.Conn to the deviceRWConn interface so proxyConns
+// can be driven by an in-memory net.Pipe instead of a real usbmux/device
+// connection. The far end of the pipe stands in for "the device".
+type fakeDeviceConn struct{ c net.Conn }
+
+func (f fakeDeviceConn) Reader() io.Reader { return f.c }
+func (f fakeDeviceConn) Writer() io.Writer { return f.c }
+func (f fakeDeviceConn) Close() error      { return f.c.Close() }
+
+// newProxySession wires up a proxyConns instance over two net.Pipes and returns
+// the test-side ends plus a cancel func and a done channel that closes when
+// proxyConns returns. clientSide writes/reads as the host client; deviceSide
+// writes/reads as the device.
+func newProxySession(t *testing.T) (clientSide, deviceSide net.Conn, cancel context.CancelFunc, done chan struct{}) {
+	t.Helper()
+	clientSide, clientConn := net.Pipe()
+	deviceSide, deviceConn := net.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	done = make(chan struct{})
+	go func() {
+		proxyConns(ctx, clientConn, fakeDeviceConn{deviceConn}, 1, 8100)
+		close(done)
+	}()
+	return clientSide, deviceSide, cancel, done
+}
+
+// awaitReturn fails the test if proxyConns does not return promptly — i.e. if a
+// teardown path leaks a goroutine.
+func awaitReturn(t *testing.T, done chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("proxyConns leaked: %s did not return", what)
+	}
+}
+
+// TestProxyConnsBidirectional verifies bytes flow both directions through the
+// pump, and that it tears down cleanly when the client side closes.
+func TestProxyConnsBidirectional(t *testing.T) {
+	clientSide, deviceSide, cancel, done := newProxySession(t)
+	defer cancel()
+
+	// client -> device
+	go func() { _, _ = clientSide.Write([]byte("ping")) }()
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(deviceSide, buf); err != nil {
+		t.Fatalf("device read: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("client->device: got %q want %q", buf, "ping")
+	}
+
+	// device -> client
+	go func() { _, _ = deviceSide.Write([]byte("pong")) }()
+	if _, err := io.ReadFull(clientSide, buf); err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	if string(buf) != "pong" {
+		t.Fatalf("device->client: got %q want %q", buf, "pong")
+	}
+
+	// Closing the client end must tear the whole session down.
+	clientSide.Close()
+	awaitReturn(t, done, "client close")
+}
+
+// TestProxyConnsCtxCancelTeardown verifies cancelling the parent context tears
+// the session down and returns, even with no IO in flight.
+func TestProxyConnsCtxCancelTeardown(t *testing.T) {
+	_, _, cancel, done := newProxySession(t)
+	cancel()
+	awaitReturn(t, done, "ctx cancel")
+}
+
+// TestProxyConnsDeviceCloseTeardown verifies the device side closing tears the
+// session down and returns.
+func TestProxyConnsDeviceCloseTeardown(t *testing.T) {
+	_, deviceSide, cancel, done := newProxySession(t)
+	defer cancel()
+	deviceSide.Close()
+	awaitReturn(t, done, "device close")
+}
+
+// TestProxyConnsSimultaneousTeardown hammers the teardown path: for many
+// iterations it fires ctx-cancel, client-close and device-close all at once at
+// a freshly started session. Run under -race this is the strongest check that
+// the three concurrent teardown routes don't race or double-close.
+func TestProxyConnsSimultaneousTeardown(t *testing.T) {
+	for i := 0; i < 300; i++ {
+		clientSide, deviceSide, cancel, done := newProxySession(t)
+
+		var start sync.WaitGroup
+		start.Add(1)
+		var racers sync.WaitGroup
+		for _, fn := range []func(){
+			func() { cancel() },
+			func() { clientSide.Close() },
+			func() { deviceSide.Close() },
+		} {
+			racers.Add(1)
+			go func(f func()) {
+				defer racers.Done()
+				start.Wait() // line all three up to fire together
+				f()
+			}(fn)
+		}
+		start.Done()
+		racers.Wait()
+
+		awaitReturn(t, done, "simultaneous teardown")
+		cancel()
+	}
+}
+
+// TestProxyConnsConcurrentHammer runs many sessions in parallel, each pushing a
+// little traffic and then tearing down via a different route, so io.Copy is
+// genuinely mid-flight when teardown hits. The goal is to surface any residual
+// race or goroutine leak across the whole forward pump under -race.
+func TestProxyConnsConcurrentHammer(t *testing.T) {
+	const sessions = 400
+	var wg sync.WaitGroup
+	for i := 0; i < sessions; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			clientSide, deviceSide, cancel, done := newProxySession(t)
+			defer cancel()
+
+			// Push a byte each way so both copy goroutines are active. Use
+			// goroutines because net.Pipe is synchronous (write blocks on read).
+			var io1, io2 sync.WaitGroup
+			io1.Add(2)
+			go func() { defer io1.Done(); _, _ = clientSide.Write([]byte{byte(i)}) }()
+			go func() {
+				defer io1.Done()
+				b := make([]byte, 1)
+				_, _ = io.ReadFull(deviceSide, b)
+			}()
+			io2.Add(2)
+			go func() { defer io2.Done(); _, _ = deviceSide.Write([]byte{byte(i)}) }()
+			go func() {
+				defer io2.Done()
+				b := make([]byte, 1)
+				_, _ = io.ReadFull(clientSide, b)
+			}()
+			io1.Wait()
+			io2.Wait()
+
+			// Tear down via a rotating route while traffic was just flowing.
+			switch i % 4 {
+			case 0:
+				cancel()
+			case 1:
+				clientSide.Close()
+			case 2:
+				deviceSide.Close()
+			case 3:
+				clientSide.Close()
+				deviceSide.Close()
+				cancel()
+			}
+			awaitReturn(t, done, "hammer session")
+			clientSide.Close()
+			deviceSide.Close()
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestForwardCloseLifecycle exercises the listener accept loop: Forward stands
+// up a real local listener, and Close must stop it cleanly. With no client ever
+// connecting, StartNewProxyConnection (which needs usbmux) is never reached, so
+// this stays device-free. It guards the #639 fix — a clean Close unblocks
+// Accept with net.ErrClosed and the loop exits without treating it as an error.
+func TestForwardCloseLifecycle(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	cl := &ConnListener{listener: l, quit: make(chan interface{})}
+
+	accepted := make(chan struct{})
+	go func() {
+		connectionAccept(cl, 1, 8100)
+		close(accepted)
+	}()
+
+	// Let the accept loop park in Accept(), then close it.
+	time.Sleep(20 * time.Millisecond)
+	if err := cl.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	select {
+	case <-accepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("connectionAccept did not exit after Close")
+	}
+}


### PR DESCRIPTION
## Why

While reviewing the recent forward logging fixes (#754, #639) I flagged a **pre-existing data race** in the proxy pump: the two `io.Copy` goroutines and the ctx watcher all touched a shared `closed` bool with no synchronization. It's a real race under `go test -race`, and both copy goroutines could enter the teardown block and double-close the conns.

This makes the forward feature race-free and adds a concurrent test suite to keep it that way.

## What

- **Extract** the device-free pump into `proxyConns()`, behind a narrow `deviceRWConn` interface (`Reader`/`Writer`/`Close`) that `ios.DeviceConnectionInterface` already satisfies. No behavioural change to forwarding; the level-aware close logging from #754 is preserved.
- **Fix the race**: teardown now funnels through a `sync.Once`, so the two copiers and the ctx watcher can all race to tear down without a data race or double-close, and `proxyConns` returns with no goroutines left running.
- **Tests** (`forward_test.go`, device-free via `net.Pipe`):
  - `TestProxyConnsBidirectional` — bytes flow both ways, clean teardown.
  - `TestProxyConnsSimultaneousTeardown` — 300× fire `cancel` + client-close + device-close *at once* at a fresh session.
  - `TestProxyConnsConcurrentHammer` — 400 parallel sessions, traffic mid-flight, rotating teardown route.
  - ctx-cancel / device-close teardown cases.
  - `TestForwardCloseLifecycle` — listener accept loop exits cleanly on `Close()` (guards the #639 `net.ErrClosed` fix); device-free since no client ever connects.

## Validation

- Clean under `go test -race -count=10 ./ios/forward/`.
- **The suite has teeth:** reintroducing the old `closed`-bool teardown makes `-race` fail on three of these tests with `DATA RACE`.
- gofmt / vet clean; full repo builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)