### PR TITLE
Make ios list discover tunnel/RSD-backed devices and support direct --address/--rsd-port targets

### DIFF
--- a/cli_device_resolution.go
+++ b/cli_device_resolution.go
@@ -151,9 +151,14 @@ func mergeTunnelDevices(deviceList ios.DeviceList, tunnelDevices []ios.DeviceEnt
 		known[d.Properties.SerialNumber] = true
 	}
 	for _, d := range tunnelDevices {
-		if !known[d.Properties.SerialNumber] {
-			deviceList.DeviceList = append(deviceList.DeviceList, d)
+		udid := d.Properties.SerialNumber
+		// A tunnel entry without a udid cannot be addressed or deduplicated by
+		// identity, so skip it rather than let it collapse with other unknowns.
+		if udid == "" || known[udid] {
+			continue
 		}
+		known[udid] = true
+		deviceList.DeviceList = append(deviceList.DeviceList, d)
 	}
 	return deviceList
 }

--- a/cli_device_resolution.go
+++ b/cli_device_resolution.go
@@ -50,8 +50,14 @@ func resolveDevice(arguments docopt.Opts, tunnelInfo tunnelInfoConfig) ios.Devic
 		return device
 	}
 
-	exitIfError("Device not found: "+udid, err)
 	if addressErr == nil && rsdErr == nil {
+		if err != nil {
+			// Explicit tunnel coordinates were given, so a device missing from
+			// usbmuxd is not fatal: it may only be reachable through a tunnel
+			// (e.g. from another host). Build the entry from the coordinates
+			// and treat --udid as identity metadata.
+			device = directTargetDevice(udid, address, userspaceTunnelErr == nil)
+		}
 		if userspaceTunnelErr == nil {
 			device.UserspaceTUN = true
 			device.UserspaceTUNHost = userspaceTunnelHost
@@ -59,6 +65,8 @@ func resolveDevice(arguments docopt.Opts, tunnelInfo tunnelInfoConfig) ios.Devic
 		}
 		return deviceWithRsdProvider(device, udid, address, rsdPort)
 	}
+
+	exitIfError("Device not found: "+udid, err)
 
 	if !needsAutomaticTunnelInfo(arguments) {
 		return device
@@ -74,6 +82,88 @@ func resolveDevice(arguments docopt.Opts, tunnelInfo tunnelInfoConfig) ios.Devic
 
 	slog.Warn("failed to get tunnel info", "udid", device.Properties.SerialNumber)
 	return device
+}
+
+// Transport markers for devices reachable through a go-ios tunnel instead of
+// usbmuxd. They show up as connectionType in `ios list` output, next to the
+// usbmuxd-reported "USB"/"Network".
+const (
+	connectionTypeTunnel          = "tunnel"
+	connectionTypeUserspaceTunnel = "userspaceTunnel"
+)
+
+// directTargetDevice builds a DeviceEntry from explicit --address/--rsd-port
+// coordinates for a device that usbmuxd does not know. The udid (possibly
+// empty) is identity metadata; the RSD handshake fills it in later if needed.
+func directTargetDevice(udid string, address string, userspaceTunnel bool) ios.DeviceEntry {
+	connectionType := connectionTypeTunnel
+	if userspaceTunnel {
+		connectionType = connectionTypeUserspaceTunnel
+	}
+	return ios.DeviceEntry{
+		Properties: ios.DeviceProperties{
+			SerialNumber:   udid,
+			ConnectionType: connectionType,
+		},
+		Address: address,
+	}
+}
+
+// tunnelBackedDeviceEntry converts a tunnel-agent entry into a DeviceEntry so
+// tunnel-backed devices can be listed alongside usbmuxd ones.
+func tunnelBackedDeviceEntry(t tunnel.Tunnel, tunnelHost string) ios.DeviceEntry {
+	connectionType := connectionTypeTunnel
+	if t.UserspaceTUN {
+		connectionType = connectionTypeUserspaceTunnel
+	}
+	return ios.DeviceEntry{
+		Properties: ios.DeviceProperties{
+			SerialNumber:   t.Udid,
+			ConnectionType: connectionType,
+		},
+		Address:          t.Address,
+		UserspaceTUN:     t.UserspaceTUN,
+		UserspaceTUNHost: tunnelHost,
+		UserspaceTUNPort: t.UserspaceTUNPort,
+	}
+}
+
+// tunnelBackedDevices queries the tunnel agent's /tunnels HTTP API and returns
+// the tunnels as device entries. An error just means no agent is reachable.
+func tunnelBackedDevices(tunnelInfo tunnelInfoConfig) ([]ios.DeviceEntry, error) {
+	tunnels, err := tunnel.ListRunningTunnels(tunnelInfo.Host, tunnelInfo.Port)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]ios.DeviceEntry, len(tunnels))
+	for i, t := range tunnels {
+		entries[i] = tunnelBackedDeviceEntry(t, tunnelInfo.Host)
+	}
+	return entries, nil
+}
+
+// mergeTunnelDevices appends tunnel-backed devices that usbmuxd does not
+// already report, so `ios list` shows devices that are only reachable via a
+// tunnel. usbmuxd entries win for devices known to both sources.
+func mergeTunnelDevices(deviceList ios.DeviceList, tunnelDevices []ios.DeviceEntry) ios.DeviceList {
+	known := make(map[string]bool, len(deviceList.DeviceList))
+	for _, d := range deviceList.DeviceList {
+		known[d.Properties.SerialNumber] = true
+	}
+	for _, d := range tunnelDevices {
+		if !known[d.Properties.SerialNumber] {
+			deviceList.DeviceList = append(deviceList.DeviceList, d)
+		}
+	}
+	return deviceList
+}
+
+// isTunnelOnlyDevice reports whether the entry came from tunnel discovery (or
+// explicit tunnel coordinates) rather than usbmuxd, meaning usbmuxd-based
+// services like lockdown are not reachable for it on this host.
+func isTunnelOnlyDevice(device ios.DeviceEntry) bool {
+	connectionType := device.Properties.ConnectionType
+	return connectionType == connectionTypeTunnel || connectionType == connectionTypeUserspaceTunnel
 }
 
 func needsAutomaticTunnelInfo(args docopt.Opts) bool {

--- a/cli_device_resolution_test.go
+++ b/cli_device_resolution_test.go
@@ -107,6 +107,37 @@ func TestMergeTunnelDevicesPrefersUsbmuxEntries(t *testing.T) {
 	}
 }
 
+// TestMergeTunnelDevicesDeduplicatesTunnelEntries ensures the merge does not
+// list the same tunnel-backed udid twice and drops entries without a udid,
+// which cannot be addressed or deduplicated by identity.
+func TestMergeTunnelDevicesDeduplicatesTunnelEntries(t *testing.T) {
+	tunnelDevices := []ios.DeviceEntry{
+		{Properties: ios.DeviceProperties{SerialNumber: "dup-udid", ConnectionType: connectionTypeTunnel}},
+		{Properties: ios.DeviceProperties{SerialNumber: "dup-udid", ConnectionType: connectionTypeUserspaceTunnel}},
+		{Properties: ios.DeviceProperties{SerialNumber: "", ConnectionType: connectionTypeTunnel}},
+		{Properties: ios.DeviceProperties{SerialNumber: "", ConnectionType: connectionTypeUserspaceTunnel}},
+		{Properties: ios.DeviceProperties{SerialNumber: "unique-udid", ConnectionType: connectionTypeTunnel}},
+	}
+
+	merged := mergeTunnelDevices(ios.DeviceList{}, tunnelDevices)
+	if len(merged.DeviceList) != 2 {
+		t.Fatalf("expected 2 deduplicated devices, got %d: %+v", len(merged.DeviceList), merged.DeviceList)
+	}
+	seen := map[string]int{}
+	for _, d := range merged.DeviceList {
+		seen[d.Properties.SerialNumber]++
+	}
+	if seen["dup-udid"] != 1 {
+		t.Errorf("duplicate tunnel udid must appear once, got %d", seen["dup-udid"])
+	}
+	if seen[""] != 0 {
+		t.Errorf("tunnel entries without a udid must be dropped, got %d", seen[""])
+	}
+	if seen["unique-udid"] != 1 {
+		t.Errorf("unique tunnel device missing from merge")
+	}
+}
+
 // TestDirectTargetDeviceBypassesUsbmuxd covers the --address/--rsd-port path:
 // resolution must produce a usable entry with the udid as identity metadata
 // even when usbmuxd does not know the device.

--- a/cli_device_resolution_test.go
+++ b/cli_device_resolution_test.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/tunnel"
+)
+
+// fakeTunnelAgent serves the tunnel agent's /tunnels endpoint on 127.0.0.1 and
+// returns the matching tunnelInfoConfig.
+func fakeTunnelAgent(t *testing.T, tunnels []tunnel.Tunnel) tunnelInfoConfig {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tunnels" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(tunnels); err != nil {
+			t.Errorf("failed to encode tunnels: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	host, portString, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		t.Fatalf("failed to parse test server address: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("failed to parse test server port: %v", err)
+	}
+	return tunnelInfoConfig{Host: host, Port: port}
+}
+
+func TestTunnelBackedDevicesMergeIntoEmptyUsbmuxList(t *testing.T) {
+	tunnelInfo := fakeTunnelAgent(t, []tunnel.Tunnel{
+		{Udid: "00008120-001905DE2E9B401E", Address: "fd6f:7edb:be57::1", RsdPort: 62173, UserspaceTUN: true, UserspaceTUNPort: 61246},
+		{Udid: "00008030-000E4C523C40802E", Address: "fd7b:15e6:a8ae::1", RsdPort: 55555},
+	})
+
+	devices, err := tunnelBackedDevices(tunnelInfo)
+	if err != nil {
+		t.Fatalf("tunnelBackedDevices failed: %v", err)
+	}
+	merged := mergeTunnelDevices(ios.DeviceList{}, devices)
+	if len(merged.DeviceList) != 2 {
+		t.Fatalf("expected 2 devices, got %d", len(merged.DeviceList))
+	}
+
+	userspaceDevice := merged.DeviceList[0]
+	if userspaceDevice.Properties.SerialNumber != "00008120-001905DE2E9B401E" {
+		t.Errorf("unexpected udid: %s", userspaceDevice.Properties.SerialNumber)
+	}
+	if userspaceDevice.Properties.ConnectionType != connectionTypeUserspaceTunnel {
+		t.Errorf("expected connectionType %q, got %q", connectionTypeUserspaceTunnel, userspaceDevice.Properties.ConnectionType)
+	}
+	if userspaceDevice.Address != "fd6f:7edb:be57::1" {
+		t.Errorf("unexpected address: %s", userspaceDevice.Address)
+	}
+	if !userspaceDevice.UserspaceTUN || userspaceDevice.UserspaceTUNPort != 61246 {
+		t.Errorf("userspace TUN fields not propagated: %+v", userspaceDevice)
+	}
+	if userspaceDevice.UserspaceTUNHost != tunnelInfo.Host {
+		t.Errorf("expected userspace TUN host %q, got %q", tunnelInfo.Host, userspaceDevice.UserspaceTUNHost)
+	}
+
+	kernelDevice := merged.DeviceList[1]
+	if kernelDevice.Properties.ConnectionType != connectionTypeTunnel {
+		t.Errorf("expected connectionType %q, got %q", connectionTypeTunnel, kernelDevice.Properties.ConnectionType)
+	}
+	if !isTunnelOnlyDevice(userspaceDevice) || !isTunnelOnlyDevice(kernelDevice) {
+		t.Error("tunnel-backed entries must be detected as tunnel-only")
+	}
+}
+
+func TestMergeTunnelDevicesPrefersUsbmuxEntries(t *testing.T) {
+	usbmux := ios.DeviceList{DeviceList: []ios.DeviceEntry{
+		{DeviceID: 7, Properties: ios.DeviceProperties{SerialNumber: "shared-udid", ConnectionType: "USB"}},
+	}}
+	tunnelDevices := []ios.DeviceEntry{
+		{Properties: ios.DeviceProperties{SerialNumber: "shared-udid", ConnectionType: connectionTypeUserspaceTunnel}},
+		{Properties: ios.DeviceProperties{SerialNumber: "tunnel-only-udid", ConnectionType: connectionTypeTunnel}},
+	}
+
+	merged := mergeTunnelDevices(usbmux, tunnelDevices)
+	if len(merged.DeviceList) != 2 {
+		t.Fatalf("expected 2 devices, got %d", len(merged.DeviceList))
+	}
+	if merged.DeviceList[0].Properties.ConnectionType != "USB" || merged.DeviceList[0].DeviceID != 7 {
+		t.Errorf("usbmuxd entry must win for devices known to both sources: %+v", merged.DeviceList[0])
+	}
+	if merged.DeviceList[1].Properties.SerialNumber != "tunnel-only-udid" {
+		t.Errorf("tunnel-only device missing from merge: %+v", merged.DeviceList[1])
+	}
+	if isTunnelOnlyDevice(merged.DeviceList[0]) {
+		t.Error("usbmuxd entry must not be marked tunnel-only")
+	}
+}
+
+// TestDirectTargetDeviceBypassesUsbmuxd covers the --address/--rsd-port path:
+// resolution must produce a usable entry with the udid as identity metadata
+// even when usbmuxd does not know the device.
+func TestDirectTargetDeviceBypassesUsbmuxd(t *testing.T) {
+	device := directTargetDevice("00008120-001905DE2E9B401E", "fd6f:7edb:be57::1", true)
+	if device.Properties.SerialNumber != "00008120-001905DE2E9B401E" {
+		t.Errorf("udid must be kept as identity metadata, got %q", device.Properties.SerialNumber)
+	}
+	if device.Address != "fd6f:7edb:be57::1" {
+		t.Errorf("unexpected address: %s", device.Address)
+	}
+	if device.Properties.ConnectionType != connectionTypeUserspaceTunnel {
+		t.Errorf("expected connectionType %q, got %q", connectionTypeUserspaceTunnel, device.Properties.ConnectionType)
+	}
+
+	kernelTarget := directTargetDevice("", "fd6f:7edb:be57::1", false)
+	if kernelTarget.Properties.ConnectionType != connectionTypeTunnel {
+		t.Errorf("expected connectionType %q, got %q", connectionTypeTunnel, kernelTarget.Properties.ConnectionType)
+	}
+	if kernelTarget.Properties.SerialNumber != "" {
+		t.Errorf("empty udid must stay empty until the RSD handshake provides one, got %q", kernelTarget.Properties.SerialNumber)
+	}
+}
+
+// TestPrintDeviceListIncludesTunnelDevices asserts the merged `ios list`
+// output contains devices only known to the tunnel agent, regardless of
+// whether a local usbmuxd is running.
+func TestPrintDeviceListIncludesTunnelDevices(t *testing.T) {
+	tunnelInfo := fakeTunnelAgent(t, []tunnel.Tunnel{
+		{Udid: "tunnel-only-test-udid", Address: "fd6f:7edb:be57::1", RsdPort: 62173, UserspaceTUN: true, UserspaceTUNPort: 61246},
+	})
+
+	output := captureStdout(t, func() {
+		printDeviceList(false, tunnelInfo)
+	})
+	if !strings.Contains(output, "tunnel-only-test-udid") {
+		t.Errorf("list output must contain the tunnel-backed device, got: %s", output)
+	}
+}
+
+// TestDetailedListMarksTunnelTransport asserts the --details output labels
+// tunnel-backed devices with their transport instead of failing on the
+// unreachable lockdown connection.
+func TestDetailedListMarksTunnelTransport(t *testing.T) {
+	deviceList := ios.DeviceList{DeviceList: []ios.DeviceEntry{
+		{
+			Properties:       ios.DeviceProperties{SerialNumber: "tunnel-only-test-udid", ConnectionType: connectionTypeUserspaceTunnel},
+			Address:          "fd6f:7edb:be57::1",
+			UserspaceTUN:     true,
+			UserspaceTUNPort: 61246,
+		},
+	}}
+
+	output := captureStdout(t, func() {
+		outputDetailedList(deviceList)
+	})
+
+	var parsed struct {
+		DeviceList []detailsEntry `json:"deviceList"`
+	}
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatalf("details output is not valid JSON: %v, output: %s", err, output)
+	}
+	if len(parsed.DeviceList) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(parsed.DeviceList))
+	}
+	if parsed.DeviceList[0].Udid != "tunnel-only-test-udid" {
+		t.Errorf("unexpected udid: %s", parsed.DeviceList[0].Udid)
+	}
+	if parsed.DeviceList[0].ConnectionType != connectionTypeUserspaceTunnel {
+		t.Errorf("expected connectionType %q, got %q", connectionTypeUserspaceTunnel, parsed.DeviceList[0].ConnectionType)
+	}
+}
+
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	original := os.Stdout
+	os.Stdout = writer
+	defer func() { os.Stdout = original }()
+
+	done := make(chan string)
+	go func() {
+		data, _ := io.ReadAll(reader)
+		done <- string(data)
+	}()
+
+	f()
+	writer.Close()
+	return <-done
+}

--- a/cmd_global.go
+++ b/cmd_global.go
@@ -63,5 +63,5 @@ func isDeviceListCommand(args docopt.Opts) bool {
 
 func runDeviceListCommand(ctx commandContext) {
 	details, _ := ctx.Args.Bool("--details")
-	printDeviceList(details)
+	printDeviceList(details, tunnelInfoConfigFromArgs(ctx.Args))
 }

--- a/main.go
+++ b/main.go
@@ -350,6 +350,8 @@ The commands work as following:
                                                                        --wait keeps the connection open if you want logs.
 
     ios list [options] [--details]                                     Prints a list of all connected device's udids.
+                                                                       Devices known to a running go-ios tunnel agent are included even if usbmuxd
+                                                                       does not see them; those are marked with connectionType tunnel/userspaceTunnel.
                                                                        If --details is specified, it includes version, name and model of each device.
 
     ios listen [options]                                               Keeps a persistent connection open and notifies about newly connected or disconnected devices.
@@ -1416,10 +1418,22 @@ func processList(device ios.DeviceEntry, applicationsOnly bool) {
 	}
 }
 
-func printDeviceList(details bool) {
-	deviceList, err := ios.ListDevices()
-	if err != nil {
-		exitIfError("failed getting device list", err)
+func printDeviceList(details bool, tunnelInfo tunnelInfoConfig) {
+	deviceList, usbmuxErr := ios.ListDevices()
+	if usbmuxErr != nil {
+		deviceList = ios.DeviceList{}
+	}
+	tunnelDevices, tunnelErr := tunnelBackedDevices(tunnelInfo)
+	if tunnelErr == nil {
+		deviceList = mergeTunnelDevices(deviceList, tunnelDevices)
+	}
+	if usbmuxErr != nil {
+		// usbmuxd may legitimately be absent on hosts that only reach devices
+		// through a tunnel agent; only fail if tunnel discovery is down too.
+		if tunnelErr != nil {
+			exitIfError("failed getting device list", usbmuxErr)
+		}
+		slog.Warn("usbmuxd is not reachable, listing tunnel-backed devices only", "error", usbmuxErr)
 	}
 
 	if details {
@@ -1445,19 +1459,29 @@ type detailsEntry struct {
 	ConnectionType string
 }
 
+// detailsEntryForDevice collects the detailed list values for one device.
+// Tunnel-only devices are not reachable through usbmuxd/lockdown on this host,
+// so they are listed with their identity and transport only.
+func detailsEntryForDevice(device ios.DeviceEntry) detailsEntry {
+	entry := detailsEntry{
+		Udid:           device.Properties.SerialNumber,
+		ConnectionType: device.ConnectionTypeLabel(),
+	}
+	if isTunnelOnlyDevice(device) {
+		return entry
+	}
+	allValues, err := ios.GetValues(device)
+	exitIfError("failed getting values", err)
+	entry.ProductName = allValues.Value.ProductName
+	entry.ProductType = allValues.Value.ProductType
+	entry.ProductVersion = allValues.Value.ProductVersion
+	return entry
+}
+
 func outputDetailedList(deviceList ios.DeviceList) {
 	result := make([]detailsEntry, len(deviceList.DeviceList))
 	for i, device := range deviceList.DeviceList {
-		udid := device.Properties.SerialNumber
-		allValues, err := ios.GetValues(device)
-		exitIfError("failed getting values", err)
-		result[i] = detailsEntry{
-			Udid:           udid,
-			ProductName:    allValues.Value.ProductName,
-			ProductType:    allValues.Value.ProductType,
-			ProductVersion: allValues.Value.ProductVersion,
-			ConnectionType: device.ConnectionTypeLabel(),
-		}
+		result[i] = detailsEntryForDevice(device)
 	}
 	fmt.Println(convertToJSONString(map[string][]detailsEntry{
 		"deviceList": result,
@@ -1466,10 +1490,8 @@ func outputDetailedList(deviceList ios.DeviceList) {
 
 func outputDetailedListNoJSON(deviceList ios.DeviceList) {
 	for _, device := range deviceList.DeviceList {
-		udid := device.Properties.SerialNumber
-		allValues, err := ios.GetValues(device)
-		exitIfError("failed getting values", err)
-		fmt.Printf("%s  %s  %s  %s  %s\n", udid, allValues.Value.ProductName, allValues.Value.ProductType, allValues.Value.ProductVersion, device.ConnectionTypeLabel())
+		entry := detailsEntryForDevice(device)
+		fmt.Printf("%s  %s  %s  %s  %s\n", entry.Udid, entry.ProductName, entry.ProductType, entry.ProductVersion, entry.ConnectionType)
 	}
 }
 
@@ -1930,10 +1952,21 @@ func deviceWithRsdProvider(device ios.DeviceEntry, udid string, address string, 
 	// service lookup would then misreport as 'service not available in RSD'.
 	exitIfError(fmt.Sprintf("RSD handshake failed, host %s, port %d", address, rsdPort), err)
 	device1, err := ios.GetDeviceWithAddress(udid, address, rsdProvider)
+	if err != nil {
+		// usbmuxd does not know this device (e.g. it is only reachable through
+		// a tunnel from another host). The RSD handshake succeeded, so keep the
+		// direct-target entry instead of failing and take the identity from the
+		// handshake when no --udid was given.
+		if device.Properties.SerialNumber == "" {
+			device.Properties.SerialNumber = rsdProvider.Udid
+		}
+		device.Address = address
+		device.Rsd = rsdProvider
+		return device
+	}
 	device1.UserspaceTUN = device.UserspaceTUN
 	device1.UserspaceTUNHost = device.UserspaceTUNHost
 	device1.UserspaceTUNPort = device.UserspaceTUNPort
-	exitIfError("error getting devicelist", err)
 
 	return device1
 }

--- a/main.go
+++ b/main.go
@@ -1429,8 +1429,11 @@ func printDeviceList(details bool, tunnelInfo tunnelInfoConfig) {
 	}
 	if usbmuxErr != nil {
 		// usbmuxd may legitimately be absent on hosts that only reach devices
-		// through a tunnel agent; only fail if tunnel discovery is down too.
-		if tunnelErr != nil {
+		// through a tunnel agent. Only suppress the usbmuxd failure if tunnel
+		// discovery actually turned up devices; otherwise there is nothing to
+		// list and the original hard failure (and its non-zero exit code, which
+		// scripts rely on) must stand.
+		if len(deviceList.DeviceList) == 0 {
 			exitIfError("failed getting device list", usbmuxErr)
 		}
 		slog.Warn("usbmuxd is not reachable, listing tunnel-backed devices only", "error", usbmuxErr)


### PR DESCRIPTION
## Problem

`ios list` and device resolution are tied to local usbmuxd discovery. On a host that can reach an iOS 17+ RSD/userspace tunnel (e.g. a remote-device bridge where the phone is physically attached to another machine), `ios list` returns `{"deviceList": []}` and commands like `rsd ls`/`info` fail early with `Device not found: <udid>` — even when the user passes explicit `--address`/`--rsd-port`/`--userspace-port` coordinates that are perfectly reachable.

## Design

Two additions, both on the CLI/resolution layer:

1. **Second discovery source for `ios list`.** The list command now also queries the go-ios tunnel agent's existing `/tunnels` HTTP API (via the existing `tunnel.ListRunningTunnels`, honoring `--tunnel-info-host`/`--tunnel-info-port`/`GO_IOS_AGENT_HOST`/`GO_IOS_AGENT_PORT`) and merges tunnel-backed devices that usbmuxd does not report into the output. Merged entries carry a distinct transport marker: `connectionType: "userspaceTunnel"` (or `"tunnel"` for kernel TUN tunnels). usbmuxd entries win for devices known to both sources. `ios list` only hard-fails if *both* usbmuxd and the tunnel agent are unreachable. In `--details` mode, tunnel-only devices are listed with identity + transport instead of dying on the unreachable usbmuxd/lockdown path.

2. **Direct-target resolution.** When `--address` and `--rsd-port` are supplied, a device missing from usbmuxd is no longer fatal: the `DeviceEntry` is built from the explicit coordinates, `--userspace-port` (+ `--userspace-host`) is preserved as the local forward endpoint, and `--udid` is treated as identity metadata. If no `--udid` is given, the UDID from the RSD handshake response is used. The RSD handshake itself is unchanged and still validated eagerly.

## Implementation

- `cli_device_resolution.go`
  - `resolveDevice`: the explicit `--address`/`--rsd-port` branch now runs *before* the `Device not found` exit; on usbmuxd miss it builds a `directTargetDevice` entry instead of failing.
  - New helpers: `directTargetDevice`, `tunnelBackedDevices` (queries `/tunnels`), `tunnelBackedDeviceEntry`, `mergeTunnelDevices`, `isTunnelOnlyDevice`, plus the `connectionTypeTunnel`/`connectionTypeUserspaceTunnel` markers.
- `main.go`
  - `printDeviceList(details, tunnelInfo)`: merges the tunnel source, tolerates a missing usbmuxd when the tunnel agent answers (warns instead of exiting).
  - `detailsEntryForDevice`: shared by JSON/no-JSON detailed output; skips lockdown `GetValues` for tunnel-only entries.
  - `deviceWithRsdProvider`: when `GetDeviceWithAddress` fails after a *successful* RSD handshake, keep the direct-target entry (attach the handshake's `RsdPortProvider`, backfill the UDID from the handshake) instead of exiting.
- `cmd_global.go`: pass the tunnel-info config into the list command.
- `ios/tunnel/tunnel_api.go` is **untouched** (read-side only via the existing `ListRunningTunnels`), deliberately avoiding overlap with the concurrent TunnelManager rework.

## Options considered

- **Merge `/tunnels` into `ios list` + direct `--address`/`--rsd-port` target path (chosen).** Reuses the tunnel agent API and the existing RSD plumbing (`NewWithAddrPortDevice` + `Handshake`), keeps changes additive and on the CLI layer, and matches what users expect (`ios list` shows reachable devices; explicit coordinates just work). This is also intentionally aligned with the #713 Phase-1 direction: it's the same resolver-source plumbing (tunnel agent as a device source next to usbmuxd) that a future multi-source resolver can formalize, without committing to new library API now.
- **Separate specialist commands for RSD-only devices** (e.g. `ios rsd list`). Works, but users would still hit the `deviceList: []` / "Device not found" wall in normal commands; discoverability is poor.
- **Emulate usbmuxd from the bridge host.** Heaviest option; duplicates discovery/forwarding logic go-ios already has for RSD and userspace tunnels.
- **Keep usbmuxd-only discovery** (status quo): blocks remote/cloud workflows entirely.

## Test plan

- New unit tests in `cli_device_resolution_test.go` (device-free, run in CI) against a fake tunnel-agent HTTP server on 127.0.0.1:
  - `/tunnels` entries convert + merge into an empty usbmux list with correct udid, address, userspace TUN fields, and `userspaceTunnel`/`tunnel` transport markers.
  - Merge dedupes: usbmuxd entry wins for a shared UDID; tunnel-only entries are appended.
  - Direct-target resolution builds a usable entry from `--address`/`--rsd-port` with `--udid` as identity metadata (and empty UDID left for the RSD handshake to fill).
  - `printDeviceList` output contains the tunnel-only device.
  - `--details` output labels tunnel-only devices with the transport marker instead of failing.
- `go build ./...`, `go test ./...` (all green), `gofmt -l` clean on changed files.
- Real-device e2e suite via CI (`/test-devices`).

Fixes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk
