### PR TITLE
fix: dispatch 'ios webinspector launch' to webinspector, not 'ios launch'

### DIFF
--- a/cmd_device_registry.go
+++ b/cmd_device_registry.go
@@ -35,7 +35,16 @@ var deviceCommands = []command{
 	commandByBool("info", runInfoCommand),
 	commandByBool("syslog", runSyslogCommand),
 	commandByBool("ostrace", runOSTraceCommand),
-	commandByBool("screenshot", runScreenshotCommand),
+	{
+		// "screenshot" is also a subcommand literal of `ios ui screenshot`
+		// (dispatched as a global ui command), so only match the top-level
+		// `ios screenshot`.
+		name: "screenshot",
+		match: func(args docopt.Opts) bool {
+			return boolArg(args, "screenshot") && !boolArg(args, "ui")
+		},
+		run: runScreenshotCommand,
+	},
 	commandByBool("resetlocation", runResetLocationCommand),
 	commandByBool("devicename", runDeviceNameCommand),
 	commandByBool("apps", runAppsCommand),
@@ -64,7 +73,15 @@ var deviceCommands = []command{
 	commandByBool("assistivetouch", runAssistiveTouchCommand),
 	commandByBool("voiceover", runVoiceOverCommand),
 	commandByBool("zoom", runZoomCommand),
-	commandByBool("lockdown", runLockdownCommand),
+	{
+		// "lockdown" is also a subcommand literal of `ios info lockdown`, so only
+		// match the top-level `ios lockdown get [<key>]`.
+		name: "lockdown",
+		match: func(args docopt.Opts) bool {
+			return boolArg(args, "lockdown") && !boolArg(args, "info")
+		},
+		run: runLockdownCommand,
+	},
 	commandByBool("setlocation", runSetLocationCommand),
 	commandByBool("setlocationgpx", runSetLocationGPXCommand),
 	commandByBool("timeformat", runTimeFormatCommand),
@@ -72,7 +89,16 @@ var deviceCommands = []command{
 	commandByBool("mdm", runMdmCommand),
 	commandByBool("profile", runProfileCommand),
 	commandByBool("forward", runForwardCommand),
-	commandByBool("launch", runLaunchCommand),
+	{
+		// "launch" is also a subcommand literal of `ios webinspector launch <url>`
+		// and `ios ui app launch <bundleID>` (the latter is dispatched as a global
+		// ui command), so only match the top-level `ios launch <bundleID>`.
+		name: "launch",
+		match: func(args docopt.Opts) bool {
+			return boolArg(args, "launch") && !boolArg(args, "webinspector") && !boolArg(args, "ui")
+		},
+		run: runLaunchCommand,
+	},
 	commandByBool("sysmontap", runSysmontapCommand),
 	commandByBool("memlimitoff", runMemlimitOffCommand),
 	commandByBool("kill", runKillCommand),

--- a/command_registry_test.go
+++ b/command_registry_test.go
@@ -49,6 +49,83 @@ func TestDeviceListCommandOnlyMatchesTopLevelList(t *testing.T) {
 	}
 }
 
+// parseCLIArgs parses a real command line against the CLI's actual docopt
+// usage string, exactly as Main does.
+func parseCLIArgs(t *testing.T, argv ...string) docopt.Opts {
+	t.Helper()
+	parser := &docopt.Parser{HelpHandler: docopt.NoHelpHandler}
+	args, err := parser.ParseArgs(cliUsage(), argv, version)
+	if err != nil {
+		t.Fatalf("failed parsing argv %v: %v", argv, err)
+	}
+	return args
+}
+
+// firstMatchingCommand mirrors dispatchCommand's first-match-wins selection
+// without running the command.
+func firstMatchingCommand(args docopt.Opts, commands []command) string {
+	for _, cmd := range commands {
+		if cmd.match(args) {
+			return cmd.name
+		}
+	}
+	return ""
+}
+
+// dispatchedCommand walks the dispatch chain in the same order as Main
+// (globalCommands, then deviceCommands) and returns the name of the command
+// that would run.
+func dispatchedCommand(t *testing.T, argv ...string) string {
+	t.Helper()
+	args := parseCLIArgs(t, argv...)
+	if name := firstMatchingCommand(args, globalCommands); name != "" {
+		return "global:" + name
+	}
+	if name := firstMatchingCommand(args, deviceCommands); name != "" {
+		return "device:" + name
+	}
+	return ""
+}
+
+// TestDispatchSubcommandCollisions guards every subcommand literal that is also
+// a top-level command name. docopt sets a boolean for each literal it matched,
+// so e.g. `ios webinspector launch <url>` sets both "webinspector" and
+// "launch"; the registries must not let the wrong top-level command win
+// (issue #769).
+func TestDispatchSubcommandCollisions(t *testing.T) {
+	testCases := []struct {
+		name string
+		argv []string
+		want string
+	}{
+		// webinspector vs launch (issue #769)
+		{name: "webinspector launch dispatches webinspector", argv: []string{"webinspector", "launch", "https://example.com"}, want: "device:webinspector"},
+		{name: "webinspector launch with bundle-id dispatches webinspector", argv: []string{"webinspector", "launch", "https://example.com", "--bundle-id=com.apple.mobilesafari"}, want: "device:webinspector"},
+		{name: "plain launch dispatches launch", argv: []string{"launch", "com.apple.mobilesafari"}, want: "device:launch"},
+		// info vs lockdown
+		{name: "info lockdown dispatches info", argv: []string{"info", "lockdown"}, want: "device:info"},
+		{name: "plain lockdown dispatches lockdown", argv: []string{"lockdown", "get", "ProductVersion"}, want: "device:lockdown"},
+		// ui vs launch/screenshot/install/run
+		{name: "ui app launch dispatches ui", argv: []string{"ui", "app", "launch", "com.apple.mobilesafari"}, want: "global:ui"},
+		{name: "ui screenshot dispatches ui", argv: []string{"ui", "screenshot"}, want: "global:ui"},
+		{name: "plain screenshot dispatches screenshot", argv: []string{"screenshot"}, want: "device:screenshot"},
+		{name: "ui install dispatches ui install", argv: []string{"ui", "install", "wda", "--p12file=cert.p12", "--profile=dev.mobileprovision"}, want: "device:ui install"},
+		{name: "plain install dispatches install", argv: []string{"install", "--path=app.ipa"}, want: "device:install"},
+		{name: "ui run dispatches ui run", argv: []string{"ui", "run", "wda"}, want: "device:ui run"},
+		// webinspector vs list (also guarded by TestDeviceListCommandOnlyMatchesTopLevelList)
+		{name: "webinspector list dispatches webinspector", argv: []string{"webinspector", "list"}, want: "device:webinspector"},
+		{name: "plain list dispatches list", argv: []string{"list"}, want: "global:list"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := dispatchedCommand(t, testCase.argv...); got != testCase.want {
+				t.Fatalf("dispatchedCommand(%v) = %q, want %q", testCase.argv, got, testCase.want)
+			}
+		})
+	}
+}
+
 func TestTunnelCommandMatcher(t *testing.T) {
 	if !isTunnelCommand(docopt.Opts{"tunnel": true}) {
 		t.Fatal("tunnel command did not match")

--- a/main.go
+++ b/main.go
@@ -60,18 +60,11 @@ func main() {
 
 const version = "local-build"
 
-// Main Exports main for testing
-func Main() {
-	helpCatalog, err := clihelp.Load()
-	exitIfError("failed loading help definitions", err)
-	if handled, exitCode := helpCatalog.WriteHelp(os.Args[1:], version, os.Stdout, os.Stderr); handled {
-		if exitCode != 0 {
-			os.Exit(exitCode)
-		}
-		return
-	}
-
-	usage := fmt.Sprintf(`go-ios %s
+// cliUsage returns the docopt usage string that drives command dispatch.
+// It is a function (not inlined in Main) so tests can parse real command
+// lines against the exact usage the CLI ships.
+func cliUsage() string {
+	return fmt.Sprintf(`go-ios %s
 
 Usage:
   ios --version | version [options]
@@ -604,7 +597,20 @@ The commands work as following:
                                                                     iOS 11+ only (Use --force to try on older versions).
 
   `, version)
-	arguments, err := docopt.ParseDoc(usage)
+}
+
+// Main Exports main for testing
+func Main() {
+	helpCatalog, err := clihelp.Load()
+	exitIfError("failed loading help definitions", err)
+	if handled, exitCode := helpCatalog.WriteHelp(os.Args[1:], version, os.Stdout, os.Stderr); handled {
+		if exitCode != 0 {
+			os.Exit(exitCode)
+		}
+		return
+	}
+
+	arguments, err := docopt.ParseDoc(cliUsage())
 	exitIfError("failed parsing args", err)
 	configureCLI(arguments)
 	if dispatchCommand(commandContext{Args: arguments}, preProxyCommands) {


### PR DESCRIPTION
## Problem

`ios webinspector launch https://example.com` (with or without `--bundle-id`) fails with `please provide a bundleID` — it executes the top-level `ios launch` command instead of the webinspector subcommand.

## Root cause

docopt sets a boolean opt for **every** literal it matched on the command line, so `ios webinspector launch <url>` sets both `webinspector: true` and `launch: true`. The device command registry (`cmd_device_registry.go`) dispatches first-match-wins, and `commandByBool("launch", ...)` was listed before `commandByBool("webinspector", ...)`, so the launch handler won and exited because `<bundleID>` was empty (the URL is bound to `<url>`, and `--bundle-id` is a different key than `<bundleID>`).

## Fix

- Give `"launch"` a match func that only fires for the top-level command: `launch && !webinspector && !ui` — the same pattern the registry already uses for the `install`/`ui install` split. This is order-independent, so future registry reshuffles can't reintroduce the bug.
- **Audit of the whole registry for the same collision class** (subcommand literals that shadow a top-level command) found two more, fixed the same way:
  - `lockdown` now excludes `info`: `ios info lockdown` dispatched correctly only because `info` happened to be registered first.
  - `screenshot` now excludes `ui`: `ios ui screenshot` is caught by the global `ui` command today; the exclusion makes that ordering non-load-bearing.
  - Already-safe collisions (verified, unchanged): `ios <cmd> list` vs global `list` (guarded by `isDeviceListCommand` + existing test), `ios ui install`/`ios ui run` (explicit compound matchers), `ios sign certificate` (global), `ios ui app launch` (global `ui`).
- Extracted the docopt usage string from `Main()` into `cliUsage()` so unit tests can parse **real command lines against the exact usage string the CLI ships** (no behavior change; `Main` now calls `docopt.ParseDoc(cliUsage())`).

## Options considered

1. **Reorder the registry** (move `webinspector` above `launch`): smallest diff, but fragile — the bug silently returns if anyone reorders or inserts entries, and it doesn't fix the latent `info lockdown` ordering dependency.
2. **Exclusion match funcs (chosen)**: dispatch becomes order-independent for every known collision, matches the established `install`/`ui` pattern in the same file, and each exclusion is documented inline. The new test locks all of them down.
3. Rewriting dispatch to score matches by specificity (most booleans matched wins): most general, but a much bigger behavioral change than this bug warrants.

## Test plan

- New `TestDispatchSubcommandCollisions` (device-free): docopt-parses real argv against `cliUsage()` and walks the global→device dispatch chain in the same order as `Main`, asserting:
  - `webinspector launch <url>` (± `--bundle-id`) → `webinspector`, plain `launch <bundleID>` → `launch` (fails on `main` before this fix)
  - `info lockdown` → `info`, `lockdown get <key>` → `lockdown`
  - `ui app launch` / `ui screenshot` → global `ui`; plain `screenshot` → `screenshot`
  - `ui install` / `ui run` / plain `install`, `webinspector list` / plain `list` regression coverage
- `go build ./...`, `go vet .`, full `go test ./...` green (24 packages); `gofmt -l` clean on changed files.

Fixes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk