### PR TITLE
instruments: retry transient device launch failures (NSError code 2)

### DIFF
--- a/ios/instruments/processcontrol.go
+++ b/ios/instruments/processcontrol.go
@@ -3,11 +3,32 @@ package instruments
 import (
 	"fmt"
 	"maps"
+	"time"
 
 	"github.com/danielpaulus/go-ios/ios"
 	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
 	"github.com/danielpaulus/go-ios/ios/golog"
+	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
 )
+
+const (
+	// deviceProcessControlDomain is the NSError domain the on-device developer
+	// tools process-control service reports launch failures under.
+	deviceProcessControlDomain = "com.apple.dt.deviceprocesscontrolservice"
+	// transientLaunchErrorCode is the "could not launch right now" code that
+	// service returns for transient device states (screen locked, a prior
+	// instance still terminating, FrontBoard not ready). It clears on retry.
+	transientLaunchErrorCode = 2
+	// launchMaxAttempts and launchRetryBackoff bound the retry loop. Backoff
+	// grows linearly per attempt, so worst case adds ~3s before surfacing a
+	// persistent failure.
+	launchMaxAttempts  = 4
+	launchRetryBackoff = 500 * time.Millisecond
+)
+
+// launchRetrySleep is the sleep used between launch retries; a package var so
+// tests can stub it out and not actually wait.
+var launchRetrySleep = time.Sleep
 
 type ProcessControl struct {
 	processControlChannel *dtx.Channel
@@ -83,29 +104,82 @@ func (p ProcessControl) KillProcess(pid uint64) error {
 }
 
 // StartProcess launches an app on the device using the bundleID and optional envvars, arguments and options. It returns the PID.
+//
+// The on-device process-control service intermittently rejects a launch with a
+// transient "could not launch right now" error (NSError code 2 in the
+// com.apple.dt.deviceprocesscontrolservice domain) when the device is in a
+// momentary state that won't accept it — screen locked, a previous instance
+// still terminating, FrontBoard not yet ready. That clears on its own, so the
+// launch is retried a bounded number of times before the error is surfaced.
 func (p ProcessControl) StartProcess(bundleID string, envVars map[string]interface{}, arguments []interface{}, options map[string]interface{}) (uint64, error) {
 	// seems like the path does not matter
 	const path = "/private/"
 
-	golog.Info("Launching process", "module", logModule, "channel_id", procControlChannel, "bundleID", bundleID)
+	return startProcessWithRetry(bundleID, func() (dtx.Message, error) {
+		golog.Info("Launching process", "module", logModule, "channel_id", procControlChannel, "bundleID", bundleID)
+		return p.processControlChannel.MethodCall(
+			"launchSuspendedProcessWithDevicePath:bundleIdentifier:environment:arguments:options:",
+			path,
+			bundleID,
+			envVars,
+			arguments,
+			options)
+	})
+}
 
-	msg, err := p.processControlChannel.MethodCall(
-		"launchSuspendedProcessWithDevicePath:bundleIdentifier:environment:arguments:options:",
-		path,
-		bundleID,
-		envVars,
-		arguments,
-		options)
+// startProcessWithRetry runs launch (a single launchSuspendedProcess call) up to
+// launchMaxAttempts times, retrying only when the device reports a transient
+// launch failure. It is split out from StartProcess so the retry behaviour can
+// be unit-tested without a device by injecting launch.
+func startProcessWithRetry(bundleID string, launch func() (dtx.Message, error)) (uint64, error) {
+	var lastErr error
+	for attempt := 1; attempt <= launchMaxAttempts; attempt++ {
+		msg, err := launch()
+		pid, perr := parseLaunchReply(bundleID, msg, err)
+		if perr == nil {
+			golog.Info("Process started successfully", "module", logModule, "channel_id", procControlChannel, "pid", pid, "bundleID", bundleID)
+			return pid, nil
+		}
+		lastErr = perr
+
+		if attempt < launchMaxAttempts && isTransientLaunchError(msg) {
+			backoff := time.Duration(attempt) * launchRetryBackoff
+			golog.Warn("transient launch failure from device, retrying", "module", logModule, "channel_id", procControlChannel, "bundleID", bundleID, "attempt", attempt, "backoff", backoff.String(), "error", perr)
+			launchRetrySleep(backoff)
+			continue
+		}
+
+		golog.Error("failed starting process", "module", logModule, "channel_id", procControlChannel, "error", perr, "bundleID", bundleID, "attempts", attempt)
+		return 0, perr
+	}
+	return 0, lastErr
+}
+
+// parseLaunchReply turns one launch call's (msg, err) into a PID or an error.
+func parseLaunchReply(bundleID string, msg dtx.Message, err error) (uint64, error) {
 	if err != nil {
-		golog.Error("failed starting process", "module", logModule, "channel_id", procControlChannel, "error", err, "bundleID", bundleID)
 		return 0, err
 	}
 	if msg.HasError() {
 		return 0, fmt.Errorf("Failed starting process: %s, msg:%v", bundleID, msg.Payload[0])
 	}
 	if pid, ok := msg.Payload[0].(uint64); ok {
-		golog.Info("Process started successfully", "module", logModule, "channel_id", procControlChannel, "pid", pid)
 		return pid, nil
 	}
 	return 0, fmt.Errorf("pid returned in payload was not of type uint64 for processcontroll.startprocess, instead: %s", msg.Payload)
+}
+
+// isTransientLaunchError reports whether msg carries the device's transient
+// launch-rejection NSError (code 2, deviceprocesscontrolservice domain), the
+// only failure StartProcess retries on. Matching the structured NSError code and
+// domain avoids brittle string matching on the localized description.
+func isTransientLaunchError(msg dtx.Message) bool {
+	if len(msg.Payload) == 0 {
+		return false
+	}
+	nsErr, ok := msg.Payload[0].(nskeyedarchiver.NSError)
+	if !ok {
+		return false
+	}
+	return nsErr.Domain == deviceProcessControlDomain && nsErr.ErrorCode == transientLaunchErrorCode
 }

--- a/ios/instruments/processcontrol_test.go
+++ b/ios/instruments/processcontrol_test.go
@@ -1,0 +1,158 @@
+package instruments
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	dtx "github.com/danielpaulus/go-ios/ios/dtx_codec"
+	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
+)
+
+// stubSleep replaces the retry sleep with a no-op that records the backoffs, so
+// retry tests don't actually wait. It restores the original on cleanup.
+func stubSleep(t *testing.T) *[]time.Duration {
+	t.Helper()
+	var slept []time.Duration
+	orig := launchRetrySleep
+	launchRetrySleep = func(d time.Duration) { slept = append(slept, d) }
+	t.Cleanup(func() { launchRetrySleep = orig })
+	return &slept
+}
+
+func transientErrMsg() dtx.Message {
+	return dtx.Message{
+		PayloadHeader: dtx.PayloadHeader{MessageType: dtx.DtxTypeError},
+		Payload: []interface{}{nskeyedarchiver.NSError{
+			ErrorCode: transientLaunchErrorCode,
+			Domain:    deviceProcessControlDomain,
+			UserInfo:  map[string]interface{}{"NSLocalizedDescription": "Request to launch com.apple.Preferences failed."},
+		}},
+	}
+}
+
+func okMsg(pid uint64) dtx.Message {
+	return dtx.Message{
+		PayloadHeader: dtx.PayloadHeader{MessageType: dtx.ResponseWithReturnValueInPayload},
+		Payload:       []interface{}{pid},
+	}
+}
+
+// a transient launch reply, as MethodCall actually returns it: the wrapped error
+// AND the message carrying the structured NSError.
+func transientLaunch() (dtx.Message, error) {
+	return transientErrMsg(), errors.New("failed invoking method 'launchSuspendedProcess...' with error: Request to launch failed. (Error code: 2, Domain: com.apple.dt.deviceprocesscontrolservice)")
+}
+
+func TestStartProcessRetry_SucceedsAfterTransientFailures(t *testing.T) {
+	slept := stubSleep(t)
+	calls := 0
+	pid, err := startProcessWithRetry("com.apple.Preferences", func() (dtx.Message, error) {
+		calls++
+		if calls < 3 {
+			return transientLaunch()
+		}
+		return okMsg(4242), nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if pid != 4242 {
+		t.Fatalf("pid = %d, want 4242", pid)
+	}
+	if calls != 3 {
+		t.Fatalf("launch called %d times, want 3", calls)
+	}
+	// Two retries → two backoffs, growing linearly.
+	if len(*slept) != 2 || (*slept)[0] != launchRetryBackoff || (*slept)[1] != 2*launchRetryBackoff {
+		t.Fatalf("backoffs = %v, want [%v %v]", *slept, launchRetryBackoff, 2*launchRetryBackoff)
+	}
+}
+
+func TestStartProcessRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	stubSleep(t)
+	calls := 0
+	_, err := startProcessWithRetry("com.apple.Preferences", func() (dtx.Message, error) {
+		calls++
+		return transientLaunch()
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if calls != launchMaxAttempts {
+		t.Fatalf("launch called %d times, want %d", calls, launchMaxAttempts)
+	}
+}
+
+func TestStartProcessRetry_NoRetryOnNonTransientError(t *testing.T) {
+	stubSleep(t)
+	calls := 0
+	otherErr := dtx.Message{
+		PayloadHeader: dtx.PayloadHeader{MessageType: dtx.DtxTypeError},
+		Payload: []interface{}{nskeyedarchiver.NSError{
+			ErrorCode: 4, // not the transient launch code
+			Domain:    "com.apple.dt.deviceprocesscontrolservice",
+		}},
+	}
+	_, err := startProcessWithRetry("com.example.notinstalled", func() (dtx.Message, error) {
+		calls++
+		return otherErr, errors.New("Failed starting process")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Fatalf("non-transient error must not retry: launch called %d times, want 1", calls)
+	}
+}
+
+func TestStartProcessRetry_NoRetryOnTransportError(t *testing.T) {
+	stubSleep(t)
+	calls := 0
+	_, err := startProcessWithRetry("com.apple.Preferences", func() (dtx.Message, error) {
+		calls++
+		return dtx.Message{}, errors.New("connection reset") // no NSError payload
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Fatalf("transport error must not retry: launch called %d times, want 1", calls)
+	}
+}
+
+func TestStartProcessRetry_SucceedsFirstTry(t *testing.T) {
+	slept := stubSleep(t)
+	calls := 0
+	pid, err := startProcessWithRetry("com.apple.Preferences", func() (dtx.Message, error) {
+		calls++
+		return okMsg(7), nil
+	})
+	if err != nil || pid != 7 || calls != 1 {
+		t.Fatalf("pid=%d err=%v calls=%d, want 7/nil/1", pid, err, calls)
+	}
+	if len(*slept) != 0 {
+		t.Fatalf("no retries expected, slept %v", *slept)
+	}
+}
+
+func TestIsTransientLaunchError(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  dtx.Message
+		want bool
+	}{
+		{"transient code 2", transientErrMsg(), true},
+		{"wrong code", dtx.Message{Payload: []interface{}{nskeyedarchiver.NSError{ErrorCode: 3, Domain: deviceProcessControlDomain}}}, false},
+		{"wrong domain", dtx.Message{Payload: []interface{}{nskeyedarchiver.NSError{ErrorCode: 2, Domain: "com.apple.something.else"}}}, false},
+		{"empty payload", dtx.Message{}, false},
+		{"non-nserror payload", dtx.Message{Payload: []interface{}{uint64(123)}}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isTransientLaunchError(c.msg); got != c.want {
+				t.Fatalf("isTransientLaunchError = %v, want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

`ios launch <bundleID>` flakes intermittently on real devices with:

```
Request to launch com.apple.Preferences failed. (Error code: 2, Domain: com.apple.dt.deviceprocesscontrolservice)
```

This is **not a go-ios bug** — it's an `NSError` produced *on the device* by the developer-tools process-control service. Code 2 in that domain is the service's transient "could not launch right now" rejection: the device is momentarily not ready (screen locked, a prior instance still terminating, FrontBoard not yet up). It clears on its own, but today a single launch fails hard, so it surfaces as a flaky `TestLaunchKill` on CI and as spurious failures for any library caller of `ProcessControl.StartProcess`.

## What

Retry the launch a bounded number of times — **only** on that specific transient error:

- **4 attempts, linear backoff** (`500ms · attempt`, ~3s worst case) before surfacing the error.
- Detection matches the **structured `NSError` code + domain** (`code 2`, `com.apple.dt.deviceprocesscontrolservice`), not the localized string — so a genuine failure (wrong bundle id, a different code/domain, a transport error) still **fails fast on the first attempt** and is never masked.
- The loop is extracted into `startProcessWithRetry` behind an injected launch closure, with the sleep behind an overridable package var, so it's fully unit-testable without a device.

## Tests (device-free, `-race` clean)

- succeeds after N transient failures (asserts attempt count + backoff schedule)
- gives up after `launchMaxAttempts`
- **no retry** on a non-transient `NSError` (different code)
- **no retry** on a transport error (no `NSError` payload)
- succeeds first try (no sleeps)
- `isTransientLaunchError` matcher table (code/domain/empty/non-NSError)

## Validation plan

This PR's own real-device e2e run is the live test of the fix — `TestLaunchKill` has been flaking on exactly this error, so a green device run here is the proof. gofmt/vet clean; `go test -race ./ios/instruments/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)