### PR TITLE
feat(debugserver): attach lldb to a running process by pid (ios debug --pid)

### DIFF
--- a/cmd_device_debug.go
+++ b/cmd_device_debug.go
@@ -158,10 +158,17 @@ func runImageCommand(ctx commandContext) {
 }
 
 func runDebugCommand(ctx commandContext) {
+	stopAtEntry, _ := ctx.Args.Bool("--stop-at-entry")
+	if pid, _ := ctx.Args.Int("--pid"); pid > 0 {
+		if stopAtEntry {
+			logFatal("--stop-at-entry only applies when launching, attaching always stops the process")
+		}
+		exitIfError("debug server failed", debugserver.AttachByPid(ctx.Device, pid))
+		return
+	}
 	appPath, _ := ctx.Args.String("<app_path>")
 	if appPath == "" {
-		logFatal("parameter bundleid and app_path must be specified")
+		logFatal("parameter app_path or --pid must be specified")
 	}
-	stopAtEntry, _ := ctx.Args.Bool("--stop-at-entry")
 	exitIfError("debug server failed", debugserver.Start(ctx.Device, appPath, stopAtEntry))
 }

--- a/internal/clihelp/help.yaml
+++ b/internal/clihelp/help.yaml
@@ -64,8 +64,8 @@ commands:
     usage: ios date [options]
     summary: Print device date.
   - path: debug
-    usage: ios debug [options] [--stop-at-entry] <app_path>
-    summary: Start LLDB debug session.
+    usage: ios debug [options] [--stop-at-entry] (<app_path> | --pid=<processID>)
+    summary: Start an LLDB session, launching the app at app_path or attaching to a running process by pid.
   - path: devicename
     usage: ios devicename [options]
     summary: Print device name.

--- a/ios/debugserver/debugserver.go
+++ b/ios/debugserver/debugserver.go
@@ -51,64 +51,85 @@ func (c *DebugClient) Conn() net.Conn {
 	return c.c.Conn()
 }
 
-// Write the script file to the tmp directory and start lldb
-func startLLDB(appPath, container string, port int, stopAtEntry bool) error {
+// lldbScriptConfig holds everything needed to render the lldb command script
+// and the python helper it imports. Either the launch fields or pid are set,
+// never both.
+type lldbScriptConfig struct {
+	// launch mode
+	appPath     string // local .app bundle, becomes the lldb target
+	container   string // path of the installed app on the device
+	stopAtEntry bool
+	// attach mode
+	pid int // when > 0, attach to this process instead of launching
+
+	port int // local proxy port lldb connects to
+}
+
+// renderLLDBScripts renders the lldb command script and the python helper it
+// imports. It is a pure function so the generated scripts can be unit tested.
+func renderLLDBScripts(cfg lldbScriptConfig) (lldbScript string, pyScript string, err error) {
 	var optionStopAtEntry string
-	if stopAtEntry {
+	if cfg.stopAtEntry {
 		optionStopAtEntry = STOP_AT_ENTRY
 	}
 
-	py, err := os.OpenFile(PY_PATH, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
-	if err != nil {
-		return err
-	}
-	defer py.Close()
-
 	pyt, err := template.New("py").Parse(PY_FMT)
 	if err != nil {
-		return err
+		return "", "", err
 	}
-	err = pyt.Execute(py, struct {
+	var py strings.Builder
+	err = pyt.Execute(&py, struct {
 		StopAtEntry string
 	}{
 		StopAtEntry: optionStopAtEntry,
 	})
 	if err != nil {
-		return err
+		return "", "", err
 	}
-
-	script, err := os.OpenFile(SCRIPT_PATH, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
-	if err != nil {
-		return err
-	}
-	defer script.Close()
 
 	st, err := template.New("script").Parse(LLDB_FMT)
 	if err != nil {
-		return err
+		return "", "", err
 	}
-	err = st.Execute(script, struct {
+	var script strings.Builder
+	err = st.Execute(&script, struct {
 		AppPath   string
 		Container string
 		Port      int
+		Pid       int
 		PyName    string
 		PyPath    string
 	}{
-		AppPath:   appPath,
-		Container: container,
-		Port:      port,
+		AppPath:   cfg.appPath,
+		Container: cfg.container,
+		Port:      cfg.port,
+		Pid:       cfg.pid,
 		PyName:    strings.TrimSuffix(path.Base(PY_PATH), path.Ext(PY_PATH)),
 		PyPath:    PY_PATH,
 	})
 	if err != nil {
+		return "", "", err
+	}
+	return script.String(), py.String(), nil
+}
+
+// Write the script files to the tmp directory and start lldb
+func startLLDB(cfg lldbScriptConfig) error {
+	lldbScript, pyScript, err := renderLLDBScripts(cfg)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(PY_PATH, []byte(pyScript), 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(SCRIPT_PATH, []byte(lldbScript), 0o644); err != nil {
 		return err
 	}
 	cmd := exec.Command(LLDB_SHELL, "-s", SCRIPT_PATH)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err = cmd.Run()
-	return err
+	return cmd.Run()
 }
 
 func fileExists(filename string) bool {
@@ -163,6 +184,8 @@ func connectToDevice(device ios.DeviceEntry) (ios.DeviceConnectionInterface, err
 	return intf, err
 }
 
+// Start launches the app at appPath on the device and opens an interactive
+// lldb session for it.
 func Start(device ios.DeviceEntry, appPath string, stopAtEntry bool) error {
 	bundleId, err := getBundleidFromApp(appPath)
 	if err != nil {
@@ -187,6 +210,22 @@ func Start(device ios.DeviceEntry, appPath string, stopAtEntry bool) error {
 		return errors.New("cannot find container of bundleid: " + bundleId)
 	}
 
+	return runSession(device, lldbScriptConfig{appPath: appPath, container: container, stopAtEntry: stopAtEntry})
+}
+
+// AttachByPid opens an interactive lldb session attached to the process with
+// the given pid on the device.
+func AttachByPid(device ios.DeviceEntry, pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid pid %d, must be > 0", pid)
+	}
+	golog.Info("attaching lldb to process", "module", logModule, "udid", device.Properties.SerialNumber, "pid", pid)
+	return runSession(device, lldbScriptConfig{pid: pid})
+}
+
+// runSession connects to the debugserver on the device, proxies it on a local
+// port and runs lldb against that port until the debug session ends.
+func runSession(device ios.DeviceEntry, cfg lldbScriptConfig) error {
 	intf, err := connectToDevice(device)
 	if err != nil {
 		return err
@@ -198,6 +237,7 @@ func Start(device ios.DeviceEntry, appPath string, stopAtEntry bool) error {
 	}
 	defer listener.Close()
 	port := listener.Addr().(*net.TCPAddr).Port
+	cfg.port = port
 	golog.Info("debug proxy listening", "module", logModule, "udid", device.Properties.SerialNumber, "port", port)
 
 	// Run lldb in the background; its result ends the debug session. Start
@@ -206,7 +246,7 @@ func Start(device ios.DeviceEntry, appPath string, stopAtEntry bool) error {
 	lldbDone := make(chan error, 1)
 	go func() {
 		time.Sleep(time.Second)
-		lldbDone <- startLLDB(appPath, container, port, stopAtEntry)
+		lldbDone <- startLLDB(cfg)
 	}()
 
 	// Proxy connections until Start returns and closes the listener.

--- a/ios/debugserver/debugserver_test.go
+++ b/ios/debugserver/debugserver_test.go
@@ -1,0 +1,70 @@
+package debugserver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func lastCommand(script string) string {
+	lines := strings.Split(strings.TrimSpace(script), "\n")
+	return lines[len(lines)-1]
+}
+
+func TestRenderLLDBScriptsLaunch(t *testing.T) {
+	lldbScript, pyScript, err := renderLLDBScripts(lldbScriptConfig{
+		appPath:   "/local/path/Wda.app",
+		container: "/private/var/containers/Bundle/Application/GUID/Wda.app",
+		port:      54321,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, lldbScript, "platform select remote-ios\n")
+	assert.Contains(t, lldbScript, `target create "/local/path/Wda.app"`)
+	assert.Contains(t, lldbScript, `script device_app="/private/var/containers/Bundle/Application/GUID/Wda.app"`)
+	assert.Contains(t, lldbScript, `script connect_url="connect://127.0.0.1:54321"`)
+	assert.Contains(t, lldbScript, `command script import "`+PY_PATH+`"`)
+	assert.Contains(t, lldbScript, "\nconnect\n")
+	assert.Equal(t, "run", lastCommand(lldbScript))
+	assert.NotContains(t, lldbScript, "process attach")
+
+	assert.Contains(t, pyScript, "def connect_command(")
+	assert.Contains(t, pyScript, "def run_command(")
+	// stop-at-entry is off by default
+	assert.NotContains(t, pyScript, STOP_AT_ENTRY)
+}
+
+func TestRenderLLDBScriptsLaunchStopAtEntry(t *testing.T) {
+	lldbScript, pyScript, err := renderLLDBScripts(lldbScriptConfig{
+		appPath:     "/local/path/Wda.app",
+		container:   "/private/var/containers/Bundle/Application/GUID/Wda.app",
+		port:        54321,
+		stopAtEntry: true,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "run", lastCommand(lldbScript))
+	assert.Contains(t, pyScript, STOP_AT_ENTRY)
+}
+
+func TestRenderLLDBScriptsAttach(t *testing.T) {
+	lldbScript, pyScript, err := renderLLDBScripts(lldbScriptConfig{
+		pid:  1337,
+		port: 54321,
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, lldbScript, "platform select remote-ios\n")
+	assert.Contains(t, lldbScript, `script connect_url="connect://127.0.0.1:54321"`)
+	assert.Contains(t, lldbScript, "\nconnect\n")
+	assert.Equal(t, "process attach --pid 1337", lastCommand(lldbScript))
+	// no local binary in attach mode: no target is created and the app is not launched
+	assert.NotContains(t, lldbScript, "target create")
+	assert.NotContains(t, lldbScript, "\nrun\n")
+
+	// the python helper creates an empty target for attach mode
+	assert.Contains(t, pyScript, "debugger.CreateTarget('')")
+	assert.NotContains(t, pyScript, STOP_AT_ENTRY)
+}

--- a/ios/debugserver/format.go
+++ b/ios/debugserver/format.go
@@ -6,8 +6,8 @@ const (
 	LLDB_SHELL  = "/usr/bin/lldb"
 	LLDB_FMT    = `
 platform select remote-ios
-target create "{{.AppPath}}"
-script device_app="{{.Container}}"
+{{if .AppPath}}target create "{{.AppPath}}"
+{{end}}script device_app="{{.Container}}"
 script connect_url="connect://127.0.0.1:{{.Port}}"
 script output_path=""
 script error_path=""
@@ -17,7 +17,7 @@ command script add -s asynchronous -f {{.PyName}}.run_command run
 command script add -s asynchronous -f {{.PyName}}.autoexit_command autoexit
 command script add -s asynchronous -f {{.PyName}}.safequit_command safequit
 connect
-run
+{{if .Pid}}process attach --pid {{.Pid}}{{else}}run{{end}}
 `
 	STOP_AT_ENTRY = "launchInfo.SetLaunchFlags(lldb.eLaunchFlagStopAtEntry)"
 	PY_FMT        = `
@@ -34,6 +34,10 @@ def connect_command(debugger, command, result, internal_dict):
 	# These two are passed in by the script which loads us
 	connect_url = internal_dict['connect_url']
 	error = lldb.SBError()
+
+	# Attach mode starts without a local binary, so no target exists yet.
+	if not debugger.GetSelectedTarget().IsValid():
+		debugger.CreateTarget('')
 
 	# We create a new listener here and will use it for both target and the process.
 	# It allows us to prevent data races when both our code and internal lldb code

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ Usage:
   ios crash ls [<pattern>] [options]
   ios crash rm <cwd> <pattern> [options]
   ios date [options]
-  ios debug [options] [--stop-at-entry] <app_path>
+  ios debug [options] [--stop-at-entry] (<app_path> | --pid=<processID>)
   ios devicename [options]
   ios devicestate enable <profileTypeId> <profileId> [options]
   ios devicestate list [options]
@@ -261,7 +261,9 @@ The commands work as following:
 
     ios crash rm <cwd> <pattern> [options]        Remove file pattern from dir. Ex.: 'ios crash rm "." "*"' to delete everything
     ios date [options]                            Prints the device date
-    ios debug [--stop-at-entry] <app_path>        Start debug with lldb
+    ios debug [--stop-at-entry] (<app_path> | --pid=<processID>)
+                                                  Start an lldb session, either launching the app at app_path
+                                                  or attaching to an already running process by its pid
     ios devicename [options]                      Prints the devicename
 
     ios devicestate enable <profileTypeId> <profileId> [options]  Enables a profile with ids (use the list command to see options).

--- a/testdata/help/global.golden
+++ b/testdata/help/global.golden
@@ -33,7 +33,7 @@ Commands:
   crash ls                        List crash reports.
   crash rm                        Remove crash reports.
   date                            Print device date.
-  debug                           Start LLDB debug session.
+  debug                           Start an LLDB session, launching the app at app_path or attaching to a running process by pid.
   devicename                      Print device name.
   devicestate enable              Enable device condition profile.
   devicestate list                List device condition profiles.


### PR DESCRIPTION
## Problem

`ios debug` can only *launch* an app from a local `.app` path. Issue #387 asks for Xcode-style "attach to running process": connect lldb to a process that is already running on the device, addressed by its pid (`ios debug --pid <pid>`).

## Design

The existing debug flow already does everything needed except the lldb command sequence: it connects to `com.apple.debugserver` via lockdown, proxies it on a random local port, and drives `/usr/bin/lldb` with a generated command script plus a python helper. Attach mode reuses that connection/proxy path unchanged and only swaps the tail of the lldb script:

- **launch**: `target create "<app>"` … `connect` … `run`
- **attach**: no `target create` (there is no local binary) … `connect` … `process attach --pid <pid>`

The python `connect_command` creates an empty target when none is selected (attach mode), so `ConnectRemote` has a target to work with; lldb's `Target::Attach` then reuses the already-connected remote process, which is the standard flow for attaching through a gdb-remote stub. App install lookup, bundle-id resolution and `Info.plist` parsing are skipped entirely for attach.

## Implementation

- `ios/debugserver/debugserver.go`
  - `renderLLDBScripts(cfg)` — **pure** function rendering both the lldb command script and the python helper from a `lldbScriptConfig` (launch fields or `pid`, plus proxy port); `startLLDB` now just renders, writes the files, and executes lldb.
  - `AttachByPid(device, pid)` — new public entry point; validates `pid > 0`, logs with `module`/`udid`/`pid` attrs via `golog`.
  - `runSession(device, cfg)` — the connection/proxy/lldb plumbing factored out of `Start`; `Start` (launch) and `AttachByPid` both call it.
- `ios/debugserver/format.go` — `LLDB_FMT` gains template conditionals for the `target create` line and `run` vs `process attach --pid`; `PY_FMT` `connect_command` creates an empty target if none exists (no-op in launch mode).
- `main.go` / `cmd_device_debug.go` — usage is now `ios debug [options] [--stop-at-entry] (<app_path> | --pid=<processID>)`; docopt's alternation enforces exactly one of the two. `--stop-at-entry` with `--pid` is rejected with a clear error (attaching always stops the process).

## Options considered

1. **`--pid=<processID>` only (chosen).** Pid is unambiguous, maps 1:1 to lldb's `process attach --pid`, matches what the issue asks for, and users can resolve names to pids with `ios ps`. It also mirrors the existing `--pid` option on `kill`/`pcap`/`ostrace`.
2. **Additionally `--attach-name=<name>` (deferred).** lldb supports `process attach --name` (vAttachName/vAttachWait on the stub), which would also enable "wait for launch" semantics. Deferred because name matching on the remote stub is less predictable (partial/duplicate names), it doubles the surface to e2e-verify, and it composes cleanly on top of this PR later without touching the design.
3. **New `ios attach` subcommand.** Rejected: attach is a mode of the same debugserver session, not a different feature; keeping it under `ios debug` matches Xcode's "Debug > Attach to Process" mental model and avoids duplicated docs/plumbing.

## Test plan

- New unit tests in `ios/debugserver/debugserver_test.go` for the pure `renderLLDBScripts`:
  - launch mode: `target create`, `device_app`, `connect_url` port, final `run`, no `process attach`, no stop-at-entry flag in the python helper
  - launch with `--stop-at-entry`: python helper contains `SetLaunchFlags(lldb.eLaunchFlagStopAtEntry)`
  - attach mode: final command `process attach --pid 1337`, no `target create`, no `run`, python helper creates the empty target
- `go build ./...` and `go test ./...` pass; `gofmt -l` clean on changed files.
- CLI parsing smoke-tested locally: `ios debug --pid=1337` parses and proceeds to device resolution; `ios debug` alone and `ios debug --pid=1 app.app` are rejected by docopt.
- **Note:** attaching needs a real device with a running process; e2e verification of attach on the device farm is a follow-up (`ios debug` currently has no e2e coverage either).

Fixes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk