### PR TITLE
feat(install): alternative installproxy install method via AFC staging

### DIFF
--- a/cmd_device_apps.go
+++ b/cmd_device_apps.go
@@ -17,7 +17,15 @@ func runPSCommand(ctx commandContext) {
 
 func runInstallCommand(ctx commandContext) {
 	path, _ := ctx.Args.String("--path")
-	installApp(ctx.Device, path)
+	method, _ := ctx.Args.String("--method")
+	switch method {
+	case "", "zipconduit":
+		installApp(ctx.Device, path)
+	case "installproxy":
+		installAppInstallProxy(ctx.Device, path)
+	default:
+		logFatal("unknown install method, supported values are 'zipconduit' (default) and 'installproxy'")
+	}
 }
 
 func runUninstallCommand(ctx commandContext) {

--- a/internal/clihelp/help.yaml
+++ b/internal/clihelp/help.yaml
@@ -127,8 +127,8 @@ commands:
     usage: ios info [display | lockdown] [options]
     summary: Dump device info.
   - path: install
-    usage: ios install --path=<ipaOrAppFolder> [options]
-    summary: Install app bundle or IPA.
+    usage: ios install --path=<ipaOrAppFolder> [--method=<method>] [options]
+    summary: Install app bundle or IPA (--method=zipconduit|installproxy).
   - path: instruments notifications
     usage: ios instruments notifications [options]
     summary: Stream app state notifications.

--- a/ios/afc/client.go
+++ b/ios/afc/client.go
@@ -453,6 +453,34 @@ func (f *File) Read(p []byte) (int, error) {
 	return n, nil
 }
 
+// maxTransferSize is the maximum payload carried in a single AFC fileWrite
+// packet. 64KiB matches what other AFC implementations use per packet.
+const maxTransferSize = 64 * 1024
+
+// ReadFrom implements io.ReaderFrom. It copies all data from r into the file,
+// splitting the stream into fileWrite packets of at most maxTransferSize bytes
+// each, so arbitrarily large uploads (e.g. staging an .ipa for installation)
+// never produce oversized AFC packets.
+func (f *File) ReadFrom(r io.Reader) (int64, error) {
+	buf := make([]byte, maxTransferSize)
+	var total int64
+	for {
+		n, readErr := r.Read(buf)
+		if n > 0 {
+			if _, writeErr := f.Write(buf[:n]); writeErr != nil {
+				return total, writeErr
+			}
+			total += int64(n)
+		}
+		if readErr == io.EOF {
+			return total, nil
+		}
+		if readErr != nil {
+			return total, readErr
+		}
+	}
+}
+
 func (f *File) Write(p []byte) (int, error) {
 	headerPayload := make([]byte, 8)
 	binary.LittleEndian.PutUint64(headerPayload, f.handle)

--- a/ios/afc/fsync.go
+++ b/ios/afc/fsync.go
@@ -101,7 +101,7 @@ func (conn *Client) WriteToFile(reader io.Reader, dstPath string) error {
 	}
 	defer fd.Close()
 
-	_, err = io.Copy(fd, reader)
+	_, err = fd.ReadFrom(reader)
 	if err != nil {
 		return err
 	}

--- a/ios/afc/upload_unit_test.go
+++ b/ios/afc/upload_unit_test.go
@@ -1,0 +1,92 @@
+package afc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ackingConn records every packet the client writes and answers each request
+// with a success status packet, mimicking a device that accepts all writes.
+type ackingConn struct {
+	out     bytes.Buffer
+	pending bytes.Buffer
+}
+
+func (c *ackingConn) Write(p []byte) (int, error) { return c.out.Write(p) }
+
+func (c *ackingConn) Read(p []byte) (int, error) {
+	if c.pending.Len() == 0 {
+		statusPayload := make([]byte, 8)
+		binary.LittleEndian.PutUint64(statusPayload, errSuccess)
+		c.pending.Write(encodeAfcPacket(status, statusPayload, nil))
+	}
+	return c.pending.Read(p)
+}
+
+func (c *ackingConn) Close() error { return nil }
+
+// decodeSentPackets parses the raw bytes the client wrote into AFC packets.
+func decodeSentPackets(t *testing.T, raw []byte) []packet {
+	t.Helper()
+	r := bytes.NewReader(raw)
+	var packets []packet
+	for r.Len() > 0 {
+		var h header
+		assert.NoError(t, binary.Read(r, binary.LittleEndian, &h))
+		headerPayload := make([]byte, h.ThisLen-headerSize)
+		_, err := io.ReadFull(r, headerPayload)
+		assert.NoError(t, err)
+		payload := make([]byte, h.EntireLen-h.ThisLen)
+		_, err = io.ReadFull(r, payload)
+		assert.NoError(t, err)
+		packets = append(packets, packet{Header: h, HeaderPayload: headerPayload, Payload: payload})
+	}
+	return packets
+}
+
+// TestFileReadFromChunksLargeUploads verifies that File.ReadFrom splits an
+// upload into fileWrite packets of at most maxTransferSize payload bytes and
+// that the reassembled payload matches the input.
+func TestFileReadFromChunksLargeUploads(t *testing.T) {
+	data := make([]byte, 2*maxTransferSize+1234)
+	rand.New(rand.NewSource(1)).Read(data)
+
+	conn := &ackingConn{}
+	f := &File{client: &Client{connection: conn}, handle: 7}
+
+	n, err := f.ReadFrom(bytes.NewReader(data))
+	assert.NoError(t, err)
+	assert.EqualValues(t, len(data), n)
+
+	packets := decodeSentPackets(t, conn.out.Bytes())
+	assert.Len(t, packets, 3)
+	var reassembled []byte
+	for _, p := range packets {
+		assert.Equal(t, fileWrite, p.Header.Operation)
+		// the header payload carries the file handle
+		assert.EqualValues(t, 7, binary.LittleEndian.Uint64(p.HeaderPayload))
+		assert.LessOrEqual(t, len(p.Payload), maxTransferSize)
+		reassembled = append(reassembled, p.Payload...)
+	}
+	assert.Len(t, packets[0].Payload, maxTransferSize)
+	assert.Len(t, packets[1].Payload, maxTransferSize)
+	assert.Len(t, packets[2].Payload, 1234)
+	assert.Equal(t, data, reassembled)
+}
+
+// TestFileReadFromEmptyReader verifies that an empty upload does not send any
+// fileWrite packets.
+func TestFileReadFromEmptyReader(t *testing.T) {
+	conn := &ackingConn{}
+	f := &File{client: &Client{connection: conn}, handle: 1}
+
+	n, err := f.ReadFrom(bytes.NewReader(nil))
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, n)
+	assert.Empty(t, conn.out.Bytes())
+}

--- a/ios/installationproxy/install.go
+++ b/ios/installationproxy/install.go
@@ -1,0 +1,142 @@
+package installationproxy
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	ios "github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/afc"
+	"github.com/danielpaulus/go-ios/ios/golog"
+)
+
+// stagingPath is the directory relative to the AFC root (/var/mobile/Media)
+// where packages are uploaded before installation.
+const stagingPath = "PublicStaging"
+
+// InstallIpa uploads the given .ipa file to the PublicStaging directory on the
+// device using AFC and then installs it by sending an Install command to the
+// installation_proxy service. This is an alternative to the zipconduit based
+// installation: the .ipa is transferred as-is (compressed, without unpacking it
+// on the host) and unpacked and verified on the device.
+func InstallIpa(device ios.DeviceEntry, ipaPath string) error {
+	info, err := os.Stat(ipaPath)
+	if err != nil {
+		return fmt.Errorf("installproxy: could not read package %s: %w", ipaPath, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("installproxy: %s is a directory, the installproxy method only supports .ipa files. Use the default zipconduit method for .app folders", ipaPath)
+	}
+	remotePath := path.Join(stagingPath, filepath.Base(ipaPath))
+
+	afcClient, err := afc.New(device)
+	if err != nil {
+		return fmt.Errorf("installproxy: failed connecting to AFC: %w", err)
+	}
+	defer afcClient.Close()
+	if _, err := afcClient.Stat(stagingPath); err != nil {
+		if err := afcClient.MkDir(stagingPath); err != nil {
+			return fmt.Errorf("installproxy: failed creating %s: %w", stagingPath, err)
+		}
+	}
+	f, err := os.Open(ipaPath)
+	if err != nil {
+		return fmt.Errorf("installproxy: failed opening %s: %w", ipaPath, err)
+	}
+	defer f.Close()
+	golog.Info("uploading package to device", "module", logModule, "udid", device.Properties.SerialNumber, "path", ipaPath, "remotePath", remotePath, "size", info.Size())
+	err = afcClient.WriteToFile(f, remotePath)
+	if err != nil {
+		return fmt.Errorf("installproxy: failed uploading %s to %s: %w", ipaPath, remotePath, err)
+	}
+	golog.Info("upload complete, starting installation", "module", logModule, "udid", device.Properties.SerialNumber, "remotePath", remotePath)
+
+	conn, err := New(device)
+	if err != nil {
+		return fmt.Errorf("installproxy: failed connecting to installation_proxy: %w", err)
+	}
+	defer conn.Close()
+	return conn.Install(remotePath, nil)
+}
+
+// Install sends the Install command for a package that was previously staged on
+// the device (packagePath is relative to the AFC root, e.g.
+// "PublicStaging/app.ipa") and blocks streaming PercentComplete progress until
+// the installation completes or fails.
+func (c *Connection) Install(packagePath string, options map[string]interface{}) error {
+	b, err := c.plistCodec.Encode(installCommand(packagePath, options))
+	if err != nil {
+		return err
+	}
+	err = c.deviceConn.Send(b)
+	if err != nil {
+		return err
+	}
+	for {
+		response, err := c.plistCodec.Decode(c.deviceConn.Reader())
+		if err != nil {
+			return err
+		}
+		dict, err := ios.ParsePlist(response)
+		if err != nil {
+			return err
+		}
+		done, percent, status, err := evaluateInstallProgress(dict)
+		if err != nil {
+			return err
+		}
+		if done {
+			golog.Info("done installing", "module", logModule, "packagePath", packagePath)
+			return nil
+		}
+		golog.Info("install status", "module", logModule, "packagePath", packagePath, "status", status, "percentComplete", percent)
+	}
+}
+
+// installCommand builds the installation_proxy Install request. ClientOptions
+// is always present, an empty dict when no options are given.
+func installCommand(packagePath string, options map[string]interface{}) map[string]interface{} {
+	if options == nil {
+		options = map[string]interface{}{}
+	}
+	return map[string]interface{}{
+		"Command":       "Install",
+		"PackagePath":   packagePath,
+		"ClientOptions": options,
+	}
+}
+
+// evaluateInstallProgress parses a single progress update sent by
+// installation_proxy while an Install command is running.
+func evaluateInstallProgress(dict map[string]interface{}) (done bool, percent int, status string, err error) {
+	if errValue, ok := dict["Error"]; ok {
+		if description, ok := dict["ErrorDescription"]; ok {
+			return false, 0, "", fmt.Errorf("received install error: %v errorDescription: %v", errValue, description)
+		}
+		return false, 0, "", fmt.Errorf("received install error: %v", errValue)
+	}
+	statusValue, ok := dict["Status"].(string)
+	if !ok {
+		return false, 0, "", fmt.Errorf("unknown install status update: %+v", dict)
+	}
+	if statusValue == "Complete" {
+		return true, 100, statusValue, nil
+	}
+	return false, toPercent(dict["PercentComplete"]), statusValue, nil
+}
+
+// toPercent converts a PercentComplete plist value, plists decode integers as
+// uint64 or int64 depending on encoding and sign.
+func toPercent(v interface{}) int {
+	switch n := v.(type) {
+	case uint64:
+		return int(n)
+	case int64:
+		return int(n)
+	case int:
+		return n
+	default:
+		return 0
+	}
+}

--- a/ios/installationproxy/install.go
+++ b/ios/installationproxy/install.go
@@ -50,6 +50,14 @@ func InstallIpa(device ios.DeviceEntry, ipaPath string) error {
 	if err != nil {
 		return fmt.Errorf("installproxy: failed uploading %s to %s: %w", ipaPath, remotePath, err)
 	}
+	// The staged .ipa (potentially hundreds of MB) is only needed until
+	// installation_proxy has consumed it. Remove it afterwards, whether the
+	// install succeeds or fails, so repeated installs don't leak device storage.
+	defer func() {
+		if rmErr := afcClient.Remove(remotePath); rmErr != nil {
+			golog.Warn("failed removing staged package from device", "module", logModule, "udid", device.Properties.SerialNumber, "remotePath", remotePath, "error", rmErr)
+		}
+	}()
 	golog.Info("upload complete, starting installation", "module", logModule, "udid", device.Properties.SerialNumber, "remotePath", remotePath)
 
 	conn, err := New(device)

--- a/ios/installationproxy/install_test.go
+++ b/ios/installationproxy/install_test.go
@@ -1,0 +1,133 @@
+package installationproxy
+
+import (
+	"bytes"
+	"testing"
+
+	ios "github.com/danielpaulus/go-ios/ios"
+	"github.com/stretchr/testify/assert"
+	"howett.net/plist"
+)
+
+// fakeConn is an in-memory stand-in for the device connection: it serves
+// canned responses from 'in' and records everything the client sends in 'out'.
+type fakeConn struct {
+	in  *bytes.Buffer
+	out *bytes.Buffer
+}
+
+func (f *fakeConn) Read(p []byte) (int, error)  { return f.in.Read(p) }
+func (f *fakeConn) Write(p []byte) (int, error) { return f.out.Write(p) }
+func (f *fakeConn) Close() error                { return nil }
+
+// cannedResponses encodes the given dicts in the length-prefixed plist wire
+// format that installation_proxy uses.
+func cannedResponses(t *testing.T, responses ...map[string]interface{}) *bytes.Buffer {
+	t.Helper()
+	codec := ios.NewPlistCodec()
+	buf := &bytes.Buffer{}
+	for _, r := range responses {
+		b, err := codec.Encode(r)
+		assert.NoError(t, err)
+		buf.Write(b)
+	}
+	return buf
+}
+
+func newTestConnection(in *bytes.Buffer) (*Connection, *fakeConn) {
+	rwc := &fakeConn{in: in, out: &bytes.Buffer{}}
+	return &Connection{
+		deviceConn: ios.NewDeviceConnectionWithRWC(rwc),
+		plistCodec: ios.NewPlistCodec(),
+	}, rwc
+}
+
+func TestInstallCommandRequestPlist(t *testing.T) {
+	cmd := installCommand("PublicStaging/wda.ipa", nil)
+	assert.Equal(t, "Install", cmd["Command"])
+	assert.Equal(t, "PublicStaging/wda.ipa", cmd["PackagePath"])
+	// ClientOptions must always be present, an empty dict when no options are given
+	assert.Equal(t, map[string]interface{}{}, cmd["ClientOptions"])
+
+	cmd = installCommand("PublicStaging/app.ipa", map[string]interface{}{"PackageType": "Developer"})
+	assert.Equal(t, map[string]interface{}{"PackageType": "Developer"}, cmd["ClientOptions"])
+}
+
+func TestInstallSendsRequestAndStreamsProgress(t *testing.T) {
+	conn, rwc := newTestConnection(cannedResponses(t,
+		map[string]interface{}{"Status": "CreatingStagingDirectory", "PercentComplete": 5},
+		map[string]interface{}{"Status": "InstallingApplication", "PercentComplete": 60},
+		map[string]interface{}{"Status": "Complete"},
+	))
+
+	err := conn.Install("PublicStaging/wda.ipa", nil)
+	assert.NoError(t, err)
+
+	// decode the request that was sent over the wire and verify the plist content
+	sent, err := ios.NewPlistCodec().Decode(bytes.NewReader(rwc.out.Bytes()))
+	assert.NoError(t, err)
+	var request map[string]interface{}
+	_, err = plist.Unmarshal(sent, &request)
+	assert.NoError(t, err)
+	assert.Equal(t, "Install", request["Command"])
+	assert.Equal(t, "PublicStaging/wda.ipa", request["PackagePath"])
+	assert.Equal(t, map[string]interface{}{}, request["ClientOptions"])
+}
+
+func TestInstallErrorResponse(t *testing.T) {
+	conn, _ := newTestConnection(cannedResponses(t,
+		map[string]interface{}{"Status": "VerifyingApplication", "PercentComplete": 40},
+		map[string]interface{}{"Error": "ApplicationVerificationFailed", "ErrorDescription": "invalid signature"},
+	))
+
+	err := conn.Install("PublicStaging/wda.ipa", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ApplicationVerificationFailed")
+	assert.Contains(t, err.Error(), "invalid signature")
+}
+
+func TestEvaluateInstallProgressFromCannedPlists(t *testing.T) {
+	progressPlist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+	<key>PercentComplete</key><integer>30</integer>
+	<key>Status</key><string>VerifyingApplication</string>
+</dict></plist>`
+	dict, err := ios.ParsePlist([]byte(progressPlist))
+	assert.NoError(t, err)
+	done, percent, status, err := evaluateInstallProgress(dict)
+	assert.NoError(t, err)
+	assert.False(t, done)
+	assert.Equal(t, 30, percent)
+	assert.Equal(t, "VerifyingApplication", status)
+
+	completePlist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+	<key>Status</key><string>Complete</string>
+</dict></plist>`
+	dict, err = ios.ParsePlist([]byte(completePlist))
+	assert.NoError(t, err)
+	done, percent, _, err = evaluateInstallProgress(dict)
+	assert.NoError(t, err)
+	assert.True(t, done)
+	assert.Equal(t, 100, percent)
+
+	errorPlist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+	<key>Error</key><string>ApplicationVerificationFailed</string>
+	<key>ErrorDescription</key><string>failed to verify code signature</string>
+</dict></plist>`
+	dict, err = ios.ParsePlist([]byte(errorPlist))
+	assert.NoError(t, err)
+	_, _, _, err = evaluateInstallProgress(dict)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ApplicationVerificationFailed")
+	assert.Contains(t, err.Error(), "failed to verify code signature")
+}
+
+func TestEvaluateInstallProgressUnknownUpdate(t *testing.T) {
+	_, _, _, err := evaluateInstallProgress(map[string]interface{}{"Foo": "Bar"})
+	assert.Error(t, err)
+}

--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ Usage:
   ios image mount [--path=<imagepath>] [options]
   ios image unmount [options]
   ios info [display | lockdown] [options]
-  ios install --path=<ipaOrAppFolder> [options]
+  ios install --path=<ipaOrAppFolder> [--method=<method>] [options]
   ios instruments notifications [options]
   ios ip [options]
   ios kill (<bundleID> | --pid=<processID> | --process=<processName>) [options]
@@ -330,7 +330,13 @@ The commands work as following:
 
     ios image unmount [options]                     Unmount developer disk image
     ios info [display | lockdown] [options]         Prints a dump of device information from the given source.
-    ios install --path=<ipaOrAppFolder> [options]   Specify a .app folder or an installable ipa file that will be installed.
+    ios install --path=<ipaOrAppFolder> [--method=<method>] [options]
+                                                    Specify a .app folder or an installable ipa file that will be installed.
+                                                    --method selects how the app is installed: 'zipconduit' (the default) streams
+                                                    the unpacked app to the device, 'installproxy' uploads the .ipa via AFC to
+                                                    PublicStaging and installs it with the installation_proxy service. The
+                                                    installproxy method transfers the compressed .ipa as-is, which is faster for
+                                                    large apps, but supports only .ipa files, not .app folders.
     ios instruments notifications [options]         Listen to application state notifications
 
     ios ip [options]                                Uses the live pcap iOS packet capture to wait until it finds one that contains the IP address of the device.
@@ -764,6 +770,12 @@ func installApp(device ios.DeviceEntry, path string) {
 	exitIfError("failed connecting to zipconduit, dev image installed?", err)
 	err = conn.SendFile(path)
 	exitIfError("failed writing", err)
+}
+
+func installAppInstallProxy(device ios.DeviceEntry, path string) {
+	slog.Info("installing via installproxy", "appPath", path, "device", device.Properties.SerialNumber)
+	err := installationproxy.InstallIpa(device, path)
+	exitIfError("failed installing", err)
 }
 
 func uninstallApp(device ios.DeviceEntry, bundleId string) {

--- a/testdata/help/global.golden
+++ b/testdata/help/global.golden
@@ -54,7 +54,7 @@ Commands:
   image mount                     Mount developer image.
   image unmount                   Unmount developer image.
   info                            Dump device info.
-  install                         Install app bundle or IPA.
+  install                         Install app bundle or IPA (--method=zipconduit|installproxy).
   instruments notifications       Stream app state notifications.
   ip                              Detect device IP from packet capture.
   kill                            Kill app by bundle ID, PID, or process.


### PR DESCRIPTION
## Problem

App installs currently go exclusively through zipconduit, which requires unpacking the bundle on the host and streaming it uncompressed to the device. USB transfers are capped at USB2 speeds (~30-35 MB/s), so sending the uncompressed payload is the bottleneck for large apps. Issue #400 asks for an alternative install path based on AFC + installation_proxy, like pymobiledevice3, which transfers the compressed .ipa as-is and lets the device do the unpacking.

## Design

The new path mirrors pymobiledevice3's `install_from_local`:

1. Connect to AFC, ensure `PublicStaging` exists (AFC root is `/var/mobile/Media`), and upload the .ipa unchanged to `PublicStaging/<basename>`.
2. Connect to `com.apple.mobile.installation_proxy` and send `{"Command": "Install", "PackagePath": "PublicStaging/<basename>", "ClientOptions": {}}`.
3. Stream the length-prefixed plist progress responses, logging `Status`/`PercentComplete`, until `Status == "Complete"` or an `Error`/`ErrorDescription` response, which is surfaced as an error.

zipconduit remains the default; the new method is opt-in via `ios install --path=<ipa> --method=installproxy`. The installproxy method supports .ipa files only — for `.app` folders it returns a clear error pointing at the default method.

## Implementation

- `ios/installationproxy/install.go`:
  - `Connection.Install(packagePath, options)` — sends the Install command and blocks streaming progress until complete or error, following the existing `Uninstall` pattern (PlistCodec + `ios.ParsePlist`).
  - `InstallIpa(device, ipaPath)` — orchestrates AFC staging (Stat/MkDir `PublicStaging`, upload) and the Install command. `ClientOptions` is always sent (empty dict when no options).
  - `installCommand` / `evaluateInstallProgress` are separate small funcs so the request construction and response parsing are unit-testable.
- `ios/afc/client.go`: `File` now implements `io.ReaderFrom`, splitting uploads into `fileWrite` packets of at most 64KiB payload each (matching common AFC implementations), so staging a large .ipa never produces oversized AFC packets. `Client.WriteToFile` uses it.
- CLI: `--method=<method>` on `ios install` (`cmd_device_apps.go`, docopt usage + help text in `main.go`, `internal/clihelp/help.yaml`, regenerated `testdata/help/global.golden`). Unknown values fail fast with the supported values listed.

## Options considered

- **`--method=installproxy` (chosen)**: a single flag with named values keeps `ios install` as one command, defaults to the existing behavior, and leaves room for future methods without adding a flag per transport.
- `--installproxy` boolean flag: simplest, but a second method later would mean mutually-exclusive booleans and docopt disambiguation pain.
- Separate command (`ios install-ipa` / `ios installproxy install`): splits one user intent ("install this app") across commands and doubles the docs/registry surface.
- Auto-selecting installproxy for .ipa inputs: changes behavior silently for existing users and makes failures harder to attribute; explicit opt-in is safer until the method has soaked on the device runners.

## Test plan

- `go build ./...`, `go test ./...` (all green), `gofmt -l` clean on changed files.
- New unit tests, all device-free:
  - `ios/installationproxy/install_test.go`: Install request plist construction (`Command`/`PackagePath`/`ClientOptions`, including the always-present empty dict) asserted by decoding the bytes written to an in-memory connection; progress → completion streaming; error responses (`Error` + `ErrorDescription`) surfaced as errors; progress/complete/error parsing against canned XML plists; unknown updates rejected.
  - `ios/afc/upload_unit_test.go`: `File.ReadFrom` chunking against an in-memory acking connection double — 2×64KiB+1234 bytes yields exactly three `fileWrite` packets with correct handle, sizes, and byte-identical reassembled payload; empty upload sends nothing.
- CLI smoke-tested locally: help output, `--method=installproxy` parsing, unknown method rejection.
- **Follow-up validation**: a real install e2e (stage + install an .ipa via `--method=installproxy` on the device runners) is the next step; this PR intentionally ships the device-free implementation and unit coverage first.

Fixes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk