### PR TITLE
feat(diagnostics): ios diagnostics ioreg command + public IORegistry API

### DIFF
--- a/cmd_device_diagnostics.go
+++ b/cmd_device_diagnostics.go
@@ -52,7 +52,23 @@ func runDateCommand(ctx commandContext) {
 }
 
 func runDiagnosticsCommand(ctx commandContext) {
+	if ioreg, _ := ctx.Args.Bool("ioreg"); ioreg {
+		runIORegCommand(ctx)
+		return
+	}
 	printDiagnostics(ctx.Device)
+}
+
+func runIORegCommand(ctx commandContext) {
+	plane, _ := ctx.Args.String("--plane")
+	name, _ := ctx.Args.String("--name")
+	class, _ := ctx.Args.String("--class")
+	conn, err := diagnostics.New(ctx.Device)
+	exitIfError("failed to connect to diagnostics service", err)
+	defer conn.Close()
+	values, err := conn.IORegistry(plane, name, class)
+	exitIfError("failed querying ioregistry", err)
+	fmt.Println(convertToJSONString(values))
 }
 
 func runBatteryRegistryCommand(ctx commandContext) {

--- a/ios/diagnostics/ioregistry.go
+++ b/ios/diagnostics/ioregistry.go
@@ -31,3 +31,34 @@ func (req *ioregistryRequest) encoded() ([]byte, error) {
 	}
 	return bt, nil
 }
+
+// IORegistry queries the device's ioregistry through the diagnostics relay.
+// plane, name and class map to the CurrentPlane, EntryName and EntryClass keys
+// of the request; empty values are omitted, so any subset can be passed.
+// Note that newer iOS versions return no data for EntryName queries; prefer
+// EntryClass there (e.g. class "IOPMPowerSource" for battery stats).
+func (diagnosticsConn *Connection) IORegistry(plane string, name string, class string) (map[string]interface{}, error) {
+	req := newIORegistryRequest()
+	if plane != "" {
+		req.addPlane(plane)
+	}
+	if name != "" {
+		req.addName(name)
+	}
+	if class != "" {
+		req.addClass(class)
+	}
+	encoded, err := req.encoded()
+	if err != nil {
+		return nil, err
+	}
+	err = diagnosticsConn.deviceConn.Send(encoded)
+	if err != nil {
+		return nil, err
+	}
+	response, err := diagnosticsConn.plistCodec.Decode(diagnosticsConn.deviceConn.Reader())
+	if err != nil {
+		return nil, err
+	}
+	return ios.ParsePlist(response)
+}

--- a/ios/diagnostics/ioregistry_test.go
+++ b/ios/diagnostics/ioregistry_test.go
@@ -1,0 +1,128 @@
+package diagnostics
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	ios "github.com/danielpaulus/go-ios/ios"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	plist "howett.net/plist"
+)
+
+// fakeDeviceConn records sent messages and replays a canned response.
+type fakeDeviceConn struct {
+	ios.DeviceConnectionInterface
+	sent     [][]byte
+	response bytes.Buffer
+}
+
+func (f *fakeDeviceConn) Send(message []byte) error {
+	f.sent = append(f.sent, message)
+	return nil
+}
+
+func (f *fakeDeviceConn) Reader() io.Reader { return &f.response }
+
+// cannedIORegistryResponse is a diagnostics relay response as a real device
+// sends it for an EntryClass=IOPMPowerSource query.
+const cannedIORegistryResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Diagnostics</key>
+	<dict>
+		<key>IORegistry</key>
+		<dict>
+			<key>CurrentCapacity</key>
+			<integer>85</integer>
+			<key>CycleCount</key>
+			<integer>321</integer>
+			<key>IsCharging</key>
+			<true/>
+			<key>Temperature</key>
+			<integer>3000</integer>
+			<key>Voltage</key>
+			<integer>4269</integer>
+		</dict>
+	</dict>
+	<key>Status</key>
+	<string>Success</string>
+</dict>
+</plist>`
+
+// framed prefixes payload with the 4 byte big endian length header used by
+// plist based lockdown services.
+func framed(payload string) []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, binary.BigEndian, uint32(len(payload)))
+	buf.WriteString(payload)
+	return buf.Bytes()
+}
+
+func newFakeConnection() (*Connection, *fakeDeviceConn) {
+	fake := &fakeDeviceConn{}
+	fake.response.Write(framed(cannedIORegistryResponse))
+	return &Connection{deviceConn: fake, plistCodec: ios.NewPlistCodec()}, fake
+}
+
+func TestIORegistryRequestEncoding(t *testing.T) {
+	tests := []struct {
+		name     string
+		plane    string
+		entry    string
+		class    string
+		expected map[string]string
+	}{
+		{"no filters", "", "", "", map[string]string{
+			"Request": "IORegistry",
+		}},
+		{"plane only", "IODeviceTree", "", "", map[string]string{
+			"Request": "IORegistry", "CurrentPlane": "IODeviceTree",
+		}},
+		{"name only", "", "AppleARMPMUCharger", "", map[string]string{
+			"Request": "IORegistry", "EntryName": "AppleARMPMUCharger",
+		}},
+		{"class only", "", "", "IOPMPowerSource", map[string]string{
+			"Request": "IORegistry", "EntryClass": "IOPMPowerSource",
+		}},
+		{"all", "IOService", "AppleARMPMUCharger", "IOPMPowerSource", map[string]string{
+			"Request": "IORegistry", "CurrentPlane": "IOService", "EntryName": "AppleARMPMUCharger", "EntryClass": "IOPMPowerSource",
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, fake := newFakeConnection()
+			_, err := conn.IORegistry(tt.plane, tt.entry, tt.class)
+			require.NoError(t, err)
+			require.Len(t, fake.sent, 1)
+			sent := fake.sent[0]
+			require.Greater(t, len(sent), 4)
+			assert.Equal(t, uint32(len(sent)-4), binary.BigEndian.Uint32(sent[:4]))
+			var decoded map[string]string
+			_, err = plist.Unmarshal(sent[4:], &decoded)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, decoded)
+		})
+	}
+}
+
+func TestIORegistryResponseDecoding(t *testing.T) {
+	conn, _ := newFakeConnection()
+	result, err := conn.IORegistry("", "", "IOPMPowerSource")
+	require.NoError(t, err)
+	assert.Equal(t, "Success", result["Status"])
+	diag, ok := result["Diagnostics"].(map[string]interface{})
+	require.True(t, ok, "Diagnostics should be a dict")
+	ioreg, ok := diag["IORegistry"].(map[string]interface{})
+	require.True(t, ok, "IORegistry should be a dict")
+	assert.Equal(t, map[string]interface{}{
+		"CurrentCapacity": uint64(85),
+		"CycleCount":      uint64(321),
+		"IsCharging":      true,
+		"Temperature":     uint64(3000),
+		"Voltage":         uint64(4269),
+	}, ioreg)
+}

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ Usage:
   ios devicestate list [options]
   ios devmode (enable | get | reveal) [--enable-post-restart] [options]
   ios diagnostics list [options]
+  ios diagnostics ioreg [--plane=<plane>] [--name=<name>] [--class=<class>] [options]
   ios diskspace [options]
   ios dproxy [--binary] [--mode=<all(default)|usbmuxd|utun>] [--iface=<iface>] [options]
   ios erase [--force] [options]
@@ -276,6 +277,13 @@ The commands work as following:
                                                                   Can also completely finalize developer mode setup after device is restarted.
 
     ios diagnostics list [options]                                List diagnostic infos
+
+    ios diagnostics ioreg [--plane=<plane>] [--name=<name>] [--class=<class>] [options]
+                                                                  Query the ioregistry and print the result as JSON.
+                                                                  Any subset of --plane (CurrentPlane), --name (EntryName) and --class (EntryClass) can be given.
+                                                                  Note: newer iOS versions return no data for EntryName queries, use --class instead.
+                                                                  Ex. "ios diagnostics ioreg --class=IOPMPowerSource"
+
     ios diskspace [options]                                       Prints disk space info.
 
     ios dproxy [--binary] [--mode=<all(default)|usbmuxd|utun>] [--iface=<iface>] [options]


### PR DESCRIPTION
## Problem

- #407 asks for CLI access to the ioregistry (`ios diagnostics ioreg <key>`-style), since MobileGestalt is deprecated on newer iOS versions.
- #278 reports that `EntryName` ioregistry queries return no data on newer iOS (worked on iOS 16, stopped on 17.4) while `EntryClass` still works. This is device-side behavior of the diagnostics relay, not a go-ios bug — the fix here is making `EntryClass` (and `CurrentPlane`) queries accessible so users have a working alternative.

Internally `ios/diagnostics/ioregistry.go` already had an `ioregistryRequest` builder supporting `CurrentPlane`/`EntryName`/`EntryClass`, but only `Battery()` (hardcoded `EntryClass=IOPMPowerSource`) was public and there was no CLI command.

## Design

- **Public API**: `Connection.IORegistry(plane, name, class string) (map[string]interface{}, error)` — any subset of parameters; empty strings are omitted from the request. Returns the parsed plist response as a generic map so callers get whatever the device returned (`Diagnostics`, `Status`, …) without a lossy typed struct.
- **CLI**: `ios diagnostics ioreg [--plane=<plane>] [--name=<name>] [--class=<class>]` prints the response as JSON. Help text documents the EntryName caveat and shows an `--class=IOPMPowerSource` example.

## Implementation

- `ios/diagnostics/ioregistry.go`: new `IORegistry` method reusing the existing request builder, `PlistCodec` send/receive, and `ios.ParsePlist` for decoding.
- `cmd_device_diagnostics.go`: `runDiagnosticsCommand` dispatches `ioreg` to a new `runIORegCommand` (connect, query, `convertToJSONString`, close), following the `runMobileGestaltCommand` pattern.
- `main.go`: usage pattern + long help entry for `ios diagnostics ioreg`.
- `ios/diagnostics/ioregistry_test.go`: device-free unit tests (see below).

## Options considered

1. **Return a typed struct** (like the existing `IORegistry` battery struct): rejected — ioregistry responses vary by plane/name/class query, a fixed struct would silently drop fields.
2. **`ios ioreg` as a top-level command**: rejected — the request goes through `com.apple.mobile.diagnostics_relay`, and #407 explicitly suggested `ios diagnostics ioreg`; grouping under `diagnostics` matches `mobilegestalt`/`batteryregistry` precedent.
3. **Preferred: generic map return + `ios diagnostics ioreg` subcommand with three optional flags** — minimal, reuses existing builders, and covers every combination the relay accepts.

## Test plan

- New unit tests (no device needed):
  - table test asserting the encoded plist request contains `Request=IORegistry` plus **exactly** the optional keys for each flag combination (none / plane / name / class / all), including the length-prefix framing;
  - a canned diagnostics relay response fixture is decoded into the returned map and asserted field-by-field.
- `go build ./...`, `go test ./...`, and `gofmt -l` clean on changed files.
- Manual: `ios diagnostics ioreg --class=IOPMPowerSource` parses correctly and reaches device lookup (no device on this host); real-device coverage via `/test-devices` CI.

Fixes #407, fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk