### PR TITLE
fix(xctest): run WDA/XCUITest on iOS 14-16 via in-memory test config

### DIFF
--- a/ios/testmanagerd/xcuitestrunner.go
+++ b/ios/testmanagerd/xcuitestrunner.go
@@ -520,6 +520,44 @@ func startTestRunner17(appserviceConn *appservice.Connection, bundleID string, s
 	return appLaunch, nil
 }
 
+// getTestInfo resolves the runner (and optional target) app on the device from
+// the installation proxy. It performs no device-side writes, so callers that
+// build the XCTestConfiguration in memory (createTestConfig) can use it without
+// pushing an .xctestconfiguration file to the device.
+func getTestInfo(device ios.DeviceEntry, bundleID string, testRunnerBundleID string) (testInfo, error) {
+	installationProxy, err := installationproxy.New(device)
+	if err != nil {
+		return testInfo{}, err
+	}
+	defer installationProxy.Close()
+
+	apps, err := installationProxy.BrowseUserApps()
+	if err != nil {
+		return testInfo{}, err
+	}
+
+	testAppInfo, err := getappInfo(testRunnerBundleID, apps)
+	if err != nil {
+		return testInfo{}, err
+	}
+
+	info := testInfo{
+		testApp: testAppInfo,
+	}
+
+	if bundleID != "" {
+		appInfo, err := getappInfo(bundleID, apps)
+		if err != nil {
+			return testInfo{}, err
+		}
+		golog.Debug("app info found", "module", logModule, "udid", device.Properties.SerialNumber, "appInfo", appInfo)
+
+		info.targetApp = appInfo
+	}
+
+	return info, nil
+}
+
 func setupXcuiTest(device ios.DeviceEntry, bundleID string, testRunnerBundleID string, xctestConfigFileName string, testsToRun []string, testsToSkip []string, isXCTest bool, version *semver.Version) (uuid.UUID, string, nskeyedarchiver.XCTestConfiguration, testInfo, error) {
 	testSessionID := uuid.New()
 	installationProxy, err := installationproxy.New(device)

--- a/ios/testmanagerd/xcuitestrunner_12.go
+++ b/ios/testmanagerd/xcuitestrunner_12.go
@@ -11,6 +11,7 @@ import (
 	"github.com/danielpaulus/go-ios/ios/golog"
 	"github.com/danielpaulus/go-ios/ios/instruments"
 	"github.com/danielpaulus/go-ios/ios/nskeyedarchiver"
+	"github.com/google/uuid"
 )
 
 func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, config TestConfig, version *semver.Version,
@@ -19,12 +20,18 @@ func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, config TestConfig, v
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot create a usbmuxd connection to testmanagerd: %w", err)
 	}
-
-	testSessionId, xctestConfigPath, testConfig, testInfo, err := setupXcuiTest(config.Device, config.BundleId, config.TestRunnerBundleId, config.XctestConfigName, config.TestsToRun, config.TestsToSkip, config.XcTest, version)
-	if err != nil {
-		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot setup test config: %w", err)
-	}
 	defer conn.Close()
+
+	// iOS 14-16 accept the XCTestConfiguration over the DTX session, the same way
+	// the iOS 17+ path does, so we build it in memory instead of writing an
+	// .xctestconfiguration file to the device and passing its path. Serializing
+	// that file on-device is what broke test runs on these versions.
+	testSessionId := uuid.New()
+	testInfo, err := getTestInfo(config.Device, config.BundleId, config.TestRunnerBundleId)
+	if err != nil {
+		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot get test info: %w", err)
+	}
+	testConfig := createTestConfig(testInfo, testSessionId, config.XctestConfigName, config.TestsToRun, config.TestsToSkip, config.XcTest, version)
 
 	ideDaemonProxy := newDtxProxyWithConfig(conn, testConfig, config.Listener)
 
@@ -58,7 +65,7 @@ func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, config TestConfig, v
 	}
 	defer pControl.Close()
 
-	pid, err := startTestRunner12(pControl, xctestConfigPath, config.TestRunnerBundleId, testSessionId.String(), testInfo.testApp.path+"/PlugIns/"+config.XctestConfigName, config.Args, config.Env)
+	pid, err := startTestRunner12(pControl, config.TestRunnerBundleId, testSessionId.String(), testInfo.testApp.path+"/PlugIns/"+config.XctestConfigName, config.Args, config.Env)
 	if err != nil {
 		return make([]TestSuite, 0), fmt.Errorf("RunXUITestWithBundleIdsXcode12Ctx: cannot start test runner: %w", err)
 	}
@@ -106,7 +113,7 @@ func runXUITestWithBundleIdsXcode12Ctx(ctx context.Context, config TestConfig, v
 	return config.Listener.TestSuites, config.Listener.err
 }
 
-func startTestRunner12(pControl *instruments.ProcessControl, xctestConfigPath string, bundleID string,
+func startTestRunner12(pControl *instruments.ProcessControl, bundleID string,
 	sessionIdentifier string, testBundlePath string, wdaargs []string, wdaenv map[string]interface{},
 ) (uint64, error) {
 	args := []interface{}{
@@ -125,7 +132,7 @@ func startTestRunner12(pControl *instruments.ProcessControl, xctestConfigPath st
 		"OS_ACTIVITY_DT_MODE":             "YES",
 		"SQLITE_ENABLE_THREAD_ASSERTIONS": "1",
 		"XCTestBundlePath":                testBundlePath,
-		"XCTestConfigurationFilePath":     xctestConfigPath,
+		"XCTestConfigurationFilePath":     "",
 		"XCTestSessionIdentifier":         sessionIdentifier,
 	}
 


### PR DESCRIPTION
Re-authors #533 (chernyka) on current main.

## Problem
On iOS 14-16, go-ios writes an `.xctestconfiguration` file onto the device (via house_arrest) and passes its on-device path to the test runner. Serializing the config that way breaks the WDA/XCUITest launch on these versions.

## Fix
iOS 17+ already delivers the `XCTestConfiguration` **in memory** over the DTX session. This makes the iOS 14-16 path do the same:
- build the config with the existing `createTestConfig` (in memory)
- launch with an empty `XCTestConfigurationFilePath`
- add `getTestInfo` (installation-proxy app lookup, no device-side write) so the Xcode12 path can resolve the runner/target app without `setupXcuiTest`'s file push

**Only the iOS 14-16 path changes.** The iOS 11 path (still uses `setupXcuiTest`) and the iOS 17+ path are untouched, so the existing WDA e2e is a clean regression guard.

## Credit
The fix idea and approach are from @chernyka in #533; this re-implements it on current main (logrus→golog, drops the unused `setupXcuiTest12`, leaves the iOS 17+ path as-is to minimise blast radius).

## Testing
- Builds, `go vet`, gofmt, and `go test ./ios/testmanagerd/` all green.
- iOS 17+ regression-guarded by the unchanged path + the existing WDA e2e on the iOS 18 fleet.
- ⚠️ **Not verified on an iOS 15/16 device** — the fleet has none. The iOS 14.3 runner does exercise this Xcode12 code path. Merging on the strength of code review + the iOS 17-parity argument; flagging the 15/16 gap explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)