### PR TITLE
feat(forward): ios forward --list (like adb forward --list)

### DIFF
--- a/cmd_global.go
+++ b/cmd_global.go
@@ -26,6 +26,16 @@ var globalCommands = []command{
 	},
 	commandByBool("listen", runListenCommand),
 	{
+		// `forward --list` only reads the local forward registry, so it needs
+		// no device and must dispatch before device resolution — listing must
+		// work on a host with no device attached.
+		name: "forward --list",
+		match: func(args docopt.Opts) bool {
+			return boolArg(args, "forward") && boolArg(args, "--list")
+		},
+		run: runForwardListCommand,
+	},
+	{
 		name:  "list",
 		match: isDeviceListCommand,
 		run:   runDeviceListCommand,

--- a/ios/forward/forward.go
+++ b/ios/forward/forward.go
@@ -24,6 +24,13 @@ type ConnListener struct {
 	quit     chan interface{}
 }
 
+// resolveDeviceID returns the current usbmux device id of the forwarded device.
+// usbmuxd assigns a fresh id every time a device is plugged in, so the id
+// captured when the forward started goes stale after a disconnect/reconnect.
+// Re-resolving through this func lets a long-running forward survive a replug
+// (issue #378).
+type resolveDeviceID func() (int, error)
+
 // Forward forwards every connection made to the hostPort to whatever service runs inside an app on the device on phonePort.
 // Port values must be between 1 and 65535.
 func Forward(device ios.DeviceEntry, hostPort uint16, phonePort uint16) (*ConnListener, error) {
@@ -43,9 +50,28 @@ func Forward(device ios.DeviceEntry, hostPort uint16, phonePort uint16) (*ConnLi
 		quit:     make(chan interface{}),
 	}
 
-	go connectionAccept(cl, device.DeviceID, phonePort)
+	go connectionAccept(cl, device.DeviceID, phonePort, deviceIDResolver(device))
 
 	return cl, nil
+}
+
+// deviceIDResolver builds a resolveDeviceID that looks the device up again by
+// its udid (the serial survives a replug, the usbmux id does not). Without a
+// udid there is nothing stable to search by, so the captured id is returned
+// as-is.
+func deviceIDResolver(device ios.DeviceEntry) resolveDeviceID {
+	udid := device.Properties.SerialNumber
+	deviceID := device.DeviceID
+	if udid == "" {
+		return func() (int, error) { return deviceID, nil }
+	}
+	return func() (int, error) {
+		fresh, err := ios.GetDevice(udid)
+		if err != nil {
+			return 0, err
+		}
+		return fresh.DeviceID, nil
+	}
 }
 
 // Close stops listening on the host port for the forwarded connection
@@ -60,7 +86,7 @@ func (cl *ConnListener) Close() error {
 	return nil
 }
 
-func connectionAccept(cl *ConnListener, deviceID int, phonePort uint16) {
+func connectionAccept(cl *ConnListener, deviceID int, phonePort uint16, resolve resolveDeviceID) {
 	for {
 		select {
 		case <-cl.quit:
@@ -80,29 +106,73 @@ func connectionAccept(cl *ConnListener, deviceID int, phonePort uint16) {
 				continue
 			}
 			golog.Debug("new client connected", "module", logModule, "deviceID", deviceID, "phonePort", phonePort, "conn", fmt.Sprintf("%#v", cl))
-			go StartNewProxyConnection(context.TODO(), clientConn, deviceID, phonePort)
+			go startProxyConnection(context.TODO(), clientConn, deviceID, phonePort, resolve)
 		}
 	}
 }
 
+// StartNewProxyConnection connects clientConn to phonePort on the device with
+// the given usbmux device id and pumps bytes in both directions until either
+// side closes.
 func StartNewProxyConnection(ctx context.Context, clientConn io.ReadWriteCloser, deviceID int, phonePort uint16) error {
+	return startProxyConnection(ctx, clientConn, deviceID, phonePort, nil)
+}
+
+func startProxyConnection(ctx context.Context, clientConn io.ReadWriteCloser, deviceID int, phonePort uint16, resolve resolveDeviceID) error {
+	deviceConn, connectedID, err := connectToPhonePort(deviceID, phonePort, resolve)
+	if err != nil {
+		clientConn.Close()
+		return err
+	}
+	golog.Debug("connected to port", "module", logModule, "deviceID", connectedID, "conn", fmt.Sprintf("%#v", clientConn), "phonePort", phonePort)
+
+	proxyConns(ctx, clientConn, deviceConn, connectedID, phonePort)
+	return nil
+}
+
+// connectToPhonePort connects to phonePort using deviceID. When that fails and
+// a resolver is available, the device is looked up again — a replugged device
+// keeps its serial but gets a new usbmux id — and the connect is retried once
+// with the fresh id. It returns the device connection together with the id it
+// was actually established on.
+func connectToPhonePort(deviceID int, phonePort uint16, resolve resolveDeviceID) (ios.DeviceConnectionInterface, int, error) {
+	deviceConn, err := dialPhonePort(deviceID, phonePort)
+	if err == nil {
+		return deviceConn, deviceID, nil
+	}
+	if resolve == nil {
+		return nil, deviceID, err
+	}
+	freshID, resolveErr := resolve()
+	if resolveErr != nil {
+		golog.Debug("could not re-resolve device after failed connect", "module", logModule, "deviceID", deviceID, "phonePort", phonePort, "error", resolveErr)
+		return nil, deviceID, err
+	}
+	if freshID == deviceID {
+		return nil, deviceID, err
+	}
+	golog.Info("usbmux device id changed since the forward started, reconnecting", "module", logModule, "deviceID", freshID, "staleDeviceID", deviceID, "phonePort", phonePort)
+	deviceConn, retryErr := dialPhonePort(freshID, phonePort)
+	if retryErr != nil {
+		return nil, freshID, retryErr
+	}
+	return deviceConn, freshID, nil
+}
+
+// dialPhonePort opens a fresh connection to usbmuxd and asks it to connect to
+// phonePort on the device with the given usbmux id.
+func dialPhonePort(deviceID int, phonePort uint16) (ios.DeviceConnectionInterface, error) {
 	usbmuxConn, err := ios.NewUsbMuxConnectionSimple()
 	if err != nil {
 		golog.Error("could not connect to usbmuxd", "module", logModule, "deviceID", deviceID, "phonePort", phonePort, "error", err)
-		clientConn.Close()
-		return fmt.Errorf("could not connect to usbmuxd: %v", err)
+		return nil, fmt.Errorf("could not connect to usbmuxd: %v", err)
 	}
-	muxError := usbmuxConn.Connect(deviceID, phonePort)
-	if muxError != nil {
-		golog.Debug("could not connect to phone", "module", logModule, "deviceID", deviceID, "conn", fmt.Sprintf("%#v", clientConn), "error", muxError, "phonePort", phonePort)
-		clientConn.Close()
-		return fmt.Errorf("could not connect to port:%d on iOS: %v", phonePort, muxError)
+	if muxError := usbmuxConn.Connect(deviceID, phonePort); muxError != nil {
+		usbmuxConn.Close()
+		golog.Debug("could not connect to phone", "module", logModule, "deviceID", deviceID, "error", muxError, "phonePort", phonePort)
+		return nil, fmt.Errorf("could not connect to port:%d on iOS: %v", phonePort, muxError)
 	}
-	golog.Debug("connected to port", "module", logModule, "deviceID", deviceID, "conn", fmt.Sprintf("%#v", clientConn), "phonePort", phonePort)
-	deviceConn := usbmuxConn.ReleaseDeviceConnection()
-
-	proxyConns(ctx, clientConn, deviceConn, deviceID, phonePort)
-	return nil
+	return usbmuxConn.ReleaseDeviceConnection(), nil
 }
 
 // deviceRWConn is the subset of ios.DeviceConnectionInterface that the proxy

--- a/ios/forward/forward_reconnect_test.go
+++ b/ios/forward/forward_reconnect_test.go
@@ -37,15 +37,13 @@ func startFakeUsbmuxd(t *testing.T, goodDeviceID int) string {
 	if err != nil {
 		t.Fatalf("tempdir: %v", err)
 	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
 	sockPath := filepath.Join(dir, "usbmuxd")
 	l, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatalf("listen on fake usbmuxd socket: %v", err)
 	}
-	t.Cleanup(func() {
-		l.Close()
-		os.RemoveAll(dir)
-	})
+	t.Cleanup(func() { l.Close() })
 	go func() {
 		for {
 			conn, err := l.Accept()

--- a/ios/forward/forward_reconnect_test.go
+++ b/ios/forward/forward_reconnect_test.go
@@ -1,0 +1,198 @@
+package forward
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios"
+	plist "howett.net/plist"
+)
+
+// connectRequest is the subset of the usbmux Connect message the fake usbmuxd
+// needs to decide whether the requested device exists.
+type connectRequest struct {
+	MessageType string
+	DeviceID    uint32
+	PortNumber  uint16
+}
+
+// startFakeUsbmuxd stands up a minimal usbmuxd on a unix socket in a temp dir
+// and returns the socket path. It speaks just enough of the protocol for
+// Connect: a Connect for goodDeviceID answers success and then echoes every
+// byte back (playing the device-side service), a Connect for any other id
+// answers mux error 2 — which is what real usbmuxd does for the stale id of a
+// re-plugged device (issue #378).
+func startFakeUsbmuxd(t *testing.T, goodDeviceID int) string {
+	t.Helper()
+	// os.MkdirTemp instead of t.TempDir: unix socket paths have a ~104 byte
+	// limit and t.TempDir paths can get long on macOS.
+	dir, err := os.MkdirTemp("", "muxsock")
+	if err != nil {
+		t.Fatalf("tempdir: %v", err)
+	}
+	sockPath := filepath.Join(dir, "usbmuxd")
+	l, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen on fake usbmuxd socket: %v", err)
+	}
+	t.Cleanup(func() {
+		l.Close()
+		os.RemoveAll(dir)
+	})
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go serveFakeUsbmuxdConn(conn, goodDeviceID)
+		}
+	}()
+	return sockPath
+}
+
+// serveFakeUsbmuxdConn handles one usbmuxd client connection: read a single
+// Connect request, answer it, and on success switch the socket into echo mode
+// like usbmuxd hands the socket over to the device service.
+func serveFakeUsbmuxdConn(conn net.Conn, goodDeviceID int) {
+	defer conn.Close()
+	var header ios.UsbMuxHeader
+	if err := binary.Read(conn, binary.LittleEndian, &header); err != nil {
+		return
+	}
+	payload := make([]byte, header.Length-16)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		return
+	}
+	var req connectRequest
+	if _, err := plist.Unmarshal(payload, &req); err != nil {
+		return
+	}
+	number := uint32(0)
+	if int(req.DeviceID) != goodDeviceID {
+		number = 2 // usbmuxd result code for "device not found"
+	}
+	respBytes := ios.ToPlistBytes(ios.MuxResponse{MessageType: "Result", Number: number})
+	respHeader := ios.UsbMuxHeader{Length: uint32(16 + len(respBytes)), Version: 1, Request: 8, Tag: header.Tag}
+	if err := binary.Write(conn, binary.LittleEndian, respHeader); err != nil {
+		return
+	}
+	if _, err := conn.Write(respBytes); err != nil {
+		return
+	}
+	if number != 0 {
+		return
+	}
+	_, _ = io.Copy(conn, conn)
+}
+
+// TestStaleDeviceIDIsReResolved reproduces issue #378: the forward captured a
+// usbmux device id, the device was re-plugged and got a new id, so connecting
+// with the stale id fails. The proxy must then re-resolve the device and
+// succeed with the fresh id, keeping the forwarded port usable end-to-end.
+func TestStaleDeviceIDIsReResolved(t *testing.T) {
+	const staleID, freshID = 5, 42
+	sockPath := startFakeUsbmuxd(t, freshID)
+	t.Setenv("USBMUXD_SOCKET_ADDRESS", "unix://"+sockPath)
+
+	var resolveCalls atomic.Int32
+	resolve := func() (int, error) {
+		resolveCalls.Add(1)
+		return freshID, nil
+	}
+
+	clientSide, clientConn := net.Pipe()
+	defer clientSide.Close()
+	done := make(chan error, 1)
+	go func() {
+		done <- startProxyConnection(context.Background(), clientConn, staleID, 8100, resolve)
+	}()
+
+	// The session must be alive end-to-end: bytes written by the client come
+	// back from the fake device echo.
+	go func() { _, _ = clientSide.Write([]byte("ping")) }()
+	buf := make([]byte, 4)
+	_ = clientSide.SetReadDeadline(time.Now().Add(10 * time.Second))
+	if _, err := io.ReadFull(clientSide, buf); err != nil {
+		t.Fatalf("echo read through forward: %v", err)
+	}
+	if string(buf) != "ping" {
+		t.Fatalf("echo through forward: got %q want %q", buf, "ping")
+	}
+	if got := resolveCalls.Load(); got != 1 {
+		t.Fatalf("expected exactly one device re-resolve, got %d", got)
+	}
+
+	clientSide.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("startProxyConnection: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("startProxyConnection did not return after client close")
+	}
+}
+
+// TestCurrentDeviceIDConnectsWithoutResolve verifies the happy path is
+// untouched: when the captured id still works, the resolver is never invoked.
+func TestCurrentDeviceIDConnectsWithoutResolve(t *testing.T) {
+	const deviceID = 7
+	sockPath := startFakeUsbmuxd(t, deviceID)
+	t.Setenv("USBMUXD_SOCKET_ADDRESS", "unix://"+sockPath)
+
+	resolve := func() (int, error) {
+		t.Error("resolve must not be called when the current id connects")
+		return deviceID, nil
+	}
+
+	clientSide, clientConn := net.Pipe()
+	defer clientSide.Close()
+	done := make(chan error, 1)
+	go func() {
+		done <- startProxyConnection(context.Background(), clientConn, deviceID, 8100, resolve)
+	}()
+
+	go func() { _, _ = clientSide.Write([]byte("ok")) }()
+	buf := make([]byte, 2)
+	_ = clientSide.SetReadDeadline(time.Now().Add(10 * time.Second))
+	if _, err := io.ReadFull(clientSide, buf); err != nil {
+		t.Fatalf("echo read through forward: %v", err)
+	}
+
+	clientSide.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("startProxyConnection: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("startProxyConnection did not return after client close")
+	}
+}
+
+// TestStaleDeviceIDWithoutResolverFails pins the library-API behavior of
+// StartNewProxyConnection (no resolver): a stale id fails and the client
+// connection is closed.
+func TestStaleDeviceIDWithoutResolverFails(t *testing.T) {
+	sockPath := startFakeUsbmuxd(t, 42)
+	t.Setenv("USBMUXD_SOCKET_ADDRESS", "unix://"+sockPath)
+
+	clientSide, clientConn := net.Pipe()
+	defer clientSide.Close()
+	if err := StartNewProxyConnection(context.Background(), clientConn, 5, 8100); err == nil {
+		t.Fatal("expected connect with stale device id to fail without a resolver")
+	}
+	// The client conn must have been closed on failure.
+	_ = clientSide.SetReadDeadline(time.Now().Add(10 * time.Second))
+	if _, err := clientSide.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("expected client conn closed (EOF), got %v", err)
+	}
+}

--- a/ios/forward/forward_test.go
+++ b/ios/forward/forward_test.go
@@ -193,7 +193,7 @@ func TestForwardCloseLifecycle(t *testing.T) {
 
 	accepted := make(chan struct{})
 	go func() {
-		connectionAccept(cl, 1, 8100)
+		connectionAccept(cl, 1, 8100, nil)
 		close(accepted)
 	}()
 

--- a/ios/forward/registry.go
+++ b/ios/forward/registry.go
@@ -52,14 +52,38 @@ func (r *Registry) entryPath(e Entry) string {
 
 // Register persists e in the registry dir so other processes can list it.
 func (r *Registry) Register(e Entry) error {
-	if err := os.MkdirAll(r.dir, 0o755); err != nil {
+	if err := os.MkdirAll(r.dir, 0o700); err != nil {
 		return fmt.Errorf("forward: could not create registry dir: %w", err)
 	}
 	data, err := json.Marshal(e)
 	if err != nil {
 		return fmt.Errorf("forward: could not marshal registry entry: %w", err)
 	}
-	if err := os.WriteFile(r.entryPath(e), data, 0o644); err != nil {
+	// Write to a temp file and rename into place so a concurrent List never
+	// observes a half-written (truncated) file — List prunes anything it can't
+	// parse, which would otherwise delete an entry mid-write. The temp file
+	// lacks the .json suffix, so List ignores it while it's being written.
+	tmp, err := os.CreateTemp(r.dir, fmt.Sprintf("%d-%d-*.tmp", e.Pid, e.HostPort))
+	if err != nil {
+		return fmt.Errorf("forward: could not create registry temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("forward: could not chmod registry temp file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("forward: could not write registry entry: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("forward: could not close registry temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, r.entryPath(e)); err != nil {
+		os.Remove(tmpPath)
 		return fmt.Errorf("forward: could not write registry entry: %w", err)
 	}
 	return nil

--- a/ios/forward/registry.go
+++ b/ios/forward/registry.go
@@ -1,0 +1,136 @@
+package forward
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"syscall"
+)
+
+// Entry describes one active port forward. Each running `ios forward` process
+// registers its forwards so `ios forward --list` can enumerate them, similar
+// to `adb forward --list`.
+type Entry struct {
+	Udid       string `json:"udid"`
+	HostPort   uint16 `json:"hostPort"`
+	DevicePort uint16 `json:"devicePort"`
+	Pid        int    `json:"pid"`
+}
+
+// Registry is a file-backed store of active forwards. Every forward is one
+// JSON file named <pid>-<hostPort>.json in dir, owned by the forwarding
+// process. Listing prunes entries whose owning process is gone, so forwards
+// that died without cleaning up (SIGKILL, crash) disappear on the next list
+// instead of lingering forever.
+type Registry struct {
+	dir string
+}
+
+// NewRegistry returns a Registry backed by dir. The dir is created lazily on
+// the first Register.
+func NewRegistry(dir string) *Registry {
+	return &Registry{dir: dir}
+}
+
+// DefaultRegistryDir is the per-user state dir the CLI uses:
+// <user config dir>/go-ios/forwards.
+func DefaultRegistryDir() (string, error) {
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("forward: could not determine user config dir: %w", err)
+	}
+	return filepath.Join(base, "go-ios", "forwards"), nil
+}
+
+func (r *Registry) entryPath(e Entry) string {
+	return filepath.Join(r.dir, fmt.Sprintf("%d-%d.json", e.Pid, e.HostPort))
+}
+
+// Register persists e in the registry dir so other processes can list it.
+func (r *Registry) Register(e Entry) error {
+	if err := os.MkdirAll(r.dir, 0o755); err != nil {
+		return fmt.Errorf("forward: could not create registry dir: %w", err)
+	}
+	data, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("forward: could not marshal registry entry: %w", err)
+	}
+	if err := os.WriteFile(r.entryPath(e), data, 0o644); err != nil {
+		return fmt.Errorf("forward: could not write registry entry: %w", err)
+	}
+	return nil
+}
+
+// Unregister removes the entry for e. A missing entry is not an error, so
+// Unregister and prune-on-list can race harmlessly.
+func (r *Registry) Unregister(e Entry) error {
+	err := os.Remove(r.entryPath(e))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("forward: could not remove registry entry: %w", err)
+	}
+	return nil
+}
+
+// List returns all registered forwards whose owning process is still alive,
+// sorted by udid, host port, pid. Entries whose process is gone (and files
+// that are not valid entries) are pruned from the dir as a side effect.
+func (r *Registry) List() ([]Entry, error) {
+	files, err := os.ReadDir(r.dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return []Entry{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("forward: could not read registry dir: %w", err)
+	}
+	entries := make([]Entry, 0, len(files))
+	for _, f := range files {
+		if f.IsDir() || filepath.Ext(f.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(r.dir, f.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal(data, &e); err != nil || e.Pid <= 0 {
+			os.Remove(path)
+			continue
+		}
+		if !pidAlive(e.Pid) {
+			os.Remove(path)
+			continue
+		}
+		entries = append(entries, e)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Udid != entries[j].Udid {
+			return entries[i].Udid < entries[j].Udid
+		}
+		if entries[i].HostPort != entries[j].HostPort {
+			return entries[i].HostPort < entries[j].HostPort
+		}
+		return entries[i].Pid < entries[j].Pid
+	})
+	return entries, nil
+}
+
+// pidAlive reports whether a process with the given pid exists. On unix,
+// signal 0 probes for existence without affecting the process — EPERM still
+// means it exists. On Windows os.FindProcess itself fails for gone pids and
+// Signal is not usable for probing, so FindProcess succeeding is the answer.
+func pidAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/ios/forward/registry_test.go
+++ b/ios/forward/registry_test.go
@@ -1,0 +1,125 @@
+package forward
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// deadPid returns a pid that is guaranteed not to be running anymore: it
+// spawns the test binary with a pattern matching no tests, waits for it to
+// exit and returns its pid.
+func deadPid(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestNothingMatchesThisName$")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("spawn helper process: %v", err)
+	}
+	return cmd.Process.Pid
+}
+
+func TestRegistryRegisterListUnregister(t *testing.T) {
+	r := NewRegistry(t.TempDir())
+
+	e1 := Entry{Udid: "udid-a", HostPort: 8100, DevicePort: 9100, Pid: os.Getpid()}
+	e2 := Entry{Udid: "udid-b", HostPort: 8200, DevicePort: 9200, Pid: os.Getpid()}
+	// Register in reverse order to verify List sorts by udid/hostPort.
+	if err := r.Register(e2); err != nil {
+		t.Fatalf("register e2: %v", err)
+	}
+	if err := r.Register(e1); err != nil {
+		t.Fatalf("register e1: %v", err)
+	}
+
+	got, err := r.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if want := []Entry{e1, e2}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("list: got %+v want %+v", got, want)
+	}
+
+	if err := r.Unregister(e1); err != nil {
+		t.Fatalf("unregister e1: %v", err)
+	}
+	got, err = r.List()
+	if err != nil {
+		t.Fatalf("list after unregister: %v", err)
+	}
+	if want := []Entry{e2}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("list after unregister: got %+v want %+v", got, want)
+	}
+
+	// Unregistering an already-removed entry must not error (prune races).
+	if err := r.Unregister(e1); err != nil {
+		t.Fatalf("unregister e1 twice: %v", err)
+	}
+}
+
+func TestRegistryPrunesDeadPids(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRegistry(dir)
+
+	alive := Entry{Udid: "udid-alive", HostPort: 8100, DevicePort: 9100, Pid: os.Getpid()}
+	dead := Entry{Udid: "udid-dead", HostPort: 8200, DevicePort: 9200, Pid: deadPid(t)}
+	if err := r.Register(alive); err != nil {
+		t.Fatalf("register alive: %v", err)
+	}
+	if err := r.Register(dead); err != nil {
+		t.Fatalf("register dead: %v", err)
+	}
+
+	got, err := r.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if want := []Entry{alive}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("list: got %+v want %+v", got, want)
+	}
+
+	// The dead entry's file must be pruned from the state dir, not just hidden.
+	if _, err := os.Stat(r.entryPath(dead)); !os.IsNotExist(err) {
+		t.Fatalf("dead entry file not pruned, stat err: %v", err)
+	}
+	if _, err := os.Stat(r.entryPath(alive)); err != nil {
+		t.Fatalf("alive entry file must survive prune: %v", err)
+	}
+}
+
+func TestRegistryListMissingDirAndGarbage(t *testing.T) {
+	dir := t.TempDir()
+	// Listing a registry whose dir was never created returns empty, no error.
+	r := NewRegistry(filepath.Join(dir, "never-created"))
+	got, err := r.List()
+	if err != nil {
+		t.Fatalf("list missing dir: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("list missing dir: got %+v want empty", got)
+	}
+
+	// Non-entry files are ignored, invalid JSON entries are pruned.
+	r = NewRegistry(dir)
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	garbage := filepath.Join(dir, "1234-1.json")
+	if err := os.WriteFile(garbage, []byte("{invalid"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err = r.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("list: got %+v want empty", got)
+	}
+	if _, err := os.Stat(garbage); !os.IsNotExist(err) {
+		t.Fatalf("garbage entry not pruned, stat err: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "notes.txt")); err != nil {
+		t.Fatalf("non-json file must be left alone: %v", err)
+	}
+}

--- a/ios/forward/registry_test.go
+++ b/ios/forward/registry_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
+	"sync"
 	"testing"
 )
 
@@ -121,5 +123,96 @@ func TestRegistryListMissingDirAndGarbage(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "notes.txt")); err != nil {
 		t.Fatalf("non-json file must be left alone: %v", err)
+	}
+}
+
+// TestRegistryPrivatePerms verifies the state dir and entry files are created
+// with owner-only permissions so a device udid, forwarded ports and pid are not
+// exposed to other local users. Permission bits are a POSIX concept.
+func TestRegistryPrivatePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits not meaningful on windows")
+	}
+	dir := t.TempDir()
+	inner := filepath.Join(dir, "reg")
+	r := NewRegistry(inner)
+	e := Entry{Udid: "udid-a", HostPort: 8100, DevicePort: 9100, Pid: os.Getpid()}
+	if err := r.Register(e); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	di, err := os.Stat(inner)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := di.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("registry dir perm: got %o want 700", perm)
+	}
+	fi, err := os.Stat(r.entryPath(e))
+	if err != nil {
+		t.Fatalf("stat entry: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("registry entry perm: got %o want 600", perm)
+	}
+}
+
+// TestRegistryConcurrentRegisterList hammers Register and List against the same
+// dir concurrently. Because Register publishes entries atomically (temp file +
+// rename), List never sees a truncated file, so it must never prune (delete) an
+// entry whose process is alive. After the storm every registered entry must
+// still be present.
+func TestRegistryConcurrentRegisterList(t *testing.T) {
+	r := NewRegistry(t.TempDir())
+	const n = 40
+	entries := make([]Entry, n)
+	for i := range entries {
+		entries[i] = Entry{Udid: "udid", HostPort: uint16(9000 + i), DevicePort: 1, Pid: os.Getpid()}
+	}
+
+	var wg sync.WaitGroup
+	// One writer per entry, each re-registering repeatedly (which truncates and
+	// rewrites its own file) to widen the race window with the listers.
+	for _, e := range entries {
+		wg.Add(1)
+		go func(e Entry) {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				if err := r.Register(e); err != nil {
+					t.Errorf("register: %v", err)
+					return
+				}
+			}
+		}(e)
+	}
+	// Concurrent listers that also prune as a side effect.
+	stop := make(chan struct{})
+	var listWG sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		listWG.Add(1)
+		go func() {
+			defer listWG.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if _, err := r.List(); err != nil {
+						t.Errorf("list: %v", err)
+						return
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	listWG.Wait()
+
+	got, err := r.List()
+	if err != nil {
+		t.Fatalf("final list: %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("final list: got %d entries want %d — a live entry was pruned during a concurrent write", len(got), n)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ Usage:
   ios file ls [--app=<bundleID> | --app-group=<groupID> | --crash | --temp] [--path=<path>] [options]
   ios file pull [--app=<bundleID> | --app-group=<groupID> | --crash | --temp] --remote=<remotePath> --local=<localPath> [options]
   ios file push [--app=<bundleID> | --app-group=<groupID> | --crash | --temp] --local=<localPath> --remote=<remotePath> [options]
-  ios forward [options] [<hostPort> <targetPort>] [--port=<mapping>]...
+  ios forward [options] [--list] [<hostPort> <targetPort>] [--port=<mapping>]...
   ios fsync [--app=bundleId] [options] (pull | push) --srcPath=<srcPath> --dstPath=<dstPath>
   ios fsync [--app=bundleId] [options] (rm [--r] | tree | mkdir) --path=<targetPath>
   ios httpproxy <host> <port> [<user>] [<pass>] --p12file=<orgid> --password=<p12password> [options]
@@ -299,9 +299,11 @@ The commands work as following:
                                                                   Upload file using RemoteXPC (iOS 17+).
                                                                   Requires tunnel. Preserves source file permissions.
 
-    ios forward [options] [<hostPort> <targetPort>] [--port=<mapping>]...
+    ios forward [options] [--list] [<hostPort> <targetPort>] [--port=<mapping>]...
                                                                   Forward TCP connections to device.
                                                                   Use --port for multiple ports: --port=8100:8100 --port=9191:9191
+                                                                  Use --list to print the active forwards started on this host
+                                                                  (like adb forward --list). Needs no device.
 
     ios fsync [--app=bundleId] [options] (pull | push) --srcPath=<srcPath> --dstPath=<dstPath>
                                                                   Pull or Push file from srcPath to dstPath.
@@ -1174,9 +1176,55 @@ func startForwarding(device ios.DeviceEntry, hostPort uint16, targetPort uint16)
 	cl, err := forward.Forward(device, hostPort, targetPort)
 	exitIfError("failed to forward port", err)
 	defer stopForwarding(cl)
+	unregister := registerForward(device, hostPort, targetPort)
+	defer unregister()
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 	<-c
+}
+
+// registerForward records this process' forward in the per-user registry so
+// `ios forward --list` can enumerate it, and returns the matching unregister
+// func. Registration is best-effort: a failure must never break the forward
+// itself, and entries of processes that died without unregistering are pruned
+// when the registry is listed.
+func registerForward(device ios.DeviceEntry, hostPort uint16, targetPort uint16) func() {
+	dir, err := forward.DefaultRegistryDir()
+	if err != nil {
+		slog.Warn("could not determine forward registry dir, forward will be missing from 'ios forward --list'", "error", err)
+		return func() {}
+	}
+	registry := forward.NewRegistry(dir)
+	entry := forward.Entry{
+		Udid:       device.Properties.SerialNumber,
+		HostPort:   hostPort,
+		DevicePort: targetPort,
+		Pid:        os.Getpid(),
+	}
+	if err := registry.Register(entry); err != nil {
+		slog.Warn("could not register forward, it will be missing from 'ios forward --list'", "error", err)
+		return func() {}
+	}
+	return func() {
+		if err := registry.Unregister(entry); err != nil {
+			slog.Warn("could not unregister forward", "error", err)
+		}
+	}
+}
+
+func runForwardListCommand(ctx commandContext) {
+	dir, err := forward.DefaultRegistryDir()
+	exitIfError("forward list: could not determine registry dir", err)
+	entries, err := forward.NewRegistry(dir).List()
+	exitIfError("forward list: could not read forward registry", err)
+	if JSONdisabled {
+		// Same shape as `adb forward --list`: <serial> tcp:<local> tcp:<remote>
+		for _, e := range entries {
+			fmt.Printf("%s tcp:%d tcp:%d pid:%d\n", e.Udid, e.HostPort, e.DevicePort, e.Pid)
+		}
+		return
+	}
+	fmt.Println(convertToJSONString(map[string]interface{}{"forwards": entries, "count": len(entries)}))
 }
 
 func stopForwarding(cl *forward.ConnListener) {
@@ -1188,10 +1236,14 @@ func stopForwarding(cl *forward.ConnListener) {
 
 func startMultiForwarding(device ios.DeviceEntry, mappings []string) {
 	var listeners []*forward.ConnListener
+	var unregisters []func()
 
 	closeAllListeners := func() {
 		for _, l := range listeners {
 			l.Close()
+		}
+		for _, unregister := range unregisters {
+			unregister()
 		}
 	}
 
@@ -1218,6 +1270,7 @@ func startMultiForwarding(device ios.DeviceEntry, mappings []string) {
 			exitIfError(fmt.Sprintf("failed to forward %d:%d", hostPort, targetPort), err)
 		}
 		listeners = append(listeners, cl)
+		unregisters = append(unregisters, registerForward(device, uint16(hostPort), uint16(targetPort)))
 		slog.Info(fmt.Sprintf("Forwarding %d -> %d", hostPort, targetPort))
 	}
 


### PR DESCRIPTION
> **Based on #804** — stacked on `fix/issue-378-forward-reconnect` (same files); the diff includes that PR's commit until it merges.

## Problem

There is no way to see which ports are currently forwarded on a host, like `adb forward --list` provides for Android (device serial + local/remote port of every active forward). (#681)

## Design

A **file-backed per-user registry** of active forwards:

- Every `ios forward` process registers each forward as one JSON file `<pid>-<hostPort>.json` (fields: `udid`, `hostPort`, `devicePort`, `pid`) under `<user config dir>/go-ios/forwards` (`os.UserConfigDir()`), and unregisters on clean shutdown.
- `ios forward --list` reads that dir and prints the entries. Entries whose owning pid is no longer alive are pruned on read, so forwards that died without cleanup (SIGKILL, crash) disappear on the next list instead of lingering.
- Listing needs no device, so it dispatches as a global command before device resolution — it works on a host with nothing attached.

## Implementation

- `ios/forward/registry.go`: `Entry`, `Registry` (`Register`/`Unregister`/`List` with prune), `DefaultRegistryDir`, portable pid-liveness probe (signal 0 on unix incl. EPERM-means-alive; `os.FindProcess` on Windows).
- `main.go`: `startForwarding`/`startMultiForwarding` register each forward (best-effort — a registry failure never breaks the forward) and unregister on shutdown; `runForwardListCommand` prints JSON by default or adb-style `<udid> tcp:<hostPort> tcp:<devicePort> pid:<pid>` lines with `--nojson`.
- `cmd_global.go`: global `forward --list` command; docopt usage gains `[--list]` on the forward pattern.

## Options considered

1. **File-backed per-user state dir (chosen).** No daemon required, works without the tunnel agent, survives agent restarts, and prune-on-read self-heals after unclean exits. Known limitation: pid reuse could briefly keep a stale entry alive, and the registry only sees forwards started via the `ios forward` CLI on this user account.
2. **Agent HTTP API.** Register forwards with the go-ios tunnel agent and query it over HTTP. Gives live truth and cross-process eviction, but `ios forward` must then depend on a running agent (which iOS <17 setups don't need at all), needs new API surface/ports, and still misses forwards started when the agent is down.
3. **Port scanning / OS socket table.** No state to keep, but cannot attribute a listening port to a device udid or device port, so it can't answer the actual question.

## Test plan

Device-free unit tests in `ios/forward/registry_test.go` against a temp state dir:

- `TestRegistryRegisterListUnregister` — register/list (sorted), unregister, idempotent double-unregister.
- `TestRegistryPrunesDeadPids` — an entry owned by a genuinely dead pid (spawned helper process that exited) is dropped from the listing **and** its file is pruned; the live entry survives.
- `TestRegistryListMissingDirAndGarbage` — never-created dir lists empty without error; invalid JSON entries are pruned; non-registry files are left alone.

Manual smoke test: `ios forward --list` (JSON and `--nojson`) with a live-pid and a dead-pid entry in the real state dir — live one listed in both formats, dead one pruned. `go build ./...`, `go test -race ./...` and `gofmt -l` are clean.

Fixes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk