### PR TITLE
fix(tunnel): bound tunnel/RSD TCP dials with a 15s timeout

### DIFF
--- a/ios/connect.go
+++ b/ios/connect.go
@@ -296,6 +296,42 @@ func initializeXpcConnection(h *http.HttpConnection) error {
 	return nil
 }
 
+// TunnelDialTimeout bounds TCP connects to tunnel/RSD endpoints. Without an
+// explicit timeout, a dial to a dead-but-still-routed tunnel address (device
+// rebooted or hung while the host-side TUN interface and route stayed up)
+// blocks for the kernel's TCP SYN timeout (~135s on Linux) per operation. 15s
+// is far above any healthy tunnel connect (sub-second) while still failing
+// fast enough for staleness handling to react.
+const TunnelDialTimeout = 15 * time.Second
+
+// ErrDialTimeout marks a tunnel/RSD TCP connect that exceeded go-ios' dial
+// timeout rather than failing outright. Callers can use errors.Is to treat the
+// endpoint as stale: the route existed but the device never answered, which is
+// the signature of a dead tunnel whose interface lingers.
+var ErrDialTimeout = errors.New("dial timed out")
+
+// DialTunnelTCP connects to a tunnel/RSD TCP endpoint (address in the form
+// accepted by net.Dial, e.g. "[fd00::1]:1234") with TunnelDialTimeout.
+func DialTunnelTCP(address string) (*net.TCPConn, error) {
+	return DialTunnelTCPWithTimeout(address, TunnelDialTimeout)
+}
+
+// DialTunnelTCPWithTimeout is DialTunnelTCP with a caller-chosen timeout.
+// Timeout errors are wrapped in ErrDialTimeout so they stay distinguishable
+// from refused/unreachable errors.
+func DialTunnelTCPWithTimeout(address string, timeout time.Duration) (*net.TCPConn, error) {
+	d := net.Dialer{Timeout: timeout}
+	conn, err := d.Dial("tcp", address)
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return nil, fmt.Errorf("%w after %v: %w", ErrDialTimeout, timeout, err)
+		}
+		return nil, err
+	}
+	return conn.(*net.TCPConn), nil
+}
+
 // ConnectTUNDevice creates a *net.TCPConn to the device at the given address and port.
 // If the device is a userspaceTUN device provided by go-ios agent, it will connect to this
 // automatically. Otherwise it will try a operating system level TUN device.
@@ -310,8 +346,7 @@ func ConnectTUNDevice(remoteIp string, port int, d DeviceEntry) (*net.TCPConn, e
 		return connectTUN(remoteIp, port)
 	}
 
-	addr, _ := net.ResolveTCPAddr("tcp4", fmt.Sprintf("%s:%d", d.UserspaceTUNHost, d.UserspaceTUNPort))
-	conn, err := net.DialTCP("tcp", nil, addr)
+	conn, err := DialTunnelTCP(fmt.Sprintf("%s:%d", d.UserspaceTUNHost, d.UserspaceTUNPort))
 	if err != nil {
 		return nil, fmt.Errorf("ConnectUserSpaceTunnel: failed to dial: %w", err)
 	}
@@ -332,11 +367,7 @@ func ConnectTUNDevice(remoteIp string, port int, d DeviceEntry) (*net.TCPConn, e
 
 // connect to a operating system level TUN device
 func connectTUN(address string, port int) (*net.TCPConn, error) {
-	addr, err := net.ResolveTCPAddr("tcp6", fmt.Sprintf("[%s]:%d", address, port))
-	if err != nil {
-		return nil, fmt.Errorf("ConnectToHttp2WithAddr: failed to resolve address: %w", err)
-	}
-	conn, err := net.DialTCP("tcp", nil, addr)
+	conn, err := DialTunnelTCP(fmt.Sprintf("[%s]:%d", address, port))
 	if err != nil {
 		return nil, fmt.Errorf("ConnectToHttp2WithAddr: failed to dial: %w", err)
 	}

--- a/ios/connect_test.go
+++ b/ios/connect_test.go
@@ -1,7 +1,9 @@
 package ios
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,4 +58,26 @@ func TestConnectToServiceFailsFastWhenServiceIsMissingFromRsd(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not available in RSD")
 	})
+}
+
+// A dial to a dead-but-still-routed tunnel address (device rebooted or hung
+// while the host-side TUN route stayed up) must fail after go-ios' own dial
+// timeout, not the kernel's ~135s SYN timeout, and the error must be
+// classifiable as a timeout so staleness handling can key off it (issue #764).
+// 192.0.2.1 (TEST-NET-1, RFC 5737) is reserved and never answers, mimicking the
+// blackholed-SYN behavior of a dead tunnel.
+func TestDialTunnelTCPWithTimeoutFailsFast(t *testing.T) {
+	const timeout = 250 * time.Millisecond
+	start := time.Now()
+	_, err := DialTunnelTCPWithTimeout("192.0.2.1:54321", timeout)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, 5*time.Second, "dial must fail well under the kernel SYN timeout")
+	if !errors.Is(err, ErrDialTimeout) {
+		// Some environments answer TEST-NET-1 with a fast ICMP unreachable or a
+		// sandbox denial instead of blackholing the SYN; then this run cannot
+		// exercise the timeout classification, only the fast failure above.
+		t.Skipf("environment did not blackhole 192.0.2.1, got: %v", err)
+	}
 }

--- a/ios/tunnel/tunnel_tcp.go
+++ b/ios/tunnel/tunnel_tcp.go
@@ -3,7 +3,6 @@ package tunnel
 import (
 	"context"
 	"fmt"
-	"net"
 
 	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/http"
@@ -55,7 +54,7 @@ func ManualPairAndConnectToTunnelTCP(ctx context.Context, device ios.DeviceEntry
 	}
 
 	tunnelAddr := fmt.Sprintf("[%s]:%d", addr, tunnelPort)
-	tcpConn, err := net.Dial("tcp", tunnelAddr)
+	tcpConn, err := ios.DialTunnelTCP(tunnelAddr)
 	if err != nil {
 		return Tunnel{}, fmt.Errorf("ManualPairAndConnectToTunnelTCP: failed to dial tunnel port %s: %w", tunnelAddr, err)
 	}


### PR DESCRIPTION
## Problem

When an iOS 17+ device drops off a **kernel** tunnel mid-session (reboot / USB blip / device hang) while the host-side TUN interface and route stay up, every subsequent RSD/tunnel connect hangs for the **kernel's TCP SYN timeout (~135s on Linux)** instead of failing fast. In the real-device e2e run that surfaced this, four back-to-back 135s dial hangs blew the 10m suite timeout before anything could recover.

## Root cause

None of the tunnel dial sites set a dial timeout, so they inherit the kernel default:

- `ios/connect.go` `connectTUN` — the kernel-TUN RSD dial (`net.DialTCP`), the exact 135s case from the incident
- `ios/connect.go` `ConnectTUNDevice` userspace-forwarder dial (`net.DialTCP`)
- `ios/tunnel/tunnel_tcp.go` TLS-PSK tunnel-listener dial for iOS 18.2+ (`net.Dial`)

A SYN sent over a live TUN route to a dead device is silently dropped, so only a timeout ever ends the dial.

## Fix

- New shared helper in `ios/connect.go`: `DialTunnelTCP(address)` / `DialTunnelTCPWithTimeout(address, timeout)` using `net.Dialer{Timeout: ...}` with a 15s default (`ios.TunnelDialTimeout`) — far above any healthy tunnel connect (sub-second) but ~9x under the kernel default.
- All three dial sites now go through the helper; keepalive behavior is unchanged.
- Timeout errors are wrapped in the exported sentinel `ios.ErrDialTimeout`, so staleness logic can key off "device unreachable over a live route" distinctly from refused/unreachable errors (used by the tunnel liveness probing built on top of this in the follow-up PR for #765).

## Options considered

- **`net.Dialer{Timeout}` helper (chosen)** — one shared place, works for both plain and TCP-specific call sites, easy to unit test with an injected timeout.
- **Context deadlines plumbed through each call path** — more invasive: `connectTUN`/`ConnectTUNDevice` have no ctx today and every caller would need one; the fixed dial-phase timeout is the actual requirement.
- **String-matching "connection timed out" at call sites** — brittle and OS-dependent; a typed sentinel (`errors.Is`) is the idiomatic signal.
- **Making the timeout configurable via flag/env** — no demonstrated need; a well-chosen constant keeps the surface small. `DialTunnelTCPWithTimeout` exists for callers (and tests) that need a different bound.

## Test plan

- New unit test `TestDialTunnelTCPWithTimeoutFailsFast` (`ios/connect_test.go`): dials blackholed TEST-NET-1 `192.0.2.1` with a 250ms injected timeout and asserts the dial fails **well under** the kernel SYN timeout and classifies as `ErrDialTimeout`. (Skips the classification assert on networks that answer TEST-NET-1 with a fast ICMP unreachable, where the fast-fail assert still holds.) Without the fix, the equivalent bare dial blocks for the kernel default and the elapsed-time assertion fails.
- `go build ./...`, `go test ./...` (all green), `gofmt -l` clean on changed files.
- Real-device e2e via `/test-devices`.

Fixes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk