### PR TITLE
fix(house_arrest): fall back to VendDocuments when VendContainer is denied

### DIFF
--- a/ios/house_arrest/house_arrest.go
+++ b/ios/house_arrest/house_arrest.go
@@ -31,6 +31,9 @@ func New(device ios.DeviceEntry, bundleID string) (*afc.Client, error) {
 // apps not installed with a developer profile, e.g. App Store apps, reporting
 // InstallationLookupFailed), it falls back to documents-only access on a fresh
 // connection, since house_arrest accepts only one command per connection.
+// Transport failures abort without the fallback: they are not a denial by the
+// device, and retrying would mask them or silently degrade a working container
+// connection to documents-only access.
 func connect(dial func() (ios.DeviceConnectionInterface, error), bundleID string, udid string) (*afc.Client, error) {
 	deviceConn, err := dial()
 	if err != nil {
@@ -41,6 +44,10 @@ func connect(dial func() (ios.DeviceConnectionInterface, error), bundleID string
 		return afc.NewFromConn(deviceConn), nil
 	}
 	deviceConn.Close()
+	var denied vendError
+	if !errors.As(containerErr, &denied) {
+		return nil, containerErr
+	}
 	golog.Info("VendContainer was denied, falling back to VendDocuments", "module", logModule, "udid", udid, "bundleID", bundleID, "err", containerErr)
 	deviceConn, err = dial()
 	if err != nil {
@@ -70,11 +77,21 @@ func vend(deviceConn ios.DeviceConnectionInterface, command string, bundleID str
 	if err != nil {
 		return err
 	}
-	return checkResponse(response)
+	return checkResponse(response, command)
 }
 
-func checkResponse(vendContainerResponseBytes []byte) error {
-	response, err := plistFromBytes(vendContainerResponseBytes)
+// vendError is an error the device reported in a house_arrest response (e.g.
+// InstallationLookupFailed), as opposed to a transport failure.
+type vendError struct {
+	message string
+}
+
+func (e vendError) Error() string {
+	return e.message
+}
+
+func checkResponse(vendResponseBytes []byte, command string) error {
+	response, err := plistFromBytes(vendResponseBytes)
 	if err != nil {
 		return err
 	}
@@ -82,9 +99,9 @@ func checkResponse(vendContainerResponseBytes []byte) error {
 		return nil
 	}
 	if response.Error != "" {
-		return errors.New(response.Error)
+		return vendError{message: response.Error}
 	}
-	return errors.New("unknown error during vendcontainer")
+	return vendError{message: fmt.Sprintf("unknown error during %s", command)}
 }
 
 func plistFromBytes(plistBytes []byte) (vendContainerResponse, error) {

--- a/ios/house_arrest/house_arrest.go
+++ b/ios/house_arrest/house_arrest.go
@@ -2,10 +2,11 @@ package house_arrest
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/danielpaulus/go-ios/ios/afc"
-	"github.com/pkg/errors"
+	"github.com/danielpaulus/go-ios/ios/golog"
 	"howett.net/plist"
 
 	"github.com/danielpaulus/go-ios/ios"
@@ -13,25 +14,52 @@ import (
 
 const serviceName = "com.apple.mobile.house_arrest"
 
+const logModule = "go-ios/house_arrest"
+
+const (
+	commandVendContainer = "VendContainer"
+	commandVendDocuments = "VendDocuments"
+)
+
 func New(device ios.DeviceEntry, bundleID string) (*afc.Client, error) {
-	deviceConn, err := ios.ConnectToService(device, serviceName)
-	if err != nil {
-		return nil, err
-	}
-	err = vendContainer(deviceConn, bundleID)
-	if err != nil {
-		deviceConn.Close()
-		return nil, err
-	}
-	return afc.NewFromConn(deviceConn), nil
+	return connect(func() (ios.DeviceConnectionInterface, error) {
+		return ios.ConnectToService(device, serviceName)
+	}, bundleID, device.Properties.SerialNumber)
 }
 
-func vendContainer(deviceConn ios.DeviceConnectionInterface, bundleID string) error {
-	plistCodec := ios.NewPlistCodec()
-	vendContainer := map[string]interface{}{"Command": "VendContainer", "Identifier": bundleID}
-	msg, err := plistCodec.Encode(vendContainer)
+// connect vends the full app container. If the device denies that (it does for
+// apps not installed with a developer profile, e.g. App Store apps, reporting
+// InstallationLookupFailed), it falls back to documents-only access on a fresh
+// connection, since house_arrest accepts only one command per connection.
+func connect(dial func() (ios.DeviceConnectionInterface, error), bundleID string, udid string) (*afc.Client, error) {
+	deviceConn, err := dial()
 	if err != nil {
-		return fmt.Errorf("vendContainer Encoding cannot fail unless the encoder is broken: %v", err)
+		return nil, err
+	}
+	containerErr := vend(deviceConn, commandVendContainer, bundleID)
+	if containerErr == nil {
+		return afc.NewFromConn(deviceConn), nil
+	}
+	deviceConn.Close()
+	golog.Info("VendContainer was denied, falling back to VendDocuments", "module", logModule, "udid", udid, "bundleID", bundleID, "err", containerErr)
+	deviceConn, err = dial()
+	if err != nil {
+		return nil, err
+	}
+	documentsErr := vend(deviceConn, commandVendDocuments, bundleID)
+	if documentsErr == nil {
+		return afc.NewFromConn(deviceConn), nil
+	}
+	deviceConn.Close()
+	return nil, fmt.Errorf("house_arrest: VendContainer failed (%v) and the VendDocuments fallback failed (%v). Full container access requires an app installed with a developer profile; documents access requires the app to set UIFileSharingEnabled in its Info.plist", containerErr, documentsErr)
+}
+
+func vend(deviceConn ios.DeviceConnectionInterface, command string, bundleID string) error {
+	plistCodec := ios.NewPlistCodec()
+	request := map[string]interface{}{"Command": command, "Identifier": bundleID}
+	msg, err := plistCodec.Encode(request)
+	if err != nil {
+		return fmt.Errorf("%s Encoding cannot fail unless the encoder is broken: %v", command, err)
 	}
 	err = deviceConn.Send(msg)
 	if err != nil {

--- a/ios/house_arrest/house_arrest_test.go
+++ b/ios/house_arrest/house_arrest_test.go
@@ -1,1 +1,126 @@
-package house_arrest_test
+package house_arrest
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"howett.net/plist"
+)
+
+func TestVendContainerSuccessDoesNotFallBack(t *testing.T) {
+	conn := newFakeHouseArrestConn(t, map[string]interface{}{"Status": "Complete"})
+	dials := 0
+	dial := func() (ios.DeviceConnectionInterface, error) {
+		dials++
+		return conn, nil
+	}
+
+	client, err := connect(dial, "com.example.app", "udid-1")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	assert.Equal(t, 1, dials)
+	require.Len(t, conn.requests, 1)
+	assert.Equal(t, "VendContainer", conn.requests[0]["Command"])
+	assert.Equal(t, "com.example.app", conn.requests[0]["Identifier"])
+	assert.False(t, conn.closed, "the vended connection must stay open for afc")
+}
+
+func TestFallsBackToVendDocumentsWhenVendContainerFails(t *testing.T) {
+	containerConn := newFakeHouseArrestConn(t, map[string]interface{}{"Error": "InstallationLookupFailed"})
+	documentsConn := newFakeHouseArrestConn(t, map[string]interface{}{"Status": "Complete"})
+	conns := []*fakeHouseArrestConn{containerConn, documentsConn}
+	dials := 0
+	dial := func() (ios.DeviceConnectionInterface, error) {
+		conn := conns[dials]
+		dials++
+		return conn, nil
+	}
+
+	client, err := connect(dial, "com.example.app", "udid-1")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	assert.Equal(t, 2, dials)
+	require.Len(t, containerConn.requests, 1)
+	assert.Equal(t, "VendContainer", containerConn.requests[0]["Command"])
+	assert.True(t, containerConn.closed, "the failed VendContainer connection must be closed")
+	require.Len(t, documentsConn.requests, 1)
+	assert.Equal(t, "VendDocuments", documentsConn.requests[0]["Command"])
+	assert.Equal(t, "com.example.app", documentsConn.requests[0]["Identifier"])
+	assert.False(t, documentsConn.closed, "the vended connection must stay open for afc")
+}
+
+func TestBothVendsFailingReturnsHelpfulError(t *testing.T) {
+	containerConn := newFakeHouseArrestConn(t, map[string]interface{}{"Error": "InstallationLookupFailed"})
+	documentsConn := newFakeHouseArrestConn(t, map[string]interface{}{"Error": "ApplicationLookupFailed"})
+	conns := []*fakeHouseArrestConn{containerConn, documentsConn}
+	dials := 0
+	dial := func() (ios.DeviceConnectionInterface, error) {
+		conn := conns[dials]
+		dials++
+		return conn, nil
+	}
+
+	client, err := connect(dial, "com.example.app", "udid-1")
+	require.Error(t, err)
+	assert.Nil(t, client)
+
+	assert.Contains(t, err.Error(), "InstallationLookupFailed")
+	assert.Contains(t, err.Error(), "ApplicationLookupFailed")
+	assert.Contains(t, err.Error(), "UIFileSharingEnabled")
+	assert.True(t, containerConn.closed)
+	assert.True(t, documentsConn.closed)
+}
+
+// fakeHouseArrestConn is a mocked DeviceConnectionInterface that records the
+// plist requests sent to it and replays a single canned house_arrest response.
+type fakeHouseArrestConn struct {
+	t        *testing.T
+	requests []map[string]interface{}
+	readBuf  *bytes.Buffer
+	closed   bool
+}
+
+func newFakeHouseArrestConn(t *testing.T, response map[string]interface{}) *fakeHouseArrestConn {
+	framed, err := ios.NewPlistCodec().Encode(response)
+	require.NoError(t, err)
+	return &fakeHouseArrestConn{t: t, readBuf: bytes.NewBuffer(framed)}
+}
+
+func (f *fakeHouseArrestConn) Send(message []byte) error {
+	require.GreaterOrEqual(f.t, len(message), 4, "plist messages carry a 4 byte length header")
+	var request map[string]interface{}
+	_, err := plist.Unmarshal(message[4:], &request)
+	require.NoError(f.t, err)
+	f.requests = append(f.requests, request)
+	return nil
+}
+
+func (f *fakeHouseArrestConn) Reader() io.Reader { return f.readBuf }
+
+func (f *fakeHouseArrestConn) Close() error {
+	f.closed = true
+	return nil
+}
+
+func (f *fakeHouseArrestConn) Read(p []byte) (int, error)  { return f.readBuf.Read(p) }
+func (f *fakeHouseArrestConn) Write(p []byte) (int, error) { return len(p), f.Send(p) }
+func (f *fakeHouseArrestConn) Writer() io.Writer           { return f }
+func (f *fakeHouseArrestConn) Conn() net.Conn              { return nil }
+func (f *fakeHouseArrestConn) DisableSessionSSL()          {}
+
+func (f *fakeHouseArrestConn) EnableSessionSsl(ios.PairRecord) error           { return nil }
+func (f *fakeHouseArrestConn) EnableSessionSslServerMode(ios.PairRecord) error { return nil }
+func (f *fakeHouseArrestConn) EnableSessionSslHandshakeOnly(ios.PairRecord) error {
+	return nil
+}
+
+func (f *fakeHouseArrestConn) EnableSessionSslServerModeHandshakeOnly(ios.PairRecord) error {
+	return nil
+}

--- a/ios/house_arrest/house_arrest_test.go
+++ b/ios/house_arrest/house_arrest_test.go
@@ -78,8 +78,27 @@ func TestBothVendsFailingReturnsHelpfulError(t *testing.T) {
 	assert.True(t, documentsConn.closed)
 }
 
+func TestTransportErrorDoesNotFallBack(t *testing.T) {
+	conn := newFakeHouseArrestConn(t, nil) // connection drops before a response arrives
+	dials := 0
+	dial := func() (ios.DeviceConnectionInterface, error) {
+		dials++
+		return conn, nil
+	}
+
+	client, err := connect(dial, "com.example.app", "udid-1")
+	require.Error(t, err)
+	assert.Nil(t, client)
+
+	assert.ErrorIs(t, err, io.EOF)
+	assert.NotContains(t, err.Error(), "UIFileSharingEnabled", "transport errors must not be explained as vend denials")
+	assert.Equal(t, 1, dials, "a transport error must not trigger the VendDocuments fallback")
+	assert.True(t, conn.closed)
+}
+
 // fakeHouseArrestConn is a mocked DeviceConnectionInterface that records the
 // plist requests sent to it and replays a single canned house_arrest response.
+// A nil response simulates a transport failure: reads hit EOF.
 type fakeHouseArrestConn struct {
 	t        *testing.T
 	requests []map[string]interface{}
@@ -88,6 +107,9 @@ type fakeHouseArrestConn struct {
 }
 
 func newFakeHouseArrestConn(t *testing.T, response map[string]interface{}) *fakeHouseArrestConn {
+	if response == nil {
+		return &fakeHouseArrestConn{t: t, readBuf: &bytes.Buffer{}}
+	}
 	framed, err := ios.NewPlistCodec().Encode(response)
 	require.NoError(t, err)
 	return &fakeHouseArrestConn{t: t, readBuf: bytes.NewBuffer(framed)}


### PR DESCRIPTION
## Problem

`ios fsync --udid=<udid> --app=<bundleID> tree --path=/Documents` fails with:

```
{"err":"InstallationLookupFailed","level":"fatal","msg":"fsync: connect afc service failed"}
```

while `tidevice fsync -B <bundleID> ls /Documents` works on the very same devices (reported on iOS 15.7.5 and 17.6.1).

## Root cause

`ios/house_arrest` only ever sent `Command=VendContainer` to `com.apple.mobile.house_arrest`. The device denies full container access for apps that were not installed with a developer profile (i.e. App Store apps) and answers `InstallationLookupFailed`, so go-ios gave up immediately. Documents-only access via `Command=VendDocuments` is still allowed for such apps when they declare `UIFileSharingEnabled` — which is why tidevice (documents access) works on the same device.

Note: this root cause is a hypothesis backed by tidevice/pymobiledevice3 behavior on the reporters' devices; e2e confirmation on a device with an App Store app is optional (CI apps are developer-signed, so VendContainer keeps succeeding there and the fallback path stays dormant).

## Fix

- `house_arrest.New` first tries `VendContainer` as before. If the device reports an error, it reconnects (house_arrest accepts only one command per connection) and retries with `VendDocuments`, logging the fallback via `golog` with module/udid/bundleID attrs.
- If both commands fail, the returned error now includes both device errors and explains that container access needs a developer-profile install while documents access needs `UIFileSharingEnabled` in the app's Info.plist — instead of the bare `InstallationLookupFailed`.
- `checkResponse` now uses stdlib `errors` (only use of `pkg/errors` in the package) so the logged error attr isn't polluted with a stack trace.

## Options considered

1. **Automatic fallback (chosen):** `VendContainer` → on device error retry `VendDocuments`. Zero CLI changes, `--app` starts working for App Store apps exactly like tidevice, and dev-profile apps keep full container access. Paths under `/Documents` behave identically in both modes.
2. **Explicit `--documents` flag on fsync:** more explicit, but every existing caller (including `testmanagerd`'s house_arrest use) would still fail on App Store apps until users learn the flag, and it pushes a protocol detail into the CLI. Could still be added later on top of the fallback if someone needs to force documents-only mode.
3. **Both:** deferred — the fallback alone resolves the reported failure with the smallest surface.

## Test plan

- New device-free unit tests in `ios/house_arrest` with a mocked `DeviceConnectionInterface` that records the request plists and replays canned device responses:
  - `VendContainer` success → no second connection, connection kept open for AFC.
  - `VendContainer` denied (`InstallationLookupFailed`) → first connection closed, `VendDocuments` request plist emitted on a fresh connection.
  - Both denied → error mentions both device error codes and `UIFileSharingEnabled`, both connections closed.
- `go build ./...`, `go test ./...`, `gofmt -l` clean.

Fixes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk