### PR TITLE
fix: exit with code 1 when DDI mount fails

### DIFF
--- a/cmd_device_debug.go
+++ b/cmd_device_debug.go
@@ -142,7 +142,7 @@ func runImageCommand(ctx commandContext) {
 		err := imagemounter.MountImage(ctx.Device, imagePath)
 		if err != nil {
 			slog.Error("error mounting image", "image", imagePath, "udid", ctx.Device.Properties.SerialNumber, "err", err)
-			return
+			os.Exit(1)
 		}
 		slog.Info("success mounting image", "image", imagePath, "udid", ctx.Device.Properties.SerialNumber)
 	}


### PR DESCRIPTION
## Summary

- `ios image mount` was logging the error and returning cleanly (exit 0) when the DDI mount failed (e.g. Apple TSS returning an unexpected status). This caused `set -e` shells to silently continue past the failure, leaving the device in a state where testmanagerd is unavailable but no error is surfaced.
- Changed the error path to call `os.Exit(1)` so the process exits with a non-zero code on mount failure, consistent with how other commands in the codebase handle fatal errors.

## Test plan

- [ ] Run `ios image mount` on a device where mount succeeds — behavior unchanged
- [ ] Run `ios image mount` on a device where Apple TSS rejects the signature request — process now exits with code 1 instead of 0

🤖 Generated with [Claude Code](https://claude.ai/claude-code)