### PR TITLE
fix(forward): quiet per-connection logs and return the real connect error

### DIFF
--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -94,9 +94,9 @@ func StartNewProxyConnection(ctx context.Context, clientConn io.ReadWriteCloser,
 	}
 	muxError := usbmuxConn.Connect(deviceID, phonePort)
 	if muxError != nil {
-		golog.Info("could not connect to phone", "module", logModule, "deviceID", deviceID, "conn", fmt.Sprintf("%#v", clientConn), "error", muxError, "phonePort", phonePort)
+		golog.Debug("could not connect to phone", "module", logModule, "deviceID", deviceID, "conn", fmt.Sprintf("%#v", clientConn), "error", muxError, "phonePort", phonePort)
 		clientConn.Close()
-		return fmt.Errorf("could not connect to port:%d on iOS: %v", phonePort, err)
+		return fmt.Errorf("could not connect to port:%d on iOS: %v", phonePort, muxError)
 	}
 	golog.Debug("connected to port", "module", logModule, "deviceID", deviceID, "conn", fmt.Sprintf("%#v", clientConn), "phonePort", phonePort)
 	deviceConn := usbmuxConn.ReleaseDeviceConnection()

--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -79,7 +79,7 @@ func connectionAccept(cl *ConnListener, deviceID int, phonePort uint16) {
 				golog.Error("error accepting new connection", "module", logModule, "deviceID", deviceID, "phonePort", phonePort, "error", err)
 				continue
 			}
-			golog.Info("new client connected", "module", logModule, "deviceID", deviceID, "phonePort", phonePort, "conn", fmt.Sprintf("%#v", cl))
+			golog.Debug("new client connected", "module", logModule, "deviceID", deviceID, "phonePort", phonePort, "conn", fmt.Sprintf("%#v", cl))
 			go StartNewProxyConnection(context.TODO(), clientConn, deviceID, phonePort)
 		}
 	}
@@ -98,7 +98,7 @@ func StartNewProxyConnection(ctx context.Context, clientConn io.ReadWriteCloser,
 		clientConn.Close()
 		return fmt.Errorf("could not connect to port:%d on iOS: %v", phonePort, err)
 	}
-	golog.Info("connected to port", "module", logModule, "deviceID", deviceID, "conn", fmt.Sprintf("%#v", clientConn), "phonePort", phonePort)
+	golog.Debug("connected to port", "module", logModule, "deviceID", deviceID, "conn", fmt.Sprintf("%#v", clientConn), "phonePort", phonePort)
 	deviceConn := usbmuxConn.ReleaseDeviceConnection()
 
 	proxyConns(ctx, clientConn, deviceConn, deviceID, phonePort)


### PR DESCRIPTION
## Problem

Following up on the teardown-logging fix (#754), the remaining per-connection lifecycle lines in the forwarder are still logged at **info**, so workloads that cycle many short-lived forwarded connections flood the logs:

```
INFO  new client connected   phonePort=6869
INFO  connected to port      phonePort=6869
INFO  new client connected   phonePort=6869
INFO  connected to port      phonePort=6869
...
```

## Changes

**1. Downgrade per-connection lifecycle logs to debug**
- `new client connected` — fires every time something connects to the forwarded host port.
- `connected to port` — fires every time the proxy opens the device-side socket.
- `could not connect to phone` — the symmetric failure case; fires once per client connection when the device port is unreachable (e.g. anything polling a port before the app is listening). Was `info`, while the sibling failure right above it (`could not connect to usbmuxd`) is `error` — inconsistent. Downgraded to debug; the error is already returned to the caller.

The forwarder now logs the connection lifecycle at debug (matching the teardown lines from #754) and reserves info/error for things an operator actually needs to see.

**2. Return the real error from `StartNewProxyConnection`**

The device-connect failure path wrapped `err` (the result of the *successful* usbmux connection, always `nil` at that point) instead of `muxError`, so the returned error always read `... on iOS: <nil>` and dropped the actual reason. Now wraps `muxError`.

## Testing

- `gofmt` clean
- `go vet ./ios/forward/` clean
- `CGO_ENABLED=0 go build ./ios/forward/` OK