### PR TITLE
feat(pcap): add --timeout and clean Ctrl-C shutdown to ios pcap

### DIFF
--- a/cmd_device_debug.go
+++ b/cmd_device_debug.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -8,6 +9,7 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/danielpaulus/go-ios/ios/crashreport"
 	"github.com/danielpaulus/go-ios/ios/debugserver"
@@ -22,7 +24,16 @@ func runPCAPCommand(ctx commandContext) {
 	i, _ := ctx.Args.Int("--pid")
 	pcap.Pid = int32(i)
 	pcap.ProcName = p
-	err := pcap.Start(ctx.Device)
+	captureCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if timeoutStr, _ := ctx.Args.String("--timeout"); timeoutStr != "" {
+		timeout, err := time.ParseDuration(timeoutStr)
+		exitIfError("invalid --timeout value, use a duration like 30s, 2m or 1h", err)
+		var cancel context.CancelFunc
+		captureCtx, cancel = context.WithTimeout(captureCtx, timeout)
+		defer cancel()
+	}
+	err := pcap.Start(captureCtx, ctx.Device)
 	if err != nil {
 		exitIfError("pcap failed", err)
 	}

--- a/ios/pcap/pcap.go
+++ b/ios/pcap/pcap.go
@@ -97,20 +97,38 @@ type captureConn interface {
 // pending read and capture returns nil, leaving w a valid pcap stream.
 func capture(ctx context.Context, conn captureConn, w io.Writer) error {
 	done := make(chan struct{})
-	defer close(done)
+	// closedByWatchdog is set (before watchdogDone is closed) only when the
+	// watchdog closed conn because ctx was canceled, so a read error caused by
+	// that close is classified as a clean shutdown rather than a failure.
+	var closedByWatchdog bool
+	watchdogDone := make(chan struct{})
 	go func() {
+		defer close(watchdogDone)
 		select {
 		case <-ctx.Done():
+			closedByWatchdog = true
 			conn.Close()
 		case <-done:
 		}
+	}()
+	// Wait for the watchdog to finish before returning so its conn.Close() never
+	// races the caller's own deferred close of the same connection.
+	defer func() {
+		close(done)
+		<-watchdogDone
 	}()
 	plistCodec := ios.NewPlistCodec()
 	for {
 		b, err := plistCodec.Decode(conn.Reader())
 		if err != nil {
+			// A read error after the watchdog closed conn is the expected way a
+			// canceled capture unblocks; report it as a clean stop. Block on
+			// watchdogDone first so closedByWatchdog is observed race-free.
 			if ctx.Err() != nil {
-				return nil
+				<-watchdogDone
+				if closedByWatchdog {
+					return nil
+				}
 			}
 			return err
 		}

--- a/ios/pcap/pcap.go
+++ b/ios/pcap/pcap.go
@@ -2,6 +2,7 @@ package pcap
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -55,13 +56,16 @@ func (iph *IOSPacketHeader) ToString() string {
 	return fmt.Sprintf("%v", *iph)
 }
 
-func Start(device ios.DeviceEntry) error {
+// Start captures network traffic from the device into a pcap file in the
+// current working directory until ctx is canceled (timeout, Ctrl-C, ...)
+// or the connection fails. On cancellation the file is finalized cleanly
+// and Start returns nil.
+func Start(ctx context.Context, device ios.DeviceEntry) error {
 	intf, err := ios.ConnectToService(device, "com.apple.pcapd")
 	if err != nil {
 		return err
 	}
 	defer intf.Close()
-	plistCodec := ios.NewPlistCodec()
 	fname := fmt.Sprintf("dump-%d.pcap", time.Now().Unix())
 	if Pid > 0 {
 		fname = fmt.Sprintf("dump-%d-%d.pcap", Pid, time.Now().Unix())
@@ -74,9 +78,40 @@ func Start(device ios.DeviceEntry) error {
 	}
 	defer f.Close()
 	golog.Info("create pcap file", "module", logModule, "udid", device.Properties.SerialNumber, "path", fname)
+	err = capture(ctx, intf, f)
+	if err != nil {
+		return err
+	}
+	golog.Info("pcap capture stopped", "module", logModule, "udid", device.Properties.SerialNumber, "path", fname)
+	return f.Sync()
+}
+
+// captureConn is the subset of ios.DeviceConnectionInterface the capture loop needs.
+type captureConn interface {
+	Reader() io.Reader
+	Close() error
+}
+
+// capture reads packets from conn and streams pcap records to w until ctx is done
+// or reading fails. When ctx is done, the connection is closed to unblock the
+// pending read and capture returns nil, leaving w a valid pcap stream.
+func capture(ctx context.Context, conn captureConn, w io.Writer) error {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			conn.Close()
+		case <-done:
+		}
+	}()
+	plistCodec := ios.NewPlistCodec()
 	for {
-		b, err := plistCodec.Decode(intf.Reader())
+		b, err := plistCodec.Decode(conn.Reader())
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
 			return err
 		}
 		decodedBytes, err := fromBytes(b)
@@ -88,7 +123,7 @@ func Start(device ios.DeviceEntry) error {
 			return err
 		}
 		if len(packet) > 0 {
-			err = writePacket(f, iph, packet)
+			err = writePacket(w, iph, packet)
 			if err != nil {
 				return err
 			}
@@ -132,16 +167,25 @@ func createPcap(name string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Write `pcap_hdr_s` with little endin to file.
-	f.Write([]byte{
+	err = writePcapHeader(f)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+// writePcapHeader writes `pcap_hdr_s` with little endian to w.
+func writePcapHeader(w io.Writer) error {
+	_, err := w.Write([]byte{
 		0xd4, 0xc3, 0xb2, 0xa1, 0x02, 0x00, 0x04, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0xff, 0xff, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
 	})
-	return f, nil
+	return err
 }
 
-func writePacket(f *os.File, iph IOSPacketHeader, packet []byte) error {
+func writePacket(w io.Writer, iph IOSPacketHeader, packet []byte) error {
 	phs := &PcaprecHdrS{
 		iph.TsSec,
 		iph.TsUsec,
@@ -153,9 +197,12 @@ func writePacket(f *os.File, iph IOSPacketHeader, packet []byte) error {
 	if err != nil {
 		return err
 	}
-	f.Write(buf.Bytes())
-	f.Write(packet)
-	return nil
+	_, err = w.Write(buf.Bytes())
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(packet)
+	return err
 }
 
 func getPacket(buf []byte) (iph IOSPacketHeader, packet []byte, err error) {

--- a/ios/pcap/pcap_test.go
+++ b/ios/pcap/pcap_test.go
@@ -1,0 +1,253 @@
+package pcap
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket/pcapgo"
+	"github.com/lunixbochs/struc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"howett.net/plist"
+)
+
+// fakeDeviceConnection is an in-memory stand-in for the pcapd service
+// connection. Close unblocks a pending Reader() read, like closing a real
+// device connection does.
+type fakeDeviceConnection struct {
+	r *io.PipeReader
+}
+
+func (f *fakeDeviceConnection) Reader() io.Reader { return f.r }
+func (f *fakeDeviceConnection) Close() error      { return f.r.Close() }
+
+func testPacketHeader(payloadLen int) IOSPacketHeader {
+	return IOSPacketHeader{
+		HdrSize:        PacketHeaderSize,
+		Version:        2,
+		PacketSize:     uint32(payloadLen),
+		Type:           1,
+		IO:             1,
+		ProtocolFamily: 2,
+		FramePreLength: 14,
+		IFName:         "en0",
+		Pid:            -1,
+		ProcName:       "testproc",
+		Pid2:           -1,
+		ProcName2:      "testproc",
+		TsSec:          1700000000,
+		TsUsec:         123456,
+	}
+}
+
+// packHeader serializes an IOSPacketHeader the way pcapd does on the wire.
+func packHeader(t *testing.T, iph IOSPacketHeader) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	err := struc.Pack(&buf, &iph)
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
+// makeFrame builds one full pcapd wire frame: a 4 byte big endian length
+// followed by a binary plist containing header+payload as a data element.
+func makeFrame(t *testing.T, iph IOSPacketHeader, payload []byte) []byte {
+	t.Helper()
+	raw := append(packHeader(t, iph), payload...)
+	plistBytes, err := plist.Marshal(raw, plist.BinaryFormat)
+	require.NoError(t, err)
+	frame := make([]byte, 4, 4+len(plistBytes))
+	binary.BigEndian.PutUint32(frame, uint32(len(plistBytes)))
+	return append(frame, plistBytes...)
+}
+
+func resetFilters(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		Pid = int32(-2)
+		ProcName = ""
+	})
+	Pid = int32(-2)
+	ProcName = ""
+}
+
+func TestFromBytes(t *testing.T) {
+	payload := []byte{0xde, 0xad, 0xbe, 0xef}
+	plistBytes, err := plist.Marshal(payload, plist.BinaryFormat)
+	require.NoError(t, err)
+	decoded, err := fromBytes(plistBytes)
+	require.NoError(t, err)
+	assert.Equal(t, payload, decoded)
+
+	_, err = fromBytes([]byte("not a plist"))
+	assert.Error(t, err)
+}
+
+func TestGetPacket(t *testing.T) {
+	resetFilters(t)
+	payload := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+
+	t.Run("parses header and payload", func(t *testing.T) {
+		iph, packet, err := getPacket(append(packHeader(t, testPacketHeader(len(payload))), payload...))
+		require.NoError(t, err)
+		assert.Equal(t, payload, packet)
+		assert.Equal(t, PacketHeaderSize, iph.HdrSize)
+		assert.Equal(t, int32(-1), iph.Pid)
+		assert.Equal(t, "testproc", trimNull(iph.ProcName))
+		assert.Equal(t, "en0", trimNull(iph.IFName))
+		assert.Equal(t, 1700000000, iph.TsSec)
+		assert.Equal(t, 123456, iph.TsUsec)
+	})
+
+	t.Run("prepends fake ethernet header when FramePreLength is zero", func(t *testing.T) {
+		hdr := testPacketHeader(len(payload))
+		hdr.FramePreLength = 0
+		_, packet, err := getPacket(append(packHeader(t, hdr), payload...))
+		require.NoError(t, err)
+		require.Len(t, packet, len(payload)+14)
+		assert.Equal(t, payload, packet[14:])
+	})
+
+	t.Run("skips extended header bytes (iOS 15 beta4)", func(t *testing.T) {
+		hdr := testPacketHeader(len(payload))
+		hdr.HdrSize = PacketHeaderSize + 4
+		raw := append(packHeader(t, hdr), 0xaa, 0xbb, 0xcc, 0xdd)
+		_, packet, err := getPacket(append(raw, payload...))
+		require.NoError(t, err)
+		assert.Equal(t, payload, packet)
+	})
+
+	t.Run("pid filter drops other pids", func(t *testing.T) {
+		resetFilters(t)
+		Pid = 42
+		_, packet, err := getPacket(append(packHeader(t, testPacketHeader(len(payload))), payload...))
+		require.NoError(t, err)
+		assert.Empty(t, packet)
+
+		hdr := testPacketHeader(len(payload))
+		hdr.Pid = 42
+		_, packet, err = getPacket(append(packHeader(t, hdr), payload...))
+		require.NoError(t, err)
+		assert.Equal(t, payload, packet)
+	})
+
+	t.Run("process name filter drops other processes", func(t *testing.T) {
+		resetFilters(t)
+		ProcName = "other"
+		_, packet, err := getPacket(append(packHeader(t, testPacketHeader(len(payload))), payload...))
+		require.NoError(t, err)
+		assert.Empty(t, packet)
+
+		ProcName = "test"
+		_, packet, err = getPacket(append(packHeader(t, testPacketHeader(len(payload))), payload...))
+		require.NoError(t, err)
+		assert.Equal(t, payload, packet)
+	})
+}
+
+func TestCaptureWritesPacketsUntilCanceled(t *testing.T) {
+	resetFilters(t)
+	payloads := [][]byte{
+		bytes.Repeat([]byte{0x11}, 20),
+		bytes.Repeat([]byte{0x22}, 40),
+		bytes.Repeat([]byte{0x33}, 60),
+	}
+
+	pr, pw := io.Pipe()
+	conn := &fakeDeviceConnection{r: pr}
+	var out bytes.Buffer
+	require.NoError(t, writePcapHeader(&out))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	captureDone := make(chan error, 1)
+	go func() { captureDone <- capture(ctx, conn, &out) }()
+
+	// io.Pipe writes complete only once capture has consumed the frame.
+	for _, payload := range payloads {
+		_, err := pw.Write(makeFrame(t, testPacketHeader(len(payload)), payload))
+		require.NoError(t, err)
+	}
+	cancel()
+
+	select {
+	case err := <-captureDone:
+		require.NoError(t, err, "capture must return nil on context cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("capture did not stop after context cancellation")
+	}
+
+	// The finalized output must be a valid pcap stream containing every packet.
+	r, err := pcapgo.NewReader(bytes.NewReader(out.Bytes()))
+	require.NoError(t, err, "output is not a valid pcap stream")
+	for i, payload := range payloads {
+		data, ci, err := r.ReadPacketData()
+		require.NoError(t, err, "packet %d missing from pcap output", i)
+		assert.Equal(t, payload, data, "packet %d payload mismatch", i)
+		assert.Equal(t, len(payload), ci.CaptureLength)
+		assert.Equal(t, len(payload), ci.Length)
+		assert.Equal(t, time.Unix(1700000000, 123456*1000).UTC(), ci.Timestamp.UTC())
+	}
+	_, _, err = r.ReadPacketData()
+	assert.ErrorIs(t, err, io.EOF, "pcap output must end cleanly after the captured packets")
+}
+
+func TestCaptureStopsOnDeadline(t *testing.T) {
+	resetFilters(t)
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	conn := &fakeDeviceConnection{r: pr}
+	var out bytes.Buffer
+	require.NoError(t, writePcapHeader(&out))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	captureDone := make(chan error, 1)
+	go func() { captureDone <- capture(ctx, conn, &out) }()
+
+	payload := bytes.Repeat([]byte{0x44}, 10)
+	_, err := pw.Write(makeFrame(t, testPacketHeader(len(payload)), payload))
+	require.NoError(t, err)
+	// No more frames arrive; the deadline must stop the blocked read.
+
+	select {
+	case err := <-captureDone:
+		require.NoError(t, err, "capture must return nil on deadline")
+	case <-time.After(5 * time.Second):
+		t.Fatal("capture did not stop on context deadline")
+	}
+
+	r, err := pcapgo.NewReader(bytes.NewReader(out.Bytes()))
+	require.NoError(t, err)
+	data, _, err := r.ReadPacketData()
+	require.NoError(t, err)
+	assert.Equal(t, payload, data)
+	_, _, err = r.ReadPacketData()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestCaptureReturnsReadErrorWhenNotCanceled(t *testing.T) {
+	resetFilters(t)
+	pr, pw := io.Pipe()
+	conn := &fakeDeviceConnection{r: pr}
+	var out bytes.Buffer
+
+	captureDone := make(chan error, 1)
+	go func() { captureDone <- capture(context.Background(), conn, &out) }()
+	require.NoError(t, pw.CloseWithError(io.ErrUnexpectedEOF))
+
+	select {
+	case err := <-captureDone:
+		require.Error(t, err, "capture must surface connection errors when the context is still active")
+	case <-time.After(5 * time.Second):
+		t.Fatal("capture did not stop on connection error")
+	}
+}
+
+func trimNull(s string) string {
+	return string(bytes.Trim([]byte(s), "\x00"))
+}

--- a/ios/pcap/pcap_test.go
+++ b/ios/pcap/pcap_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"io"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -246,6 +247,74 @@ func TestCaptureReturnsReadErrorWhenNotCanceled(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("capture did not stop on connection error")
 	}
+}
+
+// closeTrackingConn records how often Close is called and blocks in Close
+// until released, so a test can prove capture waits for the watchdog's
+// conn.Close() to finish before returning (no concurrent double-close).
+type closeTrackingConn struct {
+	r        *io.PipeReader
+	release  chan struct{}
+	closes   int32
+	inClose  chan struct{}
+	closedCh chan struct{}
+}
+
+func (c *closeTrackingConn) Reader() io.Reader { return c.r }
+
+func (c *closeTrackingConn) Close() error {
+	if atomic.AddInt32(&c.closes, 1) == 1 {
+		close(c.inClose)
+		<-c.release
+		err := c.r.Close()
+		close(c.closedCh)
+		return err
+	}
+	return c.r.Close()
+}
+
+func TestCaptureWaitsForWatchdogCloseBeforeReturning(t *testing.T) {
+	resetFilters(t)
+	pr, _ := io.Pipe()
+	conn := &closeTrackingConn{
+		r:        pr,
+		release:  make(chan struct{}),
+		inClose:  make(chan struct{}),
+		closedCh: make(chan struct{}),
+	}
+	var out bytes.Buffer
+	require.NoError(t, writePcapHeader(&out))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	captureDone := make(chan error, 1)
+	go func() { captureDone <- capture(ctx, conn, &out) }()
+
+	cancel()
+	// The watchdog is now inside Close, blocked before it finishes.
+	select {
+	case <-conn.inClose:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watchdog did not call Close after cancellation")
+	}
+
+	// capture must not have returned yet: it owns the connection and must wait
+	// for the watchdog's Close to complete so it never races the caller's own
+	// deferred Close.
+	select {
+	case <-captureDone:
+		t.Fatal("capture returned before the watchdog's Close finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(conn.release)
+	select {
+	case err := <-captureDone:
+		require.NoError(t, err, "capture must return nil on cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("capture did not return after Close finished")
+	}
+	<-conn.closedCh
+	assert.Equal(t, int32(1), atomic.LoadInt32(&conn.closes), "connection must be closed exactly once by capture")
 }
 
 func trimNull(s string) string {

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ Usage:
   ios mobilegestalt <key>... [--plist] [options]
   ios pair [--p12file=<orgid>] [--password=<p12password>] [options]
   ios pasteboard (set [<text>] | get) [options]
-  ios pcap [options] [--pid=<processID>] [--process=<processName>]
+  ios pcap [options] [--pid=<processID>] [--process=<processName>] [--timeout=<duration>]
   ios prepare [--skip-all] [--skip=<option>]... [--certfile=<cert_file_path>] [--orgname=<org_name>] [--p12password=<p12password>] [--locale=<locale>] [--lang=<lang>] [options]
   ios prepare cloudconfig [options]
   ios prepare create-cert
@@ -402,7 +402,10 @@ The commands work as following:
     ios pasteboard (set [<text>] | get) [options]                     Read or write the device pasteboard (clipboard) over RemoteXPC (iOS 17+). Requires tunnel.
                                                                        set writes <text> (or stdin when omitted) to the pasteboard; get prints its text.
 
-    ios pcap [options] [--pid=<processID>] [--process=<processName>]   Starts a pcap dump of network traffic, use --pid or --process to filter specific processes.
+    ios pcap [options] [--pid=<processID>] [--process=<processName>] [--timeout=<duration>]
+                                                                       Starts a pcap dump of network traffic, use --pid or --process to filter specific processes.
+                                                                       Use --timeout with a duration like 30s, 2m or 1h to stop the capture automatically;
+                                                                       without it, capture runs until Ctrl-C. Either way the pcap file is closed cleanly.
 
     ios prepare [--skip-all] [--skip=<option>]... [--certfile=<cert_file_path>] [--orgname=<org_name>] [--p12password=<p12password>] [--locale] [--lang] [options]
                                                                        Prepare a device. Use skip-all to skip everything multiple --skip args to skip only a subset.


### PR DESCRIPTION
## Problem

`ios pcap` captured forever: the read loop in `ios/pcap/pcap.go` had no cancellation mechanism, so the only way to end a capture was to kill the process. Issue #487 asks for collecting a pcap for a limited time.

## Design

- `pcap.Start` now takes a `context.Context`. The capture loop is extracted into `capture(ctx, conn, w)`, which reads pcapd frames and streams pcap records to the writer until the context is done or the connection fails.
- Since the plist decode blocks on a socket read, cancellation works by closing the service connection when the context fires, which unblocks the pending read. The loop then maps that read error to a clean `nil` return (`ctx.Err() != nil`), so the file is finalized (synced + closed) and remains a valid pcap.
- `capture` depends only on a tiny `captureConn` interface (`Reader()`/`Close()`) satisfied by `ios.DeviceConnectionInterface`, and writes to an `io.Writer` — this is what makes the loop unit-testable without a device.
- CLI: `ios pcap [--timeout=<duration>]` (Go duration syntax: `30s`, `2m`, `1h`). The command always installs a `signal.NotifyContext` for SIGINT/SIGTERM, so Ctrl-C now also ends the capture cleanly instead of killing the process mid-write; `--timeout` layers a `context.WithTimeout` on top.

Packets are still written to the file incrementally as they arrive (streaming behavior unchanged), and a real connection error (context still active) is still surfaced as an error.

## Implementation

- `ios/pcap/pcap.go`: context-aware `Start`, new `capture` loop with a watchdog goroutine that closes the connection on `ctx.Done()`; `writePacket` generalized to `io.Writer` with write errors checked; pcap global header factored into `writePcapHeader` (reused by tests); `f.Sync()` on clean stop.
- `cmd_device_debug.go`: `runPCAPCommand` parses `--timeout`, builds the signal + timeout context, calls `pcap.Start(ctx, device)`.
- `main.go`: docopt usage and help text for `--timeout=<duration>`.
- `ios/pcap/pcap_test.go`: new device-free tests (see test plan).

## Options considered

1. **Close-connection-on-cancel (chosen):** a goroutine closes the pcapd connection when the context is done; the blocked read errors out and the loop treats it as a clean stop. Preferred because it needs no read deadlines or protocol changes, stops immediately even when the device is idle (no packet traffic), and matches how other go-ios commands already stop blocking services.
2. **`SetReadDeadline` polling:** set short deadlines on the underlying `net.Conn` and check the context between reads. Rejected: `capture` would be tied to a concrete `net.Conn` (worse testability), and it burns wakeups while idle.
3. **CLI-side `time.AfterFunc(os.Exit)`:** trivial, but exits mid-write and can truncate the pcap record — exactly what this PR is meant to avoid, and it leaves the library API uncancelable for embedders.

## Test plan

- `go build ./...` and full `go test ./...` pass; `go test -race ./ios/pcap/` passes; `gofmt -l` / `go vet` clean on changed files.
- New unit tests drive `capture` against an in-memory fake pcapd connection (`io.Pipe`) feeding canned wire frames (length-prefixed binary plist wrapping a struc-packed `IOSPacketHeader` + payload):
  - packets written until context cancellation, then the loop returns `nil`; output validated as a well-formed pcap with `pcapgo` (payloads, lengths, timestamps, clean EOF),
  - deadline expiry stops a read blocked on an idle connection,
  - a connection error with an active context is still returned as an error.
- Fixture tests for the existing parsing: `fromBytes` (plist → bytes), `getPacket` (header fields, fake-ethernet prefix when `FramePreLength == 0`, iOS 15 beta4 extended header skip, pid/process-name filters).
- Real-device e2e suite to be run via `/test-devices`.

Fixes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk