### PR TITLE
fix(forward): reconnect automatically after device replug (ios forward)

### DIFF
--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -24,6 +24,13 @@ type ConnListener struct {
 	quit     chan interface{}
 }
 
+// resolveDeviceID returns the current usbmux device id of the forwarded device.
+// usbmuxd assigns a fresh id every time a device is plugged in, so the id
+// captured when the forward started goes stale after a disconnect/reconnect.
+// Re-resolving through this func lets a long-running forward survive a replug
+// (issue #378).
+type resolveDeviceID func() (int, error)
+
 // Forward forwards every connection made to the hostPort to whatever service runs inside an app on the device on phonePort.
 // Port values must be between 1 and 65535.
 func Forward(device ios.DeviceEntry, hostPort uint16, phonePort uint16) (*ConnListener, error) {
@@ -43,9 +50,28 @@ func Forward(device ios.DeviceEntry, hostPort uint16, phonePort uint16) (*ConnLi
 		quit:     make(chan interface{}),
 	}
 
-	go connectionAccept(cl, device.DeviceID, phonePort)
+	go connectionAccept(cl, device.DeviceID, phonePort, deviceIDResolver(device))
 
 	return cl, nil
+}
+
+// deviceIDResolver builds a resolveDeviceID that looks the device up again by
+// its udid (the serial survives a replug, the usbmux id does not). Without a
+// udid there is nothing stable to search by, so the captured id is returned
+// as-is.
+func deviceIDResolver(device ios.DeviceEntry) resolveDeviceID {
+	udid := device.Properties.SerialNumber
+	deviceID := device.DeviceID
+	if udid == "" {
+		return func() (int, error) { return deviceID, nil }
+	}
+	return func() (int, error) {
+		fresh, err := ios.GetDevice(udid)
+		if err != nil {
+			return 0, err
+		}
+		return fresh.DeviceID, nil
+	}
 }
 
 // Close stops listening on the host port for the forwarded connection
@@ -60,7 +86,7 @@ func (cl *ConnListener) Close() error {
 	return nil
 }
 
-func connectionAccept(cl *ConnListener, deviceID int, phonePort uint16) {
+func connectionAccept(cl *ConnListener, deviceID int, phonePort uint16, resolve resolveDeviceID) {
 	for {
 		select {
 		case <-cl.quit:
@@ -80,29 +106,73 @@ func connectionAccept(cl *ConnListener, deviceID int, phonePort uint16) {
 				continue
 			}
 			golog.Debug("new client connected", "module", logModule, "deviceID", deviceID, "phonePort", phonePort, "conn", fmt.Sprintf("%#v", cl))
-			go StartNewProxyConnection(context.TODO(), clientConn, deviceID, phonePort)
+			go startProxyConnection(context.TODO(), clientConn, deviceID, phonePort, resolve)
 		}
 	}
 }
 
+// StartNewProxyConnection connects clientConn to phonePort on the device with
+// the given usbmux device id and pumps bytes in both directions until either
+// side closes.
 func StartNewProxyConnection(ctx context.Context, clientConn io.ReadWriteCloser, deviceID int, phonePort uint16) error {
+	return startProxyConnection(ctx, clientConn, deviceID, phonePort, nil)
+}
+
+func startProxyConnection(ctx context.Context, clientConn io.ReadWriteCloser, deviceID int, phonePort uint16, resolve resolveDeviceID) error {
+	deviceConn, connectedID, err := connectToPhonePort(deviceID, phonePort, resolve)
+	if err != nil {
+		clientConn.Close()
+		return err
+	}
+	golog.Debug("connected to port", "module", logModule, "deviceID", connectedID, "conn", fmt.Sprintf("%#v", clientConn), "phonePort", phonePort)
+
+	proxyConns(ctx, clientConn, deviceConn, connectedID, phonePort)
+	return nil
+}
+
+// connectToPhonePort connects to phonePort using deviceID. When that fails and
+// a resolver is available, the device is looked up again — a replugged device
+// keeps its serial but gets a new usbmux id — and the connect is retried once
+// with the fresh id. It returns the device connection together with the id it
+// was actually established on.
+func connectToPhonePort(deviceID int, phonePort uint16, resolve resolveDeviceID) (ios.DeviceConnectionInterface, int, error) {
+	deviceConn, err := dialPhonePort(deviceID, phonePort)
+	if err == nil {
+		return deviceConn, deviceID, nil
+	}
+	if resolve == nil {
+		return nil, deviceID, err
+	}
+	freshID, resolveErr := resolve()
+	if resolveErr != nil {
+		golog.Debug("could not re-resolve device after failed connect", "module", logModule, "deviceID", deviceID, "phonePort", phonePort, "error", resolveErr)
+		return nil, deviceID, err
+	}
+	if freshID == deviceID {
+		return nil, deviceID, err
+	}
+	golog.Info("usbmux device id changed since the forward started, reconnecting", "module", logModule, "deviceID", freshID, "staleDeviceID", deviceID, "phonePort", phonePort)
+	deviceConn, retryErr := dialPhonePort(freshID, phonePort)
+	if retryErr != nil {
+		return nil, freshID, retryErr
+	}
+	return deviceConn, freshID, nil
+}
+
+// dialPhonePort opens a fresh connection to usbmuxd and asks it to connect to
+// phonePort on the device with the given usbmux id.
+func dialPhonePort(deviceID int, phonePort uint16) (ios.DeviceConnectionInterface, error) {
 	usbmuxConn, err := ios.NewUsbMuxConnectionSimple()
 	if err != nil {
 		golog.Error("could not connect to usbmuxd", "module", logModule, "deviceID", deviceID, "phonePort", phonePort, "error", err)
-		clientConn.Close()
-		return fmt.Errorf("could not connect to usbmuxd: %v", err)
+		return nil, fmt.Errorf("could not connect to usbmuxd: %v", err)
 	}
-	muxError := usbmuxConn.Connect(deviceID, phonePort)
-	if muxError != nil {
-		golog.Debug("could not connect to phone", "module", logModule, "deviceID", deviceID, "conn", fmt.Sprintf("%#v", clientConn), "error", muxError, "phonePort", phonePort)
-		clientConn.Close()
-		return fmt.Errorf("could not connect to port:%d on iOS: %v", phonePort, muxError)
+	if muxError := usbmuxConn.Connect(deviceID, phonePort); muxError != nil {
+		usbmuxConn.Close()
+		golog.Debug("could not connect to phone", "module", logModule, "deviceID", deviceID, "error", muxError, "phonePort", phonePort)
+		return nil, fmt.Errorf("could not connect to port:%d on iOS: %v", phonePort, muxError)
 	}
-	golog.Debug("connected to port", "module", logModule, "deviceID", deviceID, "conn", fmt.Sprintf("%#v", clientConn), "phonePort", phonePort)
-	deviceConn := usbmuxConn.ReleaseDeviceConnection()
-
-	proxyConns(ctx, clientConn, deviceConn, deviceID, phonePort)
-	return nil
+	return usbmuxConn.ReleaseDeviceConnection(), nil
 }
 
 // deviceRWConn is the subset of ios.DeviceConnectionInterface that the proxy

--- a/ios/forward/forward_reconnect_test.go
+++ b/ios/forward/forward_reconnect_test.go
@@ -37,15 +37,13 @@ func startFakeUsbmuxd(t *testing.T, goodDeviceID int) string {
 	if err != nil {
 		t.Fatalf("tempdir: %v", err)
 	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
 	sockPath := filepath.Join(dir, "usbmuxd")
 	l, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatalf("listen on fake usbmuxd socket: %v", err)
 	}
-	t.Cleanup(func() {
-		l.Close()
-		os.RemoveAll(dir)
-	})
+	t.Cleanup(func() { l.Close() })
 	go func() {
 		for {
 			conn, err := l.Accept()

--- a/ios/forward/forward_reconnect_test.go
+++ b/ios/forward/forward_reconnect_test.go
@@ -1,0 +1,198 @@
+package forward
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios"
+	plist "howett.net/plist"
+)
+
+// connectRequest is the subset of the usbmux Connect message the fake usbmuxd
+// needs to decide whether the requested device exists.
+type connectRequest struct {
+	MessageType string
+	DeviceID    uint32
+	PortNumber  uint16
+}
+
+// startFakeUsbmuxd stands up a minimal usbmuxd on a unix socket in a temp dir
+// and returns the socket path. It speaks just enough of the protocol for
+// Connect: a Connect for goodDeviceID answers success and then echoes every
+// byte back (playing the device-side service), a Connect for any other id
+// answers mux error 2 — which is what real usbmuxd does for the stale id of a
+// re-plugged device (issue #378).
+func startFakeUsbmuxd(t *testing.T, goodDeviceID int) string {
+	t.Helper()
+	// os.MkdirTemp instead of t.TempDir: unix socket paths have a ~104 byte
+	// limit and t.TempDir paths can get long on macOS.
+	dir, err := os.MkdirTemp("", "muxsock")
+	if err != nil {
+		t.Fatalf("tempdir: %v", err)
+	}
+	sockPath := filepath.Join(dir, "usbmuxd")
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen on fake usbmuxd socket: %v", err)
+	}
+	t.Cleanup(func() {
+		l.Close()
+		os.RemoveAll(dir)
+	})
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go serveFakeUsbmuxdConn(conn, goodDeviceID)
+		}
+	}()
+	return sockPath
+}
+
+// serveFakeUsbmuxdConn handles one usbmuxd client connection: read a single
+// Connect request, answer it, and on success switch the socket into echo mode
+// like usbmuxd hands the socket over to the device service.
+func serveFakeUsbmuxdConn(conn net.Conn, goodDeviceID int) {
+	defer conn.Close()
+	var header ios.UsbMuxHeader
+	if err := binary.Read(conn, binary.LittleEndian, &header); err != nil {
+		return
+	}
+	payload := make([]byte, header.Length-16)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		return
+	}
+	var req connectRequest
+	if _, err := plist.Unmarshal(payload, &req); err != nil {
+		return
+	}
+	number := uint32(0)
+	if int(req.DeviceID) != goodDeviceID {
+		number = 2 // usbmuxd result code for "device not found"
+	}
+	respBytes := ios.ToPlistBytes(ios.MuxResponse{MessageType: "Result", Number: number})
+	respHeader := ios.UsbMuxHeader{Length: uint32(16 + len(respBytes)), Version: 1, Request: 8, Tag: header.Tag}
+	if err := binary.Write(conn, binary.LittleEndian, respHeader); err != nil {
+		return
+	}
+	if _, err := conn.Write(respBytes); err != nil {
+		return
+	}
+	if number != 0 {
+		return
+	}
+	_, _ = io.Copy(conn, conn)
+}
+
+// TestStaleDeviceIDIsReResolved reproduces issue #378: the forward captured a
+// usbmux device id, the device was re-plugged and got a new id, so connecting
+// with the stale id fails. The proxy must then re-resolve the device and
+// succeed with the fresh id, keeping the forwarded port usable end-to-end.
+func TestStaleDeviceIDIsReResolved(t *testing.T) {
+	const staleID, freshID = 5, 42
+	sockPath := startFakeUsbmuxd(t, freshID)
+	t.Setenv("USBMUXD_SOCKET_ADDRESS", "unix://"+sockPath)
+
+	var resolveCalls atomic.Int32
+	resolve := func() (int, error) {
+		resolveCalls.Add(1)
+		return freshID, nil
+	}
+
+	clientSide, clientConn := net.Pipe()
+	defer clientSide.Close()
+	done := make(chan error, 1)
+	go func() {
+		done <- startProxyConnection(context.Background(), clientConn, staleID, 8100, resolve)
+	}()
+
+	// The session must be alive end-to-end: bytes written by the client come
+	// back from the fake device echo.
+	go func() { _, _ = clientSide.Write([]byte("ping")) }()
+	buf := make([]byte, 4)
+	_ = clientSide.SetReadDeadline(time.Now().Add(10 * time.Second))
+	if _, err := io.ReadFull(clientSide, buf); err != nil {
+		t.Fatalf("echo read through forward: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("echo through forward: got %q want %q", buf, "ping")
+	}
+	if got := resolveCalls.Load(); got != 1 {
+		t.Fatalf("expected exactly one device re-resolve, got %d", got)
+	}
+
+	clientSide.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("startProxyConnection: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("startProxyConnection did not return after client close")
+	}
+}
+
+// TestCurrentDeviceIDConnectsWithoutResolve verifies the happy path is
+// untouched: when the captured id still works, the resolver is never invoked.
+func TestCurrentDeviceIDConnectsWithoutResolve(t *testing.T) {
+	const deviceID = 7
+	sockPath := startFakeUsbmuxd(t, deviceID)
+	t.Setenv("USBMUXD_SOCKET_ADDRESS", "unix://"+sockPath)
+
+	resolve := func() (int, error) {
+		t.Error("resolve must not be called when the current id connects")
+		return deviceID, nil
+	}
+
+	clientSide, clientConn := net.Pipe()
+	defer clientSide.Close()
+	done := make(chan error, 1)
+	go func() {
+		done <- startProxyConnection(context.Background(), clientConn, deviceID, 8100, resolve)
+	}()
+
+	go func() { _, _ = clientSide.Write([]byte("ok")) }()
+	buf := make([]byte, 2)
+	_ = clientSide.SetReadDeadline(time.Now().Add(10 * time.Second))
+	if _, err := io.ReadFull(clientSide, buf); err != nil {
+		t.Fatalf("echo read through forward: %v", err)
+	}
+
+	clientSide.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("startProxyConnection: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("startProxyConnection did not return after client close")
+	}
+}
+
+// TestStaleDeviceIDWithoutResolverFails pins the library-API behavior of
+// StartNewProxyConnection (no resolver): a stale id fails and the client
+// connection is closed.
+func TestStaleDeviceIDWithoutResolverFails(t *testing.T) {
+	sockPath := startFakeUsbmuxd(t, 42)
+	t.Setenv("USBMUXD_SOCKET_ADDRESS", "unix://"+sockPath)
+
+	clientSide, clientConn := net.Pipe()
+	defer clientSide.Close()
+	if err := StartNewProxyConnection(context.Background(), clientConn, 5, 8100); err == nil {
+		t.Fatal("expected connect with stale device id to fail without a resolver")
+	}
+	// The client conn must have been closed on failure.
+	_ = clientSide.SetReadDeadline(time.Now().Add(10 * time.Second))
+	if _, err := clientSide.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected client conn closed (EOF), got %v", err)
+	}
+}

--- a/ios/forward/forward_test.go
+++ b/ios/forward/forward_test.go
@@ -193,7 +193,7 @@ func TestForwardCloseLifecycle(t *testing.T) {
 
 	accepted := make(chan struct{})
 	go func() {
-		connectionAccept(cl, 1, 8100)
+		connectionAccept(cl, 1, 8100, nil)
 		close(accepted)
 	}()
 


### PR DESCRIPTION
## Problem

`ios forward <hostPort> <phonePort>` stops working after the device is unplugged and plugged back in. Every new client connection fails with `could not connect to phone` until the forward process is restarted. `iproxy` from libimobiledevice handles a replug in the same session.

## Root cause

`Forward()` captures the numeric usbmux `DeviceID` once at startup and every proxied connection dials usbmuxd with it (`forward.go`, previously line 95-97). usbmuxd assigns a **new** device id each time a device is plugged in, so after a replug the captured id is stale and every `Connect` request is answered with a mux error. The device's udid (serial) is stable across replugs — only the numeric id changes.

## Fix

- Each accepted client connection still dials with the captured id first (zero extra cost on the happy path).
- When that connect fails, the device is re-resolved by udid via an injected `resolveDeviceID` func (backed by `ios.GetDevice(udid)`), and the connect is retried once with the fresh id.
- The usbmux socket is now closed when `Connect` fails (previously it leaked on that path).
- The exported `StartNewProxyConnection` keeps its signature and behavior (no resolver); the resolver is wired in by `Forward()`.

## Options considered

1. **Re-resolve by udid on connect failure, retry once (chosen).** Happy path unchanged, one extra usbmuxd round trip only while the id is stale, no background goroutines or listeners.
2. **Re-resolve on every accepted connection.** Simpler control flow but adds a `ListDevices` round trip to every connection even when nothing changed.
3. **Subscribe to usbmuxd attach/detach events and update the id.** Most "live", but adds a long-lived listener connection and state shared across goroutines for a case the retry handles with less machinery.

## Test plan

Device-free unit tests (`ios/forward/forward_reconnect_test.go`) run a minimal fake usbmuxd on a temp unix socket (`USBMUXD_SOCKET_ADDRESS`) that rejects a stale id with mux error 2 and echoes bytes for the current id:

- `TestStaleDeviceIDIsReResolved` — reproduces #378: stale id triggers exactly one re-resolve, and bytes flow end-to-end afterwards. Does not compile/pass without this change.
- `TestCurrentDeviceIDConnectsWithoutResolve` — happy path never invokes the resolver.
- `TestStaleDeviceIDWithoutResolverFails` — pins the exported `StartNewProxyConnection` behavior: stale id fails and the client conn is closed.

`go build ./...`, `go test -race ./...` and `gofmt -l` are clean.

Fixes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk