### PR TITLE
fix(npm): resolve global bin dir under pnpm and install arm64 build on Apple Silicon

### DIFF
--- a/npm_publish/postinstall.js
+++ b/npm_publish/postinstall.js
@@ -24,37 +24,55 @@ var PLATFORM_MAPPING = {
     "freebsd": "freebsd"
 };
 
+// On Windows npm's global prefix IS the bin dir (executables/shims live
+// directly in %AppData%\npm, which is what's on PATH). On Linux/macOS
+// executables go in <prefix>/bin. Appending "bin" on Windows puts the
+// binary in a folder that isn't on PATH.
+function binDirFromNpmPrefix(prefix) {
+    return process.platform === "win32" ? prefix : path.join(prefix, "bin");
+}
+
 async function getInstallationPath() {
+    var env = process.env;
 
-    // `npm bin` will output the path where binary files should be installed
-
-    const value = null //await execShellCommand("npm bin -g");
-
-
-    var dir = null;
-    if (!value || value.length === 0) {
-
-        // We couldn't infer path from `npm bin`. Let's try to get it from
-        // Environment variables set by NPM when it runs.
-        // npm_config_prefix points to NPM's installation directory where `bin` folder is available
-        // Ex: /Users/foo/.nvm/versions/node/v4.3.0
-        var env = process.env;
-        if (env && env.npm_config_prefix) {
-            // On Windows npm's global prefix IS the bin dir (executables/shims
-            // live directly in %AppData%\npm, which is what's on PATH). On
-            // Linux/macOS executables go in <prefix>/bin. Appending "bin" on
-            // Windows puts the binary in a folder that isn't on PATH.
-            dir = process.platform === "win32"
-                ? env.npm_config_prefix
-                : path.join(env.npm_config_prefix, "bin");
-        }
-    } else {
-        dir = value.trim();
+    // npm sets npm_config_prefix (newer versions also npm_config_global_prefix)
+    // to its installation directory, e.g. /Users/foo/.nvm/versions/node/v4.3.0
+    var npmPrefix = env.npm_config_prefix || env.npm_config_global_prefix;
+    if (npmPrefix) {
+        var dir = binDirFromNpmPrefix(npmPrefix);
+        await mkdirp(dir);
+        return dir;
     }
-    //throw (dir)
-    ///Users/danielpaulus/.nvm/versions/node/v19.7.0/lib/node_modules/go-ios/node_modules/.bin
-    await mkdirp(dir);
-    return dir;
+
+    // pnpm does not set npm_config_prefix (issue #659). PNPM_HOME is the
+    // directory pnpm places global binaries in; it is on PATH itself, so do
+    // not append a "bin" subdir.
+    if (env.PNPM_HOME) {
+        await mkdirp(env.PNPM_HOME);
+        return env.PNPM_HOME;
+    }
+
+    // Last resort: ask npm for its global prefix. Unlike execShellCommand
+    // (which resolves stderr on failure), resolve null on any error so a shell
+    // error message is never mistaken for a path.
+    var output = await new Promise((resolve) => {
+        require('child_process').exec("npm prefix -g", (error, stdout) => {
+            resolve(error ? null : stdout);
+        });
+    });
+    var prefix = output && output.trim();
+    if (prefix && path.isAbsolute(prefix)) {
+        var fallbackDir = binDirFromNpmPrefix(prefix);
+        await mkdirp(fallbackDir);
+        return fallbackDir;
+    }
+
+    throw new Error(
+        "Could not determine a global bin directory to install the go-ios binary into. " +
+        "None of npm_config_prefix, npm_config_global_prefix or PNPM_HOME are set, " +
+        "and 'npm prefix -g' did not return a usable path. " +
+        "Set a global prefix (e.g. 'npm config set prefix <dir>') or, for pnpm, " +
+        "run 'pnpm setup' so PNPM_HOME is set, then reinstall go-ios.");
 }
 
 async function verifyAndPlaceBinary(binName, binPath, callback) {
@@ -93,11 +111,9 @@ function validateConfiguration(packageJson) {
 }
 
 function parsePackageJson() {
-    if (process.arch !== "arm64" && process.platform !== "darwin") {
-        if (!(process.arch in ARCH_MAPPING)) {
-            console.error("Installation is not supported for this architecture: " + process.arch);
-            return;
-        }
+    if (!(process.arch in ARCH_MAPPING)) {
+        console.error("Installation is not supported for this architecture: " + process.arch);
+        return;
     }
 
     if (!(process.platform in PLATFORM_MAPPING)) {
@@ -153,12 +169,8 @@ async function install(callback) {
     mkdirp.sync(opts.binPath);
     console.info(`Copying the relevant binary for your platform ${process.platform}`);
     let src = `./dist/go-ios-${PLATFORM_MAPPING[process.platform]}-${ARCH_MAPPING[process.arch]}_${PLATFORM_MAPPING[process.platform]}_${ARCH_MAPPING[process.arch]}/${opts.binName}`;
-    if (process.arch === "arm64" && process.platform === "darwin") {
-        console.log("using amd64 build on M1 mac")
-        src = `./dist/go-ios-${process.platform}-amd64_${process.platform}_amd64/${opts.binName}`;
-    }
 
-    if (process.arch === "ia32" && process.platform === "w32") {
+    if (process.arch === "ia32" && process.platform === "win32") {
         src = `./dist/go-ios-${PLATFORM_MAPPING[process.platform]}-amd64_${PLATFORM_MAPPING[process.platform]}_amd64/${opts.binName}`;
     }
 


### PR DESCRIPTION
## Problem

`pnpm i -g go-ios` fails on macOS (reported on an M4 MacBook Air) with:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received null
    at mkdirp ...
    at getInstallationPath (postinstall.js:50)
```

The log also claimed `using amd64 build on M1 mac` even though the machine is arm64.

## Root cause

- `getInstallationPath()` in `npm_publish/postinstall.js` only knew one way to find the global bin dir: the `npm_config_prefix` env var. npm always sets it, pnpm does not — so under pnpm `dir` stayed `null` and `mkdirp(null)` threw an opaque `TypeError`.
- The darwin/arm64 branch deliberately picked the `go-ios-darwin-amd64_darwin_amd64` dist dir. That predates the package shipping a `go-ios-darwin-arm64_darwin_arm64` dist dir (both contain the lipo universal mac binary today), so it "worked" but installed via the amd64 path with a misleading log line.

## Fix

`getInstallationPath()` now resolves the install dir with fallbacks, and fails loudly and helpfully instead of throwing a `TypeError`:

1. `npm_config_prefix` (unchanged behavior for npm installs)
2. `npm_config_global_prefix` (set by newer npm versions)
3. `PNPM_HOME` — pnpm's global bin dir; used **as-is** (it is on `PATH` itself, no `bin/` subdir)
4. `npm prefix -g` output, accepted only if the command succeeds and returns an absolute path (a failure like `sh: npm: command not found` starts with `/` and must not be mistaken for a path)
5. otherwise a clear, actionable error: set an npm prefix or run `pnpm setup`, then reinstall

The Windows rule is preserved for every npm-prefix-derived path (steps 1, 2, 4): on Windows the prefix itself is the bin dir, no `bin/` subdir appended.

Arch handling:

- Removed the darwin/arm64 → amd64 override; Apple Silicon Macs now get the binary from `go-ios-darwin-arm64_darwin_arm64` via the normal platform/arch mapping (and no more "using amd64 build on M1 mac" log).
- Fixed the dead `process.platform === "w32"` typo → `"win32"` in the ia32 fallback.
- Architecture validation now runs on every platform (the old condition skipped it whenever `platform === "darwin"` or `arch === "arm64"`).

## Options considered

1. **Fallback chain in `getInstallationPath()` (chosen):** npm env vars → `PNPM_HOME` → `npm prefix -g` → clear error. Keeps npm behavior byte-identical (npm always sets `npm_config_prefix`, so step 1 wins there), fixes pnpm without special-casing the package manager, and degrades to an actionable message instead of a crash.
2. **Detect pnpm via `npm_config_user_agent` and branch per package manager:** more moving parts and still needs a fallback for other managers (yarn, bun); the env-var chain covers the same cases with less code.
3. **Drop the postinstall copy entirely and use the standard `package.json` `bin` field:** cleanest long-term, but a much bigger packaging change (per-platform shims or optionalDependencies split) — out of scope for a bug fix on the release path.

For darwin/arm64: kept using the shipped `darwin-arm64` dist dir rather than continuing to redirect to amd64 — the dist dir exists in the published package (release workflow copies the universal binary into both), so the normal mapping is correct and the special case was only misleading.

## Test plan

- `node --check npm_publish/postinstall.js` passes; `go build ./... && go test ./...` untouched and green.
- Local simulation of the postinstall against a fake `dist/` tree on darwin/arm64:
  - pnpm scenario (`npm_config_prefix` unset, `PNPM_HOME` set): binary lands directly in `$PNPM_HOME` (no `bin/` subdir), and the **darwin-arm64** dist binary is selected.
  - npm scenario (`npm_config_prefix` set): binary lands in `<prefix>/bin` as before.
  - `npm_config_global_prefix`-only and `npm prefix -g`-only scenarios: both resolve correctly.
  - Nothing resolvable (all env vars unset, `npm` not on `PATH`): clear error message, exit code 1 (previously an opaque `TypeError`).
- **Canary run** (publishes throwaway `go-ios-canary` and verifies install + run on Windows/Linux/macOS): https://github.com/danielpaulus/go-ios/actions/runs/31018210948 — **success** (published `go-ios-canary@0.0.5` with this postinstall.js; install verified on macOS, Linux and Windows). Note: the first attempt of `verify_install (windows-latest)` hit npm registry propagation lag (`ETARGET` for the version macOS/Linux had already installed from the same run); a rerun of that job passed with no code change.

## Related

Does **not** resolve #227 — that failure is a missing 32-bit `linux/arm` binary in `dist/` (only arm64/amd64 are shipped), unrelated to the pnpm prefix crash fixed here.

Fixes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk
