### PR TITLE
fix(fileservice): don't hang on ListDirectory failures; don't leave zero-byte files on failed pulls (iOS 26.5.x app-group, #784)

### DIFF
--- a/cmd_device_files.go
+++ b/cmd_device_files.go
@@ -170,29 +170,40 @@ func runFileCommand(ctx commandContext) {
 }
 
 // pullToLocalFile downloads remotePath into localPath using the passed pull
-// function and returns the downloaded size. If the pull fails, the local file
-// is removed so a failed pull does not leave a zero-byte or partial file
-// behind that pipelines could mistake for a successful download (issue #784).
-func pullToLocalFile(pull func(remotePath string, writer io.Writer) error, remotePath, localPath string) (int64, error) {
+// function and returns the downloaded size. On any failure the local file is
+// removed so a failed pull never leaves a zero-byte or partial file behind that
+// pipelines could mistake for a successful download (issue #784). This includes
+// failures surfaced by Close, which is where buffered write errors such as a
+// full disk are reported.
+func pullToLocalFile(pull func(remotePath string, writer io.Writer) error, remotePath, localPath string) (size int64, err error) {
 	outputFile, err := os.Create(localPath)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create output file: %w", err)
 	}
+	// Remove the file on any error path below. os.Create truncated any prior
+	// contents, so there is nothing worth keeping if the pull does not complete.
+	defer func() {
+		if err != nil {
+			os.Remove(localPath)
+		}
+	}()
 
-	if err := pull(remotePath, outputFile); err != nil {
+	if pullErr := pull(remotePath, outputFile); pullErr != nil {
 		outputFile.Close()
-		os.Remove(localPath)
+		err = pullErr
 		return 0, err
 	}
 
-	fileInfo, err := outputFile.Stat()
-	if err != nil {
+	fileInfo, statErr := outputFile.Stat()
+	if statErr != nil {
 		outputFile.Close()
-		return 0, fmt.Errorf("failed to get file info: %w", err)
+		err = fmt.Errorf("failed to get file info: %w", statErr)
+		return 0, err
 	}
 
-	if err := outputFile.Close(); err != nil {
-		return 0, fmt.Errorf("failed to close output file: %w", err)
+	if closeErr := outputFile.Close(); closeErr != nil {
+		err = fmt.Errorf("failed to close output file: %w", closeErr)
+		return 0, err
 	}
 
 	return fileInfo.Size(), nil

--- a/cmd_device_files.go
+++ b/cmd_device_files.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path"
@@ -115,17 +116,9 @@ func runFileCommand(ctx commandContext) {
 			exitIfError("file pull", fmt.Errorf("--local=<path> is required"))
 		}
 
-		outputFile, err := os.Create(localPath)
-		exitIfError("file pull: failed to create output file", err)
-		defer outputFile.Close()
-
 		slog.Info(fmt.Sprintf("Downloading %s to %s...", remotePath, localPath))
-		err = conn.PullFile(remotePath, outputFile)
+		fileSize, err := pullToLocalFile(conn.PullFile, remotePath, localPath)
 		exitIfError("file pull: failed to download file", err)
-
-		fileInfo, err := outputFile.Stat()
-		exitIfError("file pull: failed to get file info", err)
-		fileSize := fileInfo.Size()
 
 		if !JSONdisabled {
 			result := map[string]interface{}{
@@ -174,6 +167,35 @@ func runFileCommand(ctx commandContext) {
 			slog.Info(fmt.Sprintf("Uploaded %d bytes to %s", fileSize, remotePath))
 		}
 	}
+}
+
+// pullToLocalFile downloads remotePath into localPath using the passed pull
+// function and returns the downloaded size. If the pull fails, the local file
+// is removed so a failed pull does not leave a zero-byte or partial file
+// behind that pipelines could mistake for a successful download (issue #784).
+func pullToLocalFile(pull func(remotePath string, writer io.Writer) error, remotePath, localPath string) (int64, error) {
+	outputFile, err := os.Create(localPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create output file: %w", err)
+	}
+
+	if err := pull(remotePath, outputFile); err != nil {
+		outputFile.Close()
+		os.Remove(localPath)
+		return 0, err
+	}
+
+	fileInfo, err := outputFile.Stat()
+	if err != nil {
+		outputFile.Close()
+		return 0, fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	if err := outputFile.Close(); err != nil {
+		return 0, fmt.Errorf("failed to close output file: %w", err)
+	}
+
+	return fileInfo.Size(), nil
 }
 
 func runFsyncCommand(ctx commandContext) {

--- a/cmd_device_files_test.go
+++ b/cmd_device_files_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPullToLocalFileRemovesFileOnError(t *testing.T) {
+	localPath := filepath.Join(t.TempDir(), "manifest.json")
+	pullErr := errors.New("device error: File paths cannot contain '..'.")
+
+	size, err := pullToLocalFile(func(remotePath string, writer io.Writer) error {
+		return pullErr
+	}, "shared-data/manifest.json", localPath)
+
+	require.ErrorIs(t, err, pullErr)
+	assert.Zero(t, size)
+	_, statErr := os.Stat(localPath)
+	assert.True(t, os.IsNotExist(statErr), "failed pull must not leave a local file behind, stat err: %v", statErr)
+}
+
+func TestPullToLocalFileRemovesPartialFileOnError(t *testing.T) {
+	localPath := filepath.Join(t.TempDir(), "partial.bin")
+	pullErr := errors.New("connection reset")
+
+	size, err := pullToLocalFile(func(remotePath string, writer io.Writer) error {
+		_, _ = writer.Write([]byte("partial data"))
+		return pullErr
+	}, "big.bin", localPath)
+
+	require.ErrorIs(t, err, pullErr)
+	assert.Zero(t, size)
+	_, statErr := os.Stat(localPath)
+	assert.True(t, os.IsNotExist(statErr), "failed pull must not leave a partial file behind, stat err: %v", statErr)
+}
+
+func TestPullToLocalFileWritesFileOnSuccess(t *testing.T) {
+	localPath := filepath.Join(t.TempDir(), "manifest.json")
+	content := []byte(`{"hello":"world"}`)
+
+	size, err := pullToLocalFile(func(remotePath string, writer io.Writer) error {
+		_, err := writer.Write(content)
+		return err
+	}, "shared-data/manifest.json", localPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(content)), size)
+	written, err := os.ReadFile(localPath)
+	require.NoError(t, err)
+	assert.Equal(t, content, written)
+}

--- a/cmd_device_files_test.go
+++ b/cmd_device_files_test.go
@@ -40,6 +40,29 @@ func TestPullToLocalFileRemovesPartialFileOnError(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "failed pull must not leave a partial file behind, stat err: %v", statErr)
 }
 
+// TestPullToLocalFileRemovesFileWhenFinalizeFails proves the cleanup covers
+// failures that surface after the pull itself succeeds (Stat/Close), where a
+// full-disk write error would otherwise be reported. The pull callback closes
+// the file, so the subsequent Stat fails and the wrapper must still remove the
+// (potentially partial) file and return the error.
+func TestPullToLocalFileRemovesFileWhenFinalizeFails(t *testing.T) {
+	localPath := filepath.Join(t.TempDir(), "finalize.bin")
+
+	size, err := pullToLocalFile(func(remotePath string, writer io.Writer) error {
+		f, ok := writer.(*os.File)
+		require.True(t, ok, "expected the wrapper to pass an *os.File")
+		_, _ = f.Write([]byte("data that must not survive a finalize failure"))
+		return f.Close() // pull "succeeds" but leaves the descriptor closed
+	}, "big.bin", localPath)
+
+	// The pull reported success, but finalizing (Stat on the now-closed
+	// descriptor) fails, so the wrapper must surface the error and clean up.
+	require.Error(t, err)
+	assert.Zero(t, size)
+	_, statErr := os.Stat(localPath)
+	assert.True(t, os.IsNotExist(statErr), "a post-pull finalize failure must not leave a file behind, stat err: %v", statErr)
+}
+
 func TestPullToLocalFileWritesFileOnSuccess(t *testing.T) {
 	localPath := filepath.Join(t.TempDir(), "manifest.json")
 	content := []byte(`{"hello":"world"}`)

--- a/ios/fileservice/fileservice.go
+++ b/ios/fileservice/fileservice.go
@@ -3,6 +3,7 @@ package fileservice
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -24,7 +25,33 @@ const (
 	// MaxInlineDataSize is the maximum file size that can be sent inline in XPC message
 	// Files larger than this must use the data service
 	MaxInlineDataSize = 500 // bytes - based on Ghidra code checking for 500 bytes
+
+	// defaultReceiveTimeout bounds how long ListDirectory waits for the device
+	// to answer a RetrieveDirectoryList request before giving up.
+	defaultReceiveTimeout = 30 * time.Second
 )
+
+// ErrTimeout is returned when the device does not answer a request within the
+// receive timeout. The connection should be closed afterwards, as a response
+// may still arrive on one of its streams.
+var ErrTimeout = errors.New("timed out waiting for a response from the device")
+
+// DeviceError is an error reported by the device's file service in the
+// EncodedError field of a response, e.g. RemoteServices error 11007
+// "File paths cannot contain '..'." on iOS 26.5.x App Group containers.
+type DeviceError struct {
+	// Description is the LocalizedDescription reported by the device, if any.
+	Description string
+	// Encoded is the raw EncodedError value from the response.
+	Encoded interface{}
+}
+
+func (e *DeviceError) Error() string {
+	if e.Description != "" {
+		return fmt.Sprintf("device error: %s", e.Description)
+	}
+	return fmt.Sprintf("device error: %+v", e.Encoded)
+}
 
 // Domain represents a file system domain on the iOS device
 type Domain uint64
@@ -42,16 +69,38 @@ const (
 	DomainSystemCrashLogs Domain = 5
 )
 
+// controlConnection is the subset of *xpc.Connection used by the file service
+// control channel. It exists as a seam so the control protocol can be unit
+// tested without a device.
+type controlConnection interface {
+	Send(data map[string]interface{}, flags ...uint32) error
+	ReceiveOnClientServerStream() (map[string]interface{}, error)
+	ReceiveOnServerClientStream() (map[string]interface{}, error)
+	Close() error
+}
+
+// receiveResult carries the outcome of a stream receive across a channel.
+type receiveResult struct {
+	response map[string]interface{}
+	err      error
+}
+
 // Connection represents a connection to the file service on an iOS 17+ device.
 // It manages file operations like listing, pulling, and pushing files.
 // Note: Connection is not safe for concurrent use. Each goroutine should have its own Connection.
 type Connection struct {
 	mu         sync.Mutex
-	conn       *xpc.Connection
+	conn       controlConnection
 	device     ios.DeviceEntry
 	sessionID  string
 	domain     Domain
 	identifier string
+	// receiveTimeout bounds how long ListDirectory waits for a response.
+	receiveTimeout time.Duration
+	// pendingControl holds an in-flight read of the control (server->client)
+	// stream started by ListDirectory that no message arrived on yet. It is
+	// consumed by the next control receive so the stream never has two readers.
+	pendingControl chan receiveResult
 }
 
 // New creates a new connection to the file service on the device for iOS 17+.
@@ -65,10 +114,11 @@ func New(device ios.DeviceEntry, domain Domain, identifier string) (*Connection,
 	}
 
 	c := &Connection{
-		conn:       xpcConn,
-		device:     device,
-		domain:     domain,
-		identifier: identifier,
+		conn:           xpcConn,
+		device:         device,
+		domain:         domain,
+		identifier:     identifier,
+		receiveTimeout: defaultReceiveTimeout,
 	}
 
 	// Create session immediately
@@ -95,7 +145,7 @@ func (c *Connection) createSession() error {
 	}
 
 	// Session creation responses come on ServerClientStream
-	response, err := c.conn.ReceiveOnServerClientStream()
+	response, err := c.receiveControl()
 	if err != nil {
 		return fmt.Errorf("createSession: failed to receive response: %w", err)
 	}
@@ -115,8 +165,27 @@ func (c *Connection) createSession() error {
 	return nil
 }
 
+// receiveControl receives the next message on the control (server->client)
+// stream, consuming a pending read left behind by ListDirectory if one exists.
+func (c *Connection) receiveControl() (map[string]interface{}, error) {
+	if c.pendingControl != nil {
+		res := <-c.pendingControl
+		c.pendingControl = nil
+		return res.response, res.err
+	}
+	return c.conn.ReceiveOnServerClientStream()
+}
+
 // ListDirectory returns a list of file names in the specified directory path.
 // The path is relative to the domain root.
+//
+// The listing itself arrives on the client-server stream, but device-side
+// failures (e.g. RemoteServices error 11007 on iOS 26.5.x App Group
+// containers, see issue #784) are reported on the control (server->client)
+// stream like every other control response. Both streams are therefore
+// received concurrently with a timeout, so a failure surfaces as a typed
+// error (*DeviceError or ErrTimeout) instead of blocking forever.
+// After an error the connection should be closed.
 func (c *Connection) ListDirectory(path string) ([]string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -135,17 +204,53 @@ func (c *Connection) ListDirectory(path string) ([]string, error) {
 	}
 
 	// Directory list responses come on ClientServerStream
-	response, err := c.conn.ReceiveOnClientServerStream()
-	if err != nil {
-		return nil, fmt.Errorf("ListDirectory: failed to receive response: %w", err)
-	}
+	listCh := make(chan receiveResult, 1)
+	go func() {
+		response, err := c.conn.ReceiveOnClientServerStream()
+		listCh <- receiveResult{response, err}
+	}()
 
-	// Check for errors in response
-	if err := extractError(response); err != nil {
-		return nil, fmt.Errorf("ListDirectory: %w", err)
+	// Watch the control stream for an error response. Reuse a pending read
+	// from a previous call so the stream never has two concurrent readers.
+	controlCh := c.pendingControl
+	if controlCh == nil {
+		controlCh = make(chan receiveResult, 1)
+		conn := c.conn
+		go func() {
+			response, err := conn.ReceiveOnServerClientStream()
+			controlCh <- receiveResult{response, err}
+		}()
 	}
+	c.pendingControl = controlCh
 
-	// Extract file list
+	timeout := time.NewTimer(c.receiveTimeout)
+	defer timeout.Stop()
+
+	select {
+	case res := <-listCh:
+		if res.err != nil {
+			return nil, fmt.Errorf("ListDirectory: failed to receive response: %w", res.err)
+		}
+		if err := extractError(res.response); err != nil {
+			return nil, fmt.Errorf("ListDirectory: %w", err)
+		}
+		return parseFileList(res.response)
+	case res := <-controlCh:
+		c.pendingControl = nil
+		if res.err != nil {
+			return nil, fmt.Errorf("ListDirectory: failed to receive control response: %w", res.err)
+		}
+		if err := extractError(res.response); err != nil {
+			return nil, fmt.Errorf("ListDirectory: %w", err)
+		}
+		return nil, fmt.Errorf("ListDirectory: unexpected control response without file list (got: %+v)", res.response)
+	case <-timeout.C:
+		return nil, fmt.Errorf("ListDirectory: no response within %v: %w", c.receiveTimeout, ErrTimeout)
+	}
+}
+
+// parseFileList extracts the FileList entries from a RetrieveDirectoryList response.
+func parseFileList(response map[string]interface{}) ([]string, error) {
 	fileListRaw, ok := response["FileList"]
 	if !ok {
 		return nil, fmt.Errorf("ListDirectory: missing FileList in response")
@@ -186,7 +291,7 @@ func (c *Connection) PullFile(path string, writer io.Writer) error {
 	}
 
 	// File retrieval control responses come on ServerClientStream (like CreateSession)
-	response, err := c.conn.ReceiveOnServerClientStream()
+	response, err := c.receiveControl()
 	if err != nil {
 		return fmt.Errorf("PullFile: failed to receive response: %w", err)
 	}
@@ -307,7 +412,7 @@ func (c *Connection) PushFile(path string, reader io.Reader, fileSize int64, per
 	}
 
 	// Propose responses come on ServerClientStream (like other control commands)
-	response, err := c.conn.ReceiveOnServerClientStream()
+	response, err := c.receiveControl()
 	if err != nil {
 		return fmt.Errorf("PushFile: failed to receive response: %w", err)
 	}
@@ -418,16 +523,17 @@ func (c *Connection) Close() error {
 	return c.conn.Close()
 }
 
-// extractError checks if the response contains an error and returns it
+// extractError checks if the response contains an error and returns it as a *DeviceError
 func extractError(response map[string]interface{}) error {
 	if encodedError, ok := response["EncodedError"]; ok && encodedError != nil {
+		devErr := &DeviceError{Encoded: encodedError}
 		// Try to get localized description first
 		if errorMap, ok := encodedError.(map[string]interface{}); ok {
 			if desc, ok := errorMap["LocalizedDescription"].(string); ok && desc != "" {
-				return fmt.Errorf("device error: %s", desc)
+				devErr.Description = desc
 			}
 		}
-		return fmt.Errorf("device error: %+v", encodedError)
+		return devErr
 	}
 	return nil
 }

--- a/ios/fileservice/fileservice_test.go
+++ b/ios/fileservice/fileservice_test.go
@@ -1,0 +1,161 @@
+package fileservice
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeXpcConn implements controlConnection for tests. Responses are injected
+// via channels; a stream with no injected response blocks like a real device
+// that never answers.
+type fakeXpcConn struct {
+	controlResponses chan receiveResult // server->client (control) stream
+	listResponses    chan receiveResult // client->server stream
+	closed           chan struct{}
+	closeOnce        sync.Once
+}
+
+func newFakeXpcConn() *fakeXpcConn {
+	return &fakeXpcConn{
+		controlResponses: make(chan receiveResult, 1),
+		listResponses:    make(chan receiveResult, 1),
+		closed:           make(chan struct{}),
+	}
+}
+
+func (f *fakeXpcConn) Send(data map[string]interface{}, flags ...uint32) error {
+	return nil
+}
+
+func (f *fakeXpcConn) ReceiveOnClientServerStream() (map[string]interface{}, error) {
+	select {
+	case res := <-f.listResponses:
+		return res.response, res.err
+	case <-f.closed:
+		return nil, errors.New("connection closed")
+	}
+}
+
+func (f *fakeXpcConn) ReceiveOnServerClientStream() (map[string]interface{}, error) {
+	select {
+	case res := <-f.controlResponses:
+		return res.response, res.err
+	case <-f.closed:
+		return nil, errors.New("connection closed")
+	}
+}
+
+func (f *fakeXpcConn) Close() error {
+	f.closeOnce.Do(func() { close(f.closed) })
+	return nil
+}
+
+func testConnection(t *testing.T, fake *fakeXpcConn, timeout time.Duration) *Connection {
+	t.Helper()
+	t.Cleanup(func() { fake.Close() })
+	return &Connection{
+		conn:           fake,
+		sessionID:      "test-session",
+		receiveTimeout: timeout,
+	}
+}
+
+// listDirectoryWithDeadline fails the test instead of blocking forever if
+// ListDirectory hangs (the bug from issue #784).
+func listDirectoryWithDeadline(t *testing.T, c *Connection, path string) ([]string, error) {
+	t.Helper()
+	type result struct {
+		files []string
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		files, err := c.ListDirectory(path)
+		done <- result{files, err}
+	}()
+	select {
+	case res := <-done:
+		return res.files, res.err
+	case <-time.After(5 * time.Second):
+		t.Fatal("ListDirectory did not return within 5s, it hangs")
+		return nil, nil
+	}
+}
+
+func TestListDirectorySurfacesControlStreamError(t *testing.T) {
+	fake := newFakeXpcConn()
+	// The device reports the failure on the control stream (like every other
+	// control response) and never sends anything on the list stream.
+	fake.controlResponses <- receiveResult{response: map[string]interface{}{
+		"EncodedError": map[string]interface{}{
+			"Code":                 uint64(11007),
+			"LocalizedDescription": "File paths cannot contain '..'.",
+		},
+	}}
+	c := testConnection(t, fake, 5*time.Second)
+
+	files, err := listDirectoryWithDeadline(t, c, "shared-data")
+
+	require.Error(t, err)
+	assert.Nil(t, files)
+	var devErr *DeviceError
+	require.ErrorAs(t, err, &devErr)
+	assert.Equal(t, "File paths cannot contain '..'.", devErr.Description)
+	assert.Contains(t, err.Error(), "File paths cannot contain '..'.")
+}
+
+func TestListDirectoryTimesOutWhenDeviceNeverResponds(t *testing.T) {
+	fake := newFakeXpcConn()
+	c := testConnection(t, fake, 50*time.Millisecond)
+
+	start := time.Now()
+	files, err := listDirectoryWithDeadline(t, c, ".")
+
+	require.Error(t, err)
+	assert.Nil(t, files)
+	assert.ErrorIs(t, err, ErrTimeout)
+	assert.Less(t, time.Since(start), 5*time.Second, "must fail fast via the receive timeout")
+}
+
+func TestListDirectoryReturnsFileList(t *testing.T) {
+	fake := newFakeXpcConn()
+	fake.listResponses <- receiveResult{response: map[string]interface{}{
+		"FileList": []interface{}{"manifest.json", "sub"},
+	}}
+	c := testConnection(t, fake, time.Second)
+
+	files, err := listDirectoryWithDeadline(t, c, ".")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"manifest.json", "sub"}, files)
+}
+
+func TestPullFileConsumesPendingControlReadAfterListDirectory(t *testing.T) {
+	fake := newFakeXpcConn()
+	fake.listResponses <- receiveResult{response: map[string]interface{}{
+		"FileList": []interface{}{},
+	}}
+	c := testConnection(t, fake, time.Second)
+
+	// A successful ListDirectory leaves a pending read on the control stream.
+	_, err := listDirectoryWithDeadline(t, c, ".")
+	require.NoError(t, err)
+
+	// The next control response must reach PullFile through that pending read.
+	fake.controlResponses <- receiveResult{response: map[string]interface{}{
+		"EncodedError": map[string]interface{}{
+			"LocalizedDescription": "No such file or directory",
+		},
+	}}
+	err = c.PullFile("missing.txt", io.Discard)
+	require.Error(t, err)
+	var devErr *DeviceError
+	require.ErrorAs(t, err, &devErr)
+	assert.Equal(t, "No such file or directory", devErr.Description)
+}

--- a/main.go
+++ b/main.go
@@ -291,6 +291,10 @@ The commands work as following:
                                                                   List files using RemoteXPC (iOS 17+). Requires tunnel.
                                                                   Use --app for app container, --app-group for app group,
                                                                   --crash for crash logs, or --temp for temporary files.
+                                                                  Known limitation: on iOS 26.5.x the device-side daemon rejects
+                                                                  --app-group file operations with RemoteServices error 11007
+                                                                  ("File paths cannot contain '..'.") even for valid paths;
+                                                                  Apple's devicectl fails identically. Use --app as a workaround.
 
     ios file pull [--app=<bundleID> | --app-group=<groupID> | --crash | --temp] --remote=<remotePath> --local=<localPath> [options]
                                                                   Download file using RemoteXPC (iOS 17+). Requires tunnel.


### PR DESCRIPTION
## Problem

On iOS 26.5.x, file operations against App Group containers (`--app-group`) fail device-side with RemoteServices error 11007 "File paths cannot contain '..'." even though the paths contain no `..` (#784). That is an Apple daemon bug — reproduced identically with Apple's own `xcrun devicectl` on the same devices — but go-ios failed badly around it:

- `ios file ls --app-group=…` **hung forever** with no output.
- A failed `ios file pull` left a **zero-byte local file** behind, which scripted pipelines can mistake for a successfully pulled empty file.

## Root cause

- `ListDirectory` sends `RetrieveDirectoryList` and then blocks in `ReceiveOnClientServerStream()` with no timeout. Every *other* control response (CreateSession, RetrieveFile, ProposeFile) arrives on the **server→client** stream — when the device reports a `RetrieveDirectoryList` failure there instead of sending the listing, the error was silently lost and the call blocked indefinitely.
- `cmd_device_files.go` ran `os.Create(localPath)` *before* `PullFile`, so any pull failure (including the device-side 11007 rejection, which happens before any data streaming) left a truncated 0-byte destination file.

## Fix

- **`ios/fileservice`**: `ListDirectory` now receives on both streams concurrently under a receive timeout (default 30s) and surfaces failures as typed errors: `*fileservice.DeviceError` (carries the device's `EncodedError` + `LocalizedDescription`) and `fileservice.ErrTimeout`. A pending control-stream read left by a successful listing is tracked on the `Connection` and consumed by the next control receive (`createSession`/`PullFile`/`PushFile`), so the control stream never has two concurrent readers. `extractError` now returns `*DeviceError` everywhere (same message format as before).
- **`cmd_device_files.go`**: the pull path is extracted into a testable `pullToLocalFile` wrapper that removes the local file when the download fails — no zero-byte/partial files remain. Success behavior (including pulling genuinely empty files) is unchanged.
- **Interface seam**: `Connection.conn` is now a minimal `controlConnection` interface (satisfied by `*xpc.Connection`) so the control protocol is unit-testable without a device. No change to the wire protocol or `ios/xpc`.
- **Docs**: `ios file ls` help text in `main.go` now notes the iOS 26.5.x App Group limitation and the `--app` workaround.

## Options considered

1. **Timeout-only on the list stream, check control stream after expiry** — simplest, but the device's 11007 error would only surface after the full timeout instead of immediately, and the error could still be lost. Rejected.
2. **Concurrent receive on both streams with a pending-read handoff (chosen)** — surfaces the device error immediately, keeps a single reader per stream, and reduces to the old behavior on the happy path. Slightly more state (`pendingControl`), fully covered by tests.
3. **Modify `ios/xpc` to support deadlines/contexts** — cleaner long-term, but a much larger blast radius across all XPC consumers; out of scope for a targeted hardening.
4. For the pull: **create the local file only after the control response** (needs restructuring `PullFile`'s writer contract and breaks empty-file pulls) vs. **unlink on error (chosen)** — minimal, and also cleans up partially-written files on mid-stream failures.

## Test plan

- New device-free unit tests that hang (and fail via a 5s test deadline) without the fix:
  - `ios/fileservice/fileservice_test.go` against a fake XPC connection: control-stream `EncodedError` → typed `*DeviceError`, no hang; device never responds → `ErrTimeout` with short injected timeout; happy-path listing; pending control-read handoff to `PullFile`.
  - `cmd_device_files_test.go`: erroring puller (immediate and mid-stream) → no local file remains; successful pull writes content and returns size.
- Verified the ListDirectory tests fail against the pre-fix receive logic (both hang), and pass with the fix.
- `go build ./...`, `go test ./...`, `go test -race` on changed packages, `gofmt -l` clean.

Improves #784 — the go-ios-side hang and zero-byte-file behaviors are fixed here, but the underlying App Group 11007 rejection is an Apple iOS 26.5.x daemon bug (Apple's devicectl fails identically), so the issue stays open to track that limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk
