### PR TITLE
Improvement/fix(rsd): fail fast when a service is missing from the RSD service list

### DIFF
--- a/ios/connect.go
+++ b/ios/connect.go
@@ -108,13 +108,15 @@ func ConnectToService(device DeviceEntry, serviceName string) (DeviceConnectionI
 	return muxConn.ReleaseDeviceConnection(), nil
 }
 
-// rsdPortForService looks up the port a service is listening on in the RSD service list of the device.
-// Services provided by the developer disk image only show up after it has been mounted. Without this
-// check we would dial port 0 and report a confusing 'connection refused' instead of the actual cause.
-func rsdPortForService(device DeviceEntry, service string) (int, error) {
-	port := device.Rsd.GetPort(service)
+// RsdPortForService looks up the port a service is listening on in the given RSD service list.
+// Services provided by the developer disk image only show up after a recent enough image has been
+// mounted: mounting adds them, but an outdated image can lack newer services even when mounted.
+// Without this check we would dial port 0 and report a confusing 'connection refused' instead of
+// the actual cause.
+func RsdPortForService(rsd RsdPortProvider, service string) (int, error) {
+	port := rsd.GetPort(service)
 	if port == 0 {
-		return 0, fmt.Errorf("service '%s' is not available in RSD. If it is provided by the developer disk image, make sure the image is mounted (run `ios image auto`)", service)
+		return 0, fmt.Errorf("service '%s' is not available in RSD. If it is provided by the developer disk image, make sure a recent image is mounted (run `ios image auto`) — an outdated image can lack this service even when mounted", service)
 	}
 	return port, nil
 }
@@ -126,7 +128,7 @@ func ConnectToShimService(device DeviceEntry, service string) (DeviceConnectionI
 	if !device.SupportsRsd() {
 		return nil, fmt.Errorf("ConnectToShimService: Cannot connect to %s, missing tunnel address and RSD port.  To start the tunnel, run `ios tunnel start`", service)
 	}
-	port, err := rsdPortForService(device, service)
+	port, err := RsdPortForService(device.Rsd, service)
 	if err != nil {
 		return nil, fmt.Errorf("ConnectToShimService: %w", err)
 	}
@@ -147,7 +149,7 @@ func ConnectToXpcServiceTunnelIface(device DeviceEntry, serviceName string) (*xp
 	if !device.SupportsRsd() {
 		return nil, fmt.Errorf("ConnectToXpcServiceTunnelIface: Cannot connect to %s, missing tunnel address and RSD port. To start the tunnel, run `ios tunnel start`", serviceName)
 	}
-	port, err := rsdPortForService(device, serviceName)
+	port, err := RsdPortForService(device.Rsd, serviceName)
 	if err != nil {
 		return nil, fmt.Errorf("ConnectToXpcServiceTunnelIface: %w", err)
 	}
@@ -168,7 +170,7 @@ func ConnectToServiceTunnelIface(device DeviceEntry, serviceName string) (Device
 	if !device.SupportsRsd() {
 		return nil, fmt.Errorf("ConnectToServiceTunnelIface: Cannot connect to %s, missing tunnel address and RSD port. To start the tunnel, run `ios tunnel start`", serviceName)
 	}
-	port, err := rsdPortForService(device, serviceName)
+	port, err := RsdPortForService(device.Rsd, serviceName)
 	if err != nil {
 		return nil, fmt.Errorf("ConnectToServiceTunnelIface: %w", err)
 	}
@@ -298,6 +300,12 @@ func initializeXpcConnection(h *http.HttpConnection) error {
 // If the device is a userspaceTUN device provided by go-ios agent, it will connect to this
 // automatically. Otherwise it will try a operating system level TUN device.
 func ConnectTUNDevice(remoteIp string, port int, d DeviceEntry) (*net.TCPConn, error) {
+	// Backstop for callers that skip the RsdPortForService check: on the
+	// userspace-TUN path a port-0 dial would not even fail — the forwarder
+	// accepts it and the caller hangs later with no pointer to the cause.
+	if port <= 0 {
+		return nil, fmt.Errorf("ConnectTUNDevice: invalid port %d for %s — the service is not available in RSD (is the developer disk image mounted and recent enough?)", port, remoteIp)
+	}
 	if !d.UserspaceTUN {
 		return connectTUN(remoteIp, port)
 	}

--- a/ios/connect.go
+++ b/ios/connect.go
@@ -108,6 +108,17 @@ func ConnectToService(device DeviceEntry, serviceName string) (DeviceConnectionI
 	return muxConn.ReleaseDeviceConnection(), nil
 }
 
+// rsdPortForService looks up the port a service is listening on in the RSD service list of the device.
+// Services provided by the developer disk image only show up after it has been mounted. Without this
+// check we would dial port 0 and report a confusing 'connection refused' instead of the actual cause.
+func rsdPortForService(device DeviceEntry, service string) (int, error) {
+	port := device.Rsd.GetPort(service)
+	if port == 0 {
+		return 0, fmt.Errorf("service '%s' is not available in RSD. If it is provided by the developer disk image, make sure the image is mounted (run `ios image auto`)", service)
+	}
+	return port, nil
+}
+
 // ConnectToShimService opens a new connection of the tunnel interface of the provided device
 // to the provided service.
 // The 'RSDCheckin' required by shim services is also executed before returning the connection to the caller
@@ -115,7 +126,10 @@ func ConnectToShimService(device DeviceEntry, service string) (DeviceConnectionI
 	if !device.SupportsRsd() {
 		return nil, fmt.Errorf("ConnectToShimService: Cannot connect to %s, missing tunnel address and RSD port.  To start the tunnel, run `ios tunnel start`", service)
 	}
-	port := device.Rsd.GetPort(service)
+	port, err := rsdPortForService(device, service)
+	if err != nil {
+		return nil, fmt.Errorf("ConnectToShimService: %w", err)
+	}
 	conn, err := ConnectTUNDevice(device.Address, port, device)
 	if err != nil {
 		return nil, err
@@ -133,7 +147,10 @@ func ConnectToXpcServiceTunnelIface(device DeviceEntry, serviceName string) (*xp
 	if !device.SupportsRsd() {
 		return nil, fmt.Errorf("ConnectToXpcServiceTunnelIface: Cannot connect to %s, missing tunnel address and RSD port. To start the tunnel, run `ios tunnel start`", serviceName)
 	}
-	port := device.Rsd.GetPort(serviceName)
+	port, err := rsdPortForService(device, serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("ConnectToXpcServiceTunnelIface: %w", err)
+	}
 
 	conn, err := ConnectTUNDevice(device.Address, port, device)
 	if err != nil {
@@ -151,7 +168,10 @@ func ConnectToServiceTunnelIface(device DeviceEntry, serviceName string) (Device
 	if !device.SupportsRsd() {
 		return nil, fmt.Errorf("ConnectToServiceTunnelIface: Cannot connect to %s, missing tunnel address and RSD port. To start the tunnel, run `ios tunnel start`", serviceName)
 	}
-	port := device.Rsd.GetPort(serviceName)
+	port, err := rsdPortForService(device, serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("ConnectToServiceTunnelIface: %w", err)
+	}
 
 	conn, err := ConnectTUNDevice(device.Address, port, device)
 	if err != nil {

--- a/ios/connect_test.go
+++ b/ios/connect_test.go
@@ -17,13 +17,13 @@ func TestRsdPortForService(t *testing.T) {
 	}
 
 	t.Run("service is listed in rsd", func(t *testing.T) {
-		port, err := rsdPortForService(device, "com.apple.mobile.notification_proxy.shim.remote")
+		port, err := RsdPortForService(device.Rsd, "com.apple.mobile.notification_proxy.shim.remote")
 		require.NoError(t, err)
 		assert.Equal(t, 50123, port)
 	})
 
 	t.Run("service is missing from rsd", func(t *testing.T) {
-		_, err := rsdPortForService(device, "com.apple.instruments.dtservicehub")
+		_, err := RsdPortForService(device.Rsd, "com.apple.instruments.dtservicehub")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "com.apple.instruments.dtservicehub")
 		assert.Contains(t, err.Error(), "developer disk image")

--- a/ios/connect_test.go
+++ b/ios/connect_test.go
@@ -1,0 +1,59 @@
+package ios
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRsdPortForService(t *testing.T) {
+	device := DeviceEntry{
+		Rsd: RsdHandshakeResponse{
+			Services: map[string]RsdServiceEntry{
+				"com.apple.mobile.notification_proxy.shim.remote": {Port: 50123},
+			},
+		},
+	}
+
+	t.Run("service is listed in rsd", func(t *testing.T) {
+		port, err := rsdPortForService(device, "com.apple.mobile.notification_proxy.shim.remote")
+		require.NoError(t, err)
+		assert.Equal(t, 50123, port)
+	})
+
+	t.Run("service is missing from rsd", func(t *testing.T) {
+		_, err := rsdPortForService(device, "com.apple.instruments.dtservicehub")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "com.apple.instruments.dtservicehub")
+		assert.Contains(t, err.Error(), "developer disk image")
+	})
+}
+
+// Services provided by the developer disk image are missing from the RSD service list until the
+// image is mounted. Connecting to one of them has to fail with that reason instead of dialing
+// port 0, which used to surface as an unrelated 'connection refused' on the tunnel address.
+func TestConnectToServiceFailsFastWhenServiceIsMissingFromRsd(t *testing.T) {
+	device := DeviceEntry{
+		Address: "fd00::1",
+		Rsd:     RsdHandshakeResponse{Services: map[string]RsdServiceEntry{}},
+	}
+
+	t.Run("ConnectToServiceTunnelIface", func(t *testing.T) {
+		_, err := ConnectToServiceTunnelIface(device, "com.apple.instruments.dtservicehub")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not available in RSD")
+	})
+
+	t.Run("ConnectToXpcServiceTunnelIface", func(t *testing.T) {
+		_, err := ConnectToXpcServiceTunnelIface(device, "com.apple.coredevice.deviceinfo")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not available in RSD")
+	})
+
+	t.Run("ConnectToShimService", func(t *testing.T) {
+		_, err := ConnectToShimService(device, "com.apple.mobile.notification_proxy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not available in RSD")
+	})
+}

--- a/ios/openstdio/service.go
+++ b/ios/openstdio/service.go
@@ -25,7 +25,11 @@ func NewOpenStdIoSocket(device ios.DeviceEntry) (Connection, error) {
 	if device.Rsd == nil {
 		return Connection{}, errors.New("NewOpenStdIoSocket: no rsd device found")
 	}
-	port := device.Rsd.GetPort("com.apple.coredevice.openstdiosocket")
+	const stdioServiceName = "com.apple.coredevice.openstdiosocket"
+	port := device.Rsd.GetPort(stdioServiceName)
+	if port == 0 {
+		return Connection{}, fmt.Errorf("NewOpenStdIoSocket: service '%s' is not available in RSD. If it is provided by the developer disk image, make sure the image is mounted (run `ios image auto`)", stdioServiceName)
+	}
 	conn, err := ios.ConnectTUNDevice(device.Address, port, device)
 	if err != nil {
 		return Connection{}, fmt.Errorf("NewOpenStdIoSocket: failed to open connection: %w", err)

--- a/ios/openstdio/service.go
+++ b/ios/openstdio/service.go
@@ -26,9 +26,9 @@ func NewOpenStdIoSocket(device ios.DeviceEntry) (Connection, error) {
 		return Connection{}, errors.New("NewOpenStdIoSocket: no rsd device found")
 	}
 	const stdioServiceName = "com.apple.coredevice.openstdiosocket"
-	port := device.Rsd.GetPort(stdioServiceName)
-	if port == 0 {
-		return Connection{}, fmt.Errorf("NewOpenStdIoSocket: service '%s' is not available in RSD. If it is provided by the developer disk image, make sure the image is mounted (run `ios image auto`)", stdioServiceName)
+	port, err := ios.RsdPortForService(device.Rsd, stdioServiceName)
+	if err != nil {
+		return Connection{}, fmt.Errorf("NewOpenStdIoSocket: %w", err)
 	}
 	conn, err := ios.ConnectTUNDevice(device.Address, port, device)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1879,6 +1879,9 @@ func deviceWithRsdProvider(device ios.DeviceEntry, udid string, address string, 
 	exitIfError(fmt.Sprintf("could not connect to RSD, host %s, port %d", address, rsdPort), err)
 	defer rsdService.Close()
 	rsdProvider, err := rsdService.Handshake()
+	// An unchecked handshake error would leave an empty RSD service list, and every
+	// service lookup would then misreport as 'service not available in RSD'.
+	exitIfError(fmt.Sprintf("RSD handshake failed, host %s, port %d", address, rsdPort), err)
 	device1, err := ios.GetDeviceWithAddress(udid, address, rsdProvider)
 	device1.UserspaceTUN = device.UserspaceTUN
 	device1.UserspaceTUNHost = device.UserspaceTUNHost


### PR DESCRIPTION
GetPort returns 0 for a service that is not in the RSD service list, and the callers dialed that port without checking it. Services provided by the developer disk image are only listed once the image is mounted, so a missing image surfaced as 'connection forcibly closed by the remote host' on the tunnel address, which gives no hint about the actual cause.

Report the missing service by name instead, following the check that getUntrustedTunnelServicePort already does.

New tests are also added.