### PR TITLE
Fix imagemounter to validate mount/unmount reply

### DIFF
--- a/ios/imagemounter/imagedownloader_test.go
+++ b/ios/imagemounter/imagedownloader_test.go
@@ -59,6 +59,10 @@ func TestUsesProxy(t *testing.T) {
 		t.Skip("No device attached")
 		return
 	}
+	// the device rejects 'MountImage' when an image is already mounted, so start from a clean state
+	if err := imagemounter.UnmountImage(d.DeviceList[0]); err != nil {
+		log.Printf("could not unmount an already mounted developer disk image: %v", err)
+	}
 	wg.Add(1)
 	m, err := imagemounter.NewPersonalizedDeveloperDiskImageMounter(d.DeviceList[0], ios.IOS17())
 	if !assert.Nil(t, err) {
@@ -92,6 +96,10 @@ func TestWorksWithoutProxy(t *testing.T) {
 	if len(d.DeviceList) == 0 {
 		t.Skip("No device attached")
 		return
+	}
+	// the device rejects 'MountImage' when an image is already mounted, so start from a clean state
+	if err := imagemounter.UnmountImage(d.DeviceList[0]); err != nil {
+		log.Printf("could not unmount an already mounted developer disk image: %v", err)
 	}
 	m, err := imagemounter.NewPersonalizedDeveloperDiskImageMounter(d.DeviceList[0], ios.IOS17())
 	if !assert.Nil(t, err) {

--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -108,7 +108,7 @@ func (conn *DeveloperDiskImageMounter) UnmountImage() error {
 	if err != nil {
 		return err
 	}
-	return nil
+	return readUnmountResponse(conn.plistRw)
 }
 
 func (conn *DeveloperDiskImageMounter) mountImage(signatureBytes []byte) error {
@@ -175,6 +175,26 @@ func waitForUploadComplete(plistRw ios.PlistCodecReadWriter) error {
 	}
 	if "Complete" != status {
 		return fmt.Errorf("unexpected response: %+v", plist)
+	}
+	return nil
+}
+
+// readUnmountResponse reads the reply to an 'UnmountImage' command. The device rejects the
+// command when it is locked or when no image is mounted, so without inspecting the reply an
+// unmount that never happened is reported as a success.
+func readUnmountResponse(plistRw ios.PlistCodecReadWriter) error {
+	var res map[string]interface{}
+	err := plistRw.Read(&res)
+	if err != nil {
+		return fmt.Errorf("readUnmountResponse: failed to read response for 'UnmountImage': %w", err)
+	}
+	golog.Debug("unmount response", "module", logModule, "response", res)
+	status, ok := res["Status"]
+	if !ok {
+		return fmt.Errorf("readUnmountResponse: unexpected response: %+v", res)
+	}
+	if status != "Complete" {
+		return fmt.Errorf("readUnmountResponse: unexpected response: %+v", res)
 	}
 	return nil
 }

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -296,6 +296,14 @@ func (p PersonalizedDeveloperDiskImageMounter) mountPersonalizedImage(signatureB
 	if err != nil {
 		return fmt.Errorf("mountPersonalizedImage: failed to read response for 'MountImage': %w", err)
 	}
+	golog.Debug("mount response", "module", logModule, "response", res)
+	status, ok := res["Status"]
+	if !ok {
+		return fmt.Errorf("mountPersonalizedImage: unexpected response: %+v", res)
+	}
+	if status != "Complete" {
+		return fmt.Errorf("mountPersonalizedImage: unexpected response: %+v", res)
+	}
 	return nil
 }
 

--- a/ios/imagemounter/personalized_image_mounter.go
+++ b/ios/imagemounter/personalized_image_mounter.go
@@ -159,7 +159,7 @@ func (p PersonalizedDeveloperDiskImageMounter) UnmountImage() error {
 	if err != nil {
 		return err
 	}
-	return nil
+	return readUnmountResponse(p.plistRw)
 }
 
 func (p PersonalizedDeveloperDiskImageMounter) queryPersonalizationManifest(dmgPath string) ([]byte, error) {

--- a/ios/imagemounter/personalized_image_mounter_test.go
+++ b/ios/imagemounter/personalized_image_mounter_test.go
@@ -1,0 +1,80 @@
+package imagemounter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// encodePlistMessage frames a plist message the same way the device does, so that it can be
+// read back through the regular codec.
+func encodePlistMessage(t *testing.T, msg map[string]interface{}) *bytes.Buffer {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	require.NoError(t, ios.NewPlistCodecReadWriter(nil, buf).Write(msg))
+	return buf
+}
+
+func TestMountPersonalizedImage(t *testing.T) {
+	tests := []struct {
+		name        string
+		response    map[string]interface{}
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "mount completed",
+			response: map[string]interface{}{"Status": "Complete"},
+		},
+		{
+			name: "developer mode is not enabled",
+			response: map[string]interface{}{
+				"Error":         "ImageMountFailed",
+				"DetailedError": `Error Domain=com.apple.MobileStorage Code=-2 "Failed to mount image" UserInfo={NSUnderlyingError=Code=-4 "Developer mode is not enabled."}`,
+			},
+			wantErr:     true,
+			errContains: "Developer mode is not enabled.",
+		},
+		{
+			name:        "device is locked",
+			response:    map[string]interface{}{"Error": "DeviceLocked"},
+			wantErr:     true,
+			errContains: "DeviceLocked",
+		},
+		{
+			name:        "unexpected status",
+			response:    map[string]interface{}{"Status": "Failure"},
+			wantErr:     true,
+			errContains: "Failure",
+		},
+		{
+			name:        "empty response",
+			response:    map[string]interface{}{},
+			wantErr:     true,
+			errContains: "unexpected response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			written := new(bytes.Buffer)
+			mounter := PersonalizedDeveloperDiskImageMounter{
+				plistRw: ios.NewPlistCodecReadWriter(encodePlistMessage(t, tt.response), written),
+			}
+
+			err := mounter.mountPersonalizedImage([]byte("signature"), []byte("trust-cache"))
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Contains(t, written.String(), "MountImage", "the 'MountImage' command should have been sent")
+		})
+	}
+}

--- a/ios/imagemounter/unmount_test.go
+++ b/ios/imagemounter/unmount_test.go
@@ -1,0 +1,95 @@
+package imagemounter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// encodeUnmountResponse frames a plist message the same way the device does, so that it can be
+// read back through the regular codec.
+func encodeUnmountResponse(t *testing.T, msg map[string]interface{}) *bytes.Buffer {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	require.NoError(t, ios.NewPlistCodecReadWriter(nil, buf).Write(msg))
+	return buf
+}
+
+func TestReadUnmountResponse(t *testing.T) {
+	tests := []struct {
+		name        string
+		response    map[string]interface{}
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "unmount completed",
+			response: map[string]interface{}{"Status": "Complete"},
+		},
+		{
+			name:        "device is locked",
+			response:    map[string]interface{}{"Error": "DeviceLocked"},
+			wantErr:     true,
+			errContains: "DeviceLocked",
+		},
+		{
+			name:        "no image mounted",
+			response:    map[string]interface{}{"Error": "ImageNotMounted"},
+			wantErr:     true,
+			errContains: "ImageNotMounted",
+		},
+		{
+			name:        "empty response",
+			response:    map[string]interface{}{},
+			wantErr:     true,
+			errContains: "unexpected response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := readUnmountResponse(ios.NewPlistCodecReadWriter(encodeUnmountResponse(t, tt.response), nil))
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// A device that refuses to unmount must not be reported as a successful unmount.
+func TestUnmountImageReportsDeviceError(t *testing.T) {
+	deviceLocked := map[string]interface{}{"Error": "DeviceLocked"}
+
+	t.Run("personalized image mounter", func(t *testing.T) {
+		written := new(bytes.Buffer)
+		mounter := PersonalizedDeveloperDiskImageMounter{
+			plistRw: ios.NewPlistCodecReadWriter(encodeUnmountResponse(t, deviceLocked), written),
+		}
+
+		err := mounter.UnmountImage()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "DeviceLocked")
+		assert.Contains(t, written.String(), "UnmountImage", "the 'UnmountImage' command should have been sent")
+	})
+
+	t.Run("developer disk image mounter", func(t *testing.T) {
+		written := new(bytes.Buffer)
+		mounter := DeveloperDiskImageMounter{
+			plistRw: ios.NewPlistCodecReadWriter(encodeUnmountResponse(t, deviceLocked), written),
+		}
+
+		err := mounter.UnmountImage()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "DeviceLocked")
+		assert.Contains(t, written.String(), "UnmountImage", "the 'UnmountImage' command should have been sent")
+	})
+}


### PR DESCRIPTION
func (p PersonalizedDeveloperDiskImageMounter) mountPersonalizedImage(signatureBytes []byte, trustCache []byte) 

Discards the unsuccessful mounting when device returns nil or status is not 'Complete'. It handles both condition and return error to catch unsuccessful mounting (like developer mode is not enabled etc.)

New tests are also added. 