### PR TITLE
feat(syslog): client-side --process/--pid filters to follow the app under test

### DIFF
--- a/cmd_device_debug.go
+++ b/cmd_device_debug.go
@@ -15,6 +15,7 @@ import (
 	"github.com/danielpaulus/go-ios/ios/instruments"
 	"github.com/danielpaulus/go-ios/ios/ostrace"
 	"github.com/danielpaulus/go-ios/ios/pcap"
+	"github.com/danielpaulus/go-ios/ios/syslog"
 )
 
 func runPCAPCommand(ctx commandContext) {
@@ -35,7 +36,13 @@ func runDproxyCommand(ctx commandContext) {
 
 func runSyslogCommand(ctx commandContext) {
 	parse, _ := ctx.Args.Bool("--parse")
-	runSyslog(ctx.Device, parse)
+	process, _ := ctx.Args.String("--process")
+	pidStr, _ := ctx.Args.String("--pid")
+	if pidStr != "" {
+		_, err := strconv.Atoi(pidStr)
+		exitIfError("invalid --pid value", err)
+	}
+	runSyslog(ctx.Device, parse, syslog.EntryFilter{Process: process, PID: pidStr})
 }
 
 func runOSTraceCommand(ctx commandContext) {

--- a/cmd_device_debug.go
+++ b/cmd_device_debug.go
@@ -39,8 +39,10 @@ func runSyslogCommand(ctx commandContext) {
 	process, _ := ctx.Args.String("--process")
 	pidStr, _ := ctx.Args.String("--pid")
 	if pidStr != "" {
-		_, err := strconv.Atoi(pidStr)
+		pid, err := strconv.Atoi(pidStr)
 		exitIfError("invalid --pid value", err)
+		// normalize (e.g. "0042" -> "42") so the string compare against parsed pids works
+		pidStr = strconv.Itoa(pid)
 	}
 	runSyslog(ctx.Device, parse, syslog.EntryFilter{Process: process, PID: pidStr})
 }

--- a/ios/syslog/syslog.go
+++ b/ios/syslog/syslog.go
@@ -122,6 +122,35 @@ func Parser() func(log string) (*LogEntry, error) {
 	}
 }
 
+// EntryFilter is a client-side predicate over parsed log entries.
+// Empty fields match everything, so the zero value matches every entry.
+type EntryFilter struct {
+	// Process matches the parsed process name exactly (e.g. "SpringBoard").
+	Process string
+	// PID matches the parsed process id exactly (e.g. "1234").
+	PID string
+}
+
+// IsEmpty reports whether the filter matches every entry.
+func (f EntryFilter) IsEmpty() bool {
+	return f.Process == "" && f.PID == ""
+}
+
+// Matches reports whether the parsed entry passes the filter.
+// A nil entry never matches.
+func (f EntryFilter) Matches(entry *LogEntry) bool {
+	if entry == nil {
+		return false
+	}
+	if f.Process != "" && entry.Process != f.Process {
+		return false
+	}
+	if f.PID != "" && entry.PID != f.PID {
+		return false
+	}
+	return true
+}
+
 // Close closes the underlying UsbMuxConnection
 func (sysLogConn *Connection) Close() error {
 	return sysLogConn.closer.Close()

--- a/ios/syslog/syslog.go
+++ b/ios/syslog/syslog.go
@@ -126,6 +126,9 @@ func Parser() func(log string) (*LogEntry, error) {
 // Empty fields match everything, so the zero value matches every entry.
 type EntryFilter struct {
 	// Process matches the parsed process name exactly (e.g. "SpringBoard").
+	// Syslog annotates os_log senders with the emitting library, e.g.
+	// "SpringBoard(FrontBoard)[52]"; such an annotation is ignored, so
+	// "SpringBoard" matches both "SpringBoard" and "SpringBoard(FrontBoard)".
 	Process string
 	// PID matches the parsed process id exactly (e.g. "1234").
 	PID string
@@ -142,13 +145,22 @@ func (f EntryFilter) Matches(entry *LogEntry) bool {
 	if entry == nil {
 		return false
 	}
-	if f.Process != "" && entry.Process != f.Process {
+	if f.Process != "" && entry.Process != f.Process && baseProcessName(entry.Process) != f.Process {
 		return false
 	}
 	if f.PID != "" && entry.PID != f.PID {
 		return false
 	}
 	return true
+}
+
+// baseProcessName strips the "(Library)" annotation syslog appends to os_log
+// senders, e.g. "SpringBoard(FrontBoard)" -> "SpringBoard".
+func baseProcessName(process string) string {
+	if i := strings.IndexByte(process, '('); i > 0 && strings.HasSuffix(process, ")") {
+		return process[:i]
+	}
+	return process
 }
 
 // Close closes the underlying UsbMuxConnection

--- a/ios/syslog/syslog.go
+++ b/ios/syslog/syslog.go
@@ -58,12 +58,13 @@ func NewWithShimConnection(device ios.DeviceEntry) (*Connection, error) {
 
 // ReadLogMessage this is a blocking function that will return individual log messages received from syslog.
 // Call it in an endless for loop in a separate go routine.
+// Messages are vis-decoded (see DecodeVis) so non-ASCII text renders as UTF-8.
 func (sysLogConn *Connection) ReadLogMessage() (string, error) {
 	logmsg, err := sysLogConn.bufferedReader.ReadString(0)
 	if err != nil {
 		return "", err
 	}
-	return logmsg, nil
+	return DecodeVis(logmsg), nil
 }
 
 // LogEntry represents a parsed log entry

--- a/ios/syslog/syslog_test.go
+++ b/ios/syslog/syslog_test.go
@@ -146,6 +146,9 @@ func TestEntryFilter(t *testing.T) {
 	require.NoError(t, err)
 	myApp, err := parse("Jan 2 15:04:06 iPhone MyApp[42] <Error>: something failed")
 	require.NoError(t, err)
+	annotated, err := parse("Jan 2 15:04:07 iPhone SpringBoard(FrontBoard)[123] <Notice>: os_log line")
+	require.NoError(t, err)
+	require.Equal(t, "SpringBoard(FrontBoard)", annotated.Process)
 
 	tests := []struct {
 		name   string
@@ -175,6 +178,30 @@ func TestEntryFilter(t *testing.T) {
 			name:   "process name match is exact, not substring",
 			filter: syslog.EntryFilter{Process: "MyApp"},
 			entry:  &syslog.LogEntry{Process: "MyAppExtension", PID: "43"},
+			want:   false,
+		},
+		{
+			name:   "process name matches despite (Library) annotation",
+			filter: syslog.EntryFilter{Process: "SpringBoard"},
+			entry:  annotated,
+			want:   true,
+		},
+		{
+			name:   "annotated process name matches exactly",
+			filter: syslog.EntryFilter{Process: "SpringBoard(FrontBoard)"},
+			entry:  annotated,
+			want:   true,
+		},
+		{
+			name:   "library annotation alone does not match",
+			filter: syslog.EntryFilter{Process: "FrontBoard"},
+			entry:  annotated,
+			want:   false,
+		},
+		{
+			name:   "annotation does not turn exact match into prefix match",
+			filter: syslog.EntryFilter{Process: "MyApp"},
+			entry:  &syslog.LogEntry{Process: "MyAppExtension(Foundation)", PID: "44"},
 			want:   false,
 		},
 		{

--- a/ios/syslog/syslog_test.go
+++ b/ios/syslog/syslog_test.go
@@ -140,6 +140,88 @@ func TestDecodeVis(t *testing.T) {
 	}
 }
 
+func TestEntryFilter(t *testing.T) {
+	parse := syslog.Parser()
+	springboard, err := parse("Jan 2 15:04:05 iPhone SpringBoard[123] <Notice>: hello world")
+	require.NoError(t, err)
+	myApp, err := parse("Jan 2 15:04:06 iPhone MyApp[42] <Error>: something failed")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		filter syslog.EntryFilter
+		entry  *syslog.LogEntry
+		want   bool
+	}{
+		{
+			name:   "empty filter matches everything",
+			filter: syslog.EntryFilter{},
+			entry:  springboard,
+			want:   true,
+		},
+		{
+			name:   "process name matches",
+			filter: syslog.EntryFilter{Process: "MyApp"},
+			entry:  myApp,
+			want:   true,
+		},
+		{
+			name:   "process name does not match",
+			filter: syslog.EntryFilter{Process: "MyApp"},
+			entry:  springboard,
+			want:   false,
+		},
+		{
+			name:   "process name match is exact, not substring",
+			filter: syslog.EntryFilter{Process: "MyApp"},
+			entry:  &syslog.LogEntry{Process: "MyAppExtension", PID: "43"},
+			want:   false,
+		},
+		{
+			name:   "pid matches",
+			filter: syslog.EntryFilter{PID: "42"},
+			entry:  myApp,
+			want:   true,
+		},
+		{
+			name:   "pid does not match",
+			filter: syslog.EntryFilter{PID: "42"},
+			entry:  springboard,
+			want:   false,
+		},
+		{
+			name:   "process and pid both match",
+			filter: syslog.EntryFilter{Process: "MyApp", PID: "42"},
+			entry:  myApp,
+			want:   true,
+		},
+		{
+			name:   "process matches but pid does not",
+			filter: syslog.EntryFilter{Process: "MyApp", PID: "99"},
+			entry:  myApp,
+			want:   false,
+		},
+		{
+			name:   "nil entry never matches",
+			filter: syslog.EntryFilter{},
+			entry:  nil,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.filter.Matches(tt.entry))
+		})
+	}
+}
+
+func TestEntryFilterIsEmpty(t *testing.T) {
+	assert.True(t, syslog.EntryFilter{}.IsEmpty())
+	assert.False(t, syslog.EntryFilter{Process: "MyApp"}.IsEmpty())
+	assert.False(t, syslog.EntryFilter{PID: "42"}.IsEmpty())
+}
+
 func TestParserWithDecodedVisLine(t *testing.T) {
 	parse := syslog.Parser()
 	line := syslog.DecodeVis(`Jan 2 15:04:05 iPhone MyApp[42] <Error>: indexPath \M-f\M^H\M^V model \M-d\M-8\M-:\M-g\M-)\M-:`)

--- a/ios/syslog/syslog_test.go
+++ b/ios/syslog/syslog_test.go
@@ -59,3 +59,94 @@ func TestParser(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeVis(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "vis-escaped CJK decodes to UTF-8",
+			in:   `indexPath \M-f\M^H\M^V model \M-d\M-8\M-:\M-g\M-)\M-: - done`,
+			want: "indexPath 或 model 为空 - done",
+		},
+		{
+			name: "meta escape",
+			in:   `\M-f`,
+			want: "\xe6",
+		},
+		{
+			name: "meta-control escape",
+			in:   `\M^H`,
+			want: "\x88",
+		},
+		{
+			name: "meta-control DEL variant",
+			in:   `\M^?`,
+			want: "\xff",
+		},
+		{
+			name: "plain ASCII passes through",
+			in:   "hello world [123] <Notice>: nothing to decode",
+			want: "hello world [123] <Notice>: nothing to decode",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "escaped backslash decodes to single backslash",
+			in:   `path C:\\Users\\M-f`,
+			want: `path C:\Users\M-f`,
+		},
+		{
+			name: "lone trailing backslash stays",
+			in:   `abc\`,
+			want: `abc\`,
+		},
+		{
+			name: "truncated meta escape stays",
+			in:   `abc\M-`,
+			want: `abc\M-`,
+		},
+		{
+			name: "truncated meta-control escape stays",
+			in:   `abc\M^`,
+			want: `abc\M^`,
+		},
+		{
+			name: "unknown escape stays",
+			in:   `abc\q def\Mx`,
+			want: `abc\q def\Mx`,
+		},
+		{
+			name: "control escape is left encoded",
+			in:   `esc \^[ bell \^G`,
+			want: `esc \^[ bell \^G`,
+		},
+		{
+			name: "raw UTF-8 passes through unchanged",
+			in:   "已经是 UTF-8 了",
+			want: "已经是 UTF-8 了",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, syslog.DecodeVis(tt.in))
+		})
+	}
+}
+
+func TestParserWithDecodedVisLine(t *testing.T) {
+	parse := syslog.Parser()
+	line := syslog.DecodeVis(`Jan 2 15:04:05 iPhone MyApp[42] <Error>: indexPath \M-f\M^H\M^V model \M-d\M-8\M-:\M-g\M-)\M-:`)
+	e, err := parse(line)
+	require.NoError(t, err)
+	require.NotNil(t, e)
+	assert.Equal(t, "MyApp", e.Process)
+	assert.Equal(t, "42", e.PID)
+	assert.Equal(t, "indexPath 或 model 为空", e.Message)
+}

--- a/ios/syslog/vis.go
+++ b/ios/syslog/vis.go
@@ -1,0 +1,50 @@
+package syslog
+
+import "strings"
+
+// DecodeVis reverses the BSD vis(3) encoding that syslog_relay applies to
+// non-ASCII bytes before sending log lines. Without decoding, multi-byte
+// UTF-8 characters (e.g. CJK) show up as escape sequences like
+// "\M-f\M^H\M^V" instead of readable text.
+//
+// Only the escapes syslog_relay emits for high bytes are decoded:
+//
+//	\M-x  -> 0x80 | x          (meta)
+//	\M^X  -> 0x80 | (X ^ 0x40) (meta + control)
+//	\\    -> \                 (escaped backslash)
+//
+// Control-character escapes (\^X) and anything unrecognized are left
+// untouched, so decoding never reintroduces raw control bytes (e.g. ESC)
+// into terminal output. Lone or truncated backslash sequences pass through
+// unchanged.
+func DecodeVis(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] != '\\' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		rest := s[i+1:]
+		switch {
+		case len(rest) >= 3 && rest[0] == 'M' && rest[1] == '-':
+			b.WriteByte(rest[2] | 0x80)
+			i += 4
+		case len(rest) >= 3 && rest[0] == 'M' && rest[1] == '^':
+			b.WriteByte((rest[2] ^ 0x40) | 0x80)
+			i += 4
+		case len(rest) >= 1 && rest[0] == '\\':
+			b.WriteByte('\\')
+			i += 2
+		default:
+			// lone backslash or unrecognized escape: keep as-is
+			b.WriteByte('\\')
+			i++
+		}
+	}
+	return b.String()
+}

--- a/main.go
+++ b/main.go
@@ -544,8 +544,11 @@ The commands work as following:
     ios syslog [--parse] [--pid=<processID>] [--process=<processName>]
                                                                     Prints a device's log output, Use --parse to parse the fields from the log
                                                                     Client-side filters (the full stream is still received from the device):
-                                                                      --process=<name>     Only show entries logged by this process name (exact match)
+                                                                      --process=<name>     Only show entries logged by this process name (exact match;
+                                                                                           a "(Library)" annotation as in "SpringBoard(FrontBoard)" is ignored)
                                                                       --pid=<pid>          Only show entries logged by this process ID
+                                                                    Lines that cannot be parsed (and therefore cannot be attributed to a
+                                                                    process) are omitted while a filter is active.
                                                                     Filtering is handy alongside 'ios test'/'ios runtest': run syslog with
                                                                     --process=<appName> in a second terminal to capture the NSLog/os_log
                                                                     output of the app under test while the tests execute.

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ Usage:
   ios get-wallpaper [--output=<outfile>] [options]
   ios get-icon-layout [--output=<outfile>] [options]
   ios set-icon-layout <layoutFile> [options]
-  ios syslog [--parse] [options]
+  ios syslog [--parse] [--pid=<processID>] [--process=<processName>] [options]
   ios ostrace [--pid=<processID>] [--process=<processName>] [--follow] [--level=<levels>] [--subsystem=<sub>] [--match=<str>] [--exclude=<str>] [options]
   ios sysmontap [options]
   ios timeformat (24h | 12h | toggle | get) [--force] [options]
@@ -541,7 +541,14 @@ The commands work as following:
                                                                     behavior may occur if the given layout does not contain every icon on the device".
                                                                     Missing apps are re-paginated, not hidden.
 
-    ios syslog [--parse] [options]                                  Prints a device's log output, Use --parse to parse the fields from the log
+    ios syslog [--parse] [--pid=<processID>] [--process=<processName>]
+                                                                    Prints a device's log output, Use --parse to parse the fields from the log
+                                                                    Client-side filters (the full stream is still received from the device):
+                                                                      --process=<name>     Only show entries logged by this process name (exact match)
+                                                                      --pid=<pid>          Only show entries logged by this process ID
+                                                                    Filtering is handy alongside 'ios test'/'ios runtest': run syslog with
+                                                                    --process=<appName> in a second terminal to capture the NSLog/os_log
+                                                                    output of the app under test while the tests execute.
     ios ostrace [--pid=<processID>] [--process=<processName>] [--follow] [--level=<levels>] [--subsystem=<sub>] [--match=<str>] [--exclude=<str>]
                                                                      Stream structured syslog via os_trace_relay. Note: streaming logs
                                                                      places significant CPU load on the device.
@@ -1574,7 +1581,7 @@ func printDeviceInfo(device ios.DeviceEntry) {
 	fmt.Println(convertToJSONString(allValues))
 }
 
-func runSyslog(device ios.DeviceEntry, parse bool) {
+func runSyslog(device ios.DeviceEntry, parse bool, filter syslog.EntryFilter) {
 	slog.Debug("Run Syslog.")
 
 	syslogConnection, err := syslog.New(device)
@@ -1591,6 +1598,7 @@ func runSyslog(device ios.DeviceEntry, parse bool) {
 		logFormatter = legacyJsonSyslog()
 	}
 
+	filterParser := syslog.Parser()
 	go func() {
 		for {
 			logMessage, err := syslogConnection.ReadLogMessage()
@@ -1599,6 +1607,14 @@ func runSyslog(device ios.DeviceEntry, parse bool) {
 			}
 			logMessage = strings.TrimSuffix(logMessage, "\x00")
 			logMessage = strings.TrimSuffix(logMessage, "\x0A")
+
+			if !filter.IsEmpty() {
+				entry, err := filterParser(logMessage)
+				if err != nil || !filter.Matches(entry) {
+					// unparseable lines cannot be attributed to a process, skip them while filtering
+					continue
+				}
+			}
 
 			fmt.Println(logFormatter(logMessage))
 		}


### PR DESCRIPTION
Based on #793 (stacked; same package). The diff includes #793's commit; only the last commit (`feat(syslog): add client-side --process and --pid filters`) is new here. Merge #793 first.

## Problem

Issue #202: when running XCUITests via `ios test`/`ios runtest`, there is no convenient way to see the main app's logs. `ios syslog` does stream them (NSLog/os_log go to the system log), but the full firehose makes the app's output impossible to follow.

## Root cause

`ios/syslog` already parses `Process` and `PID` out of each entry, but the CLI had no way to select entries by them — the only options were "everything" or grepping the raw stream yourself.

## Fix

- New `syslog.EntryFilter` (`ios/syslog/syslog.go`): a client-side predicate over parsed entries matching exact process name and/or PID; the zero value matches everything.
- CLI wiring: `ios syslog [--parse] [--pid=<processID>] [--process=<processName>]`. While filtering, each line is parsed and non-matching (or unparseable, hence unattributable) lines are skipped. Works with all output modes (`--nojson`, legacy JSON, `--parse`); `--pid` is validated to be numeric.
- Help text documents the runtest workflow: run `ios syslog --process=<appName>` in a second terminal while `ios test`/`ios runtest` executes to capture the app under test's NSLog/os_log output.

## Options considered

1. **Client-side filter over parsed entries (chosen)** — small, safe, works on every iOS version go-ios supports, and composes with existing output modes. Downside: the full stream still crosses USB (documented in help text).
2. Device-side filtered syslog (the "mechanism 2" mentioned in the issue thread, as in iosif) — reduces USB traffic, but is a different service/protocol and a much larger change; can still be added later without conflicting with this flag surface. For device-side filtering today, `ios ostrace --process=<name>` already exists.
3. Full Xcode-parity stdout capture inside `ios runtest` (attaching to the app process / debugger-style stdout redirection via dtx) — **out of scope**: it requires touching xctest/testmanagerd/dtx protocol internals, which are deliberately frozen until e2e coverage exists (see also the abandoned attempt in #205). `print()` output that never reaches the system log is therefore still not captured; NSLog/os_log is.

## Test plan

- New table-driven `TestEntryFilter` over canned parsed lines: empty filter matches all, match/non-match by process name (exact, not substring), match/non-match by PID, combined process+PID, nil entry never matches.
- `TestEntryFilterIsEmpty` for the zero-value fast path.
- Manual smoke test: `ios syslog --process=MyApp --pid=42` passes docopt parsing; `--pid=notanumber` is rejected.
- `go build ./...`, `go test ./...`, `gofmt -l` clean.

Fixes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk
