### PR TITLE
Implement remoteFetchSymbols service client and ios fetchsymbols command (#700)

### DIFF
--- a/cli_device_resolution.go
+++ b/cli_device_resolution.go
@@ -77,7 +77,7 @@ func resolveDevice(arguments docopt.Opts, tunnelInfo tunnelInfoConfig) ios.Devic
 }
 
 func needsAutomaticTunnelInfo(args docopt.Opts) bool {
-	if boolArg(args, "rsd") || boolArg(args, "file") || boolArg(args, "webinspector") {
+	if boolArg(args, "rsd") || boolArg(args, "file") || boolArg(args, "fetchsymbols") || boolArg(args, "webinspector") {
 		return true
 	}
 	if boolArg(args, "info") && boolArg(args, "display") {

--- a/cmd_device_files.go
+++ b/cmd_device_files.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/afc"
+	"github.com/danielpaulus/go-ios/ios/fetchsymbols"
 	"github.com/danielpaulus/go-ios/ios/fileservice"
 	"github.com/danielpaulus/go-ios/ios/house_arrest"
 )
@@ -173,6 +174,78 @@ func runFileCommand(ctx commandContext) {
 		} else {
 			slog.Info(fmt.Sprintf("Uploaded %d bytes to %s", fileSize, remotePath))
 		}
+	}
+}
+
+func runFetchSymbolsCommand(ctx commandContext) {
+	if !ctx.Device.SupportsRsd() {
+		exitIfError("fetchsymbols requires iOS 17+ with tunnel", fmt.Errorf("tunnel not running. Start with: ios tunnel start"))
+	}
+
+	baseDir, _ := ctx.Args.String("--path")
+	if baseDir == "" {
+		baseDir = "./ios-symbols"
+	}
+
+	// Cache per iOS version + build so the multi-GB download is reused across devices on
+	// the same version.
+	versionSubdir := "unknown-version"
+	if values, err := ios.GetValues(ctx.Device); err == nil {
+		versionSubdir = values.Value.ProductVersion + "_" + values.Value.BuildVersion
+	} else {
+		slog.Warn("fetchsymbols: could not read iOS version from lockdown, caching without version index", "error", err)
+	}
+	cacheDir := filepath.Join(baseDir, versionSubdir)
+
+	conn, err := fetchsymbols.New(ctx.Device)
+	exitIfError("fetchsymbols: failed to connect to service", err)
+	defer conn.Close()
+
+	files, err := conn.ListFiles()
+	exitIfError("fetchsymbols: failed to list shared cache files", err)
+
+	var totalBytes uint64
+	for _, f := range files {
+		totalBytes += f.Size
+	}
+	slog.Info("fetchsymbols downloads the dyld shared cache from the device. This is a large download, make sure you have enough disk space and time.",
+		"files", len(files), "totalMB", totalBytes/(1024*1024), "cacheDir", cacheDir)
+
+	downloaded := 0
+	skipped := 0
+	for i, f := range files {
+		dest, err := fetchsymbols.CachePath(cacheDir, f.FilePath)
+		exitIfError("fetchsymbols: invalid file path received from device", err)
+
+		if fetchsymbols.IsCached(dest, f.Size) {
+			slog.Info("already cached, skipping", "file", f.FilePath, "dest", dest)
+			skipped++
+			continue
+		}
+
+		var lastLogged uint64
+		progress := func(written uint64) {
+			if written-lastLogged >= 512*1024*1024 || written == f.Size {
+				lastLogged = written
+				slog.Info("downloading", "file", f.FilePath, "writtenMB", written/(1024*1024), "totalMB", f.Size/(1024*1024))
+			}
+		}
+		err = conn.DownloadToCache(dest, i, f, progress)
+		exitIfError("fetchsymbols: download failed", err)
+		downloaded++
+	}
+
+	result := map[string]interface{}{
+		"cacheDir":   cacheDir,
+		"files":      len(files),
+		"downloaded": downloaded,
+		"skipped":    skipped,
+		"totalBytes": totalBytes,
+	}
+	if !JSONdisabled {
+		fmt.Println(convertToJSONString(result))
+	} else {
+		slog.Info("fetchsymbols done", "cacheDir", cacheDir, "files", len(files), "downloaded", downloaded, "skipped", skipped)
 	}
 }
 

--- a/cmd_device_registry.go
+++ b/cmd_device_registry.go
@@ -83,6 +83,7 @@ var deviceCommands = []command{
 	commandByBool("resetax", runResetAXCommand),
 	commandByBool("debug", runDebugCommand),
 	commandByBool("file", runFileCommand),
+	commandByBool("fetchsymbols", runFetchSymbolsCommand),
 	commandByBool("pasteboard", runPasteboardCommand),
 	commandByBool("fsync", runFsyncCommand),
 	commandByBool("devmode", runDevModeCommand),

--- a/command_registry_test.go
+++ b/command_registry_test.go
@@ -69,6 +69,7 @@ func TestNeedsAutomaticTunnelInfo(t *testing.T) {
 		{name: "assistivetouch stays tunnel-free", args: docopt.Opts{"assistivetouch": true}, want: false},
 		{name: "timeformat stays tunnel-free", args: docopt.Opts{"timeformat": true}, want: false},
 		{name: "file needs tunnel", args: docopt.Opts{"file": true}, want: true},
+		{name: "fetchsymbols needs tunnel", args: docopt.Opts{"fetchsymbols": true}, want: true},
 		{name: "rsd needs tunnel", args: docopt.Opts{"rsd": true}, want: true},
 		{name: "display info needs tunnel", args: docopt.Opts{"info": true, "display": true}, want: true},
 		{name: "plain info stays tunnel-free", args: docopt.Opts{"info": true}, want: false},

--- a/internal/clihelp/help.yaml
+++ b/internal/clihelp/help.yaml
@@ -90,6 +90,9 @@ commands:
   - path: erase
     usage: ios erase [--force] [options]
     summary: Erase device.
+  - path: fetchsymbols
+    usage: ios fetchsymbols [--path=<dir>] [options]
+    summary: Download the dyld shared cache for local symbolication (multi-GB, iOS 17+).
   - path: file ls
     usage: ios file ls [--app=<bundleID> | --app-group=<groupID> | --crash | --temp] [--path=<path>] [options]
     summary: List files in app/group/temp/crash container.

--- a/ios/fetchsymbols/cache.go
+++ b/ios/fetchsymbols/cache.go
@@ -1,0 +1,86 @@
+package fetchsymbols
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// CachePath returns the local cache location for a device file, rooted at baseDir and
+// preserving the on-device directory layout. Device-controlled paths are normalized so
+// they cannot escape baseDir.
+func CachePath(baseDir, devicePath string) (string, error) {
+	cleaned := path.Clean("/" + strings.ReplaceAll(devicePath, `\`, "/"))
+	rel := strings.TrimPrefix(cleaned, "/")
+	if rel == "" || rel == "." {
+		return "", fmt.Errorf("CachePath: invalid device path %q", devicePath)
+	}
+	return filepath.Join(baseDir, filepath.FromSlash(rel)), nil
+}
+
+// IsCached reports whether dest already holds a fully downloaded file of the expected size.
+func IsCached(dest string, size uint64) bool {
+	stat, err := os.Stat(dest)
+	return err == nil && stat.Mode().IsRegular() && stat.Size() >= 0 && uint64(stat.Size()) == size
+}
+
+// DownloadToCache downloads the file at fileIndex (its position in the ListFiles result)
+// to dest, creating parent directories as needed. The download goes to a temporary
+// '.download' file first and is renamed only after it completed, so an interrupted
+// download never leaves a truncated file that IsCached would treat as complete.
+// progress, if non-nil, is called with the running byte count while downloading.
+func (c *Connection) DownloadToCache(dest string, fileIndex int, info FileInfo, progress func(written uint64)) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("DownloadToCache: failed to create cache dir: %w", err)
+	}
+	err := writeFileAtomically(dest, func(w io.Writer) error {
+		if progress != nil {
+			w = &progressWriter{w: w, progress: progress}
+		}
+		return c.DownloadFile(w, fileIndex, info)
+	})
+	if err != nil {
+		return fmt.Errorf("DownloadToCache: %w", err)
+	}
+	return nil
+}
+
+// writeFileAtomically writes the output of write to a temporary file next to dest and
+// renames it to dest only if write succeeded.
+func writeFileAtomically(dest string, write func(w io.Writer) error) error {
+	tmp := dest + ".download"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("writeFileAtomically: failed to create temp file: %w", err)
+	}
+	if err := write(f); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("writeFileAtomically: failed to close temp file: %w", err)
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("writeFileAtomically: failed to move temp file in place: %w", err)
+	}
+	return nil
+}
+
+type progressWriter struct {
+	w        io.Writer
+	written  uint64
+	progress func(written uint64)
+}
+
+func (p *progressWriter) Write(b []byte) (int, error) {
+	n, err := p.w.Write(b)
+	p.written += uint64(n)
+	p.progress(p.written)
+	return n, err
+}

--- a/ios/fetchsymbols/fetchsymbols.go
+++ b/ios/fetchsymbols/fetchsymbols.go
@@ -1,0 +1,194 @@
+// Package fetchsymbols downloads the dyld shared cache from iOS 17+ devices using the
+// com.apple.dt.remoteFetchSymbols RemoteXPC service. This is what Xcode does when it shows
+// "Preparing debugger support" and enables local symbolication without a device connection.
+// The protocol mirrors pymobiledevice3's RemoteFetchSymbolsService: request the list of
+// shared cache files with a DSCFilePaths message, receive one metadata message per file and
+// stream each file's raw content over a dedicated HTTP2 side stream.
+package fetchsymbols
+
+import (
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/golog"
+	"github.com/danielpaulus/go-ios/ios/http"
+	"github.com/danielpaulus/go-ios/ios/xpc"
+	"github.com/google/uuid"
+)
+
+const logModule = "go-ios/fetchsymbols"
+
+const serviceName = "com.apple.dt.remoteFetchSymbols"
+
+// maxFileCount bounds the device-declared number of shared cache files so a malformed
+// response cannot drive an unbounded receive loop. Real devices report a handful of files.
+const maxFileCount = 256
+
+// FileInfo describes one dyld shared cache file offered by the device.
+type FileInfo struct {
+	// FilePath is the absolute on-device path of the file.
+	FilePath string
+	// Size is the expected raw byte length of the file.
+	Size uint64
+}
+
+// Connection is a client for the remoteFetchSymbols service. It is not safe for
+// concurrent use.
+type Connection struct {
+	h    *http.HttpConnection
+	xpc  *xpc.Connection
+	udid string
+}
+
+// New connects to the remoteFetchSymbols service on an iOS 17+ device. It requires a
+// running tunnel.
+func New(device ios.DeviceEntry) (*Connection, error) {
+	if !device.SupportsRsd() {
+		return nil, fmt.Errorf("New: cannot connect to %s, missing tunnel address and RSD port. To start the tunnel, run `ios tunnel start`", serviceName)
+	}
+	port, err := ios.RsdPortForService(device.Rsd, serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("New: %w", err)
+	}
+	conn, err := ios.ConnectTUNDevice(device.Address, port, device)
+	if err != nil {
+		return nil, fmt.Errorf("New: failed to dial: %w", err)
+	}
+	h, err := http.NewHttpConnection(conn)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("New: failed to connect to http2: %w", err)
+	}
+	xpcConn, err := ios.CreateXpcConnection(h)
+	if err != nil {
+		h.Close()
+		return nil, fmt.Errorf("New: failed to create xpc connection: %w", err)
+	}
+	return &Connection{h: h, xpc: xpcConn, udid: device.Properties.SerialNumber}, nil
+}
+
+// Close closes the connection to the service.
+func (c *Connection) Close() error {
+	return c.xpc.Close()
+}
+
+// ListFiles asks the device which dyld shared cache files it offers for download. The
+// returned order matters: the index of a file is needed to download it.
+func (c *Connection) ListFiles() ([]FileInfo, error) {
+	req := map[string]interface{}{
+		"XPCDictionary_sideChannel": uuid.New(),
+		"DSCFilePaths":              []interface{}{},
+	}
+	if err := c.xpc.Send(req, xpc.HeartbeatRequestFlag); err != nil {
+		return nil, fmt.Errorf("ListFiles: failed to send request: %w", err)
+	}
+	resp, err := c.xpc.ReceiveOnServerClientStream()
+	if err != nil {
+		return nil, fmt.Errorf("ListFiles: failed to receive file count: %w", err)
+	}
+	count, err := parseFileCount(resp)
+	if err != nil {
+		return nil, fmt.Errorf("ListFiles: %w", err)
+	}
+	files := make([]FileInfo, 0, count)
+	for i := 0; i < count; i++ {
+		resp, err := c.xpc.ReceiveOnServerClientStream()
+		if err != nil {
+			return nil, fmt.Errorf("ListFiles: failed to receive metadata of file %d: %w", i, err)
+		}
+		info, err := parseFileInfo(resp)
+		if err != nil {
+			return nil, fmt.Errorf("ListFiles: file %d: %w", i, err)
+		}
+		files = append(files, info)
+	}
+	golog.Info("listed dyld shared cache files", "module", logModule, "udid", c.udid, "count", len(files))
+	return files, nil
+}
+
+// DownloadFile streams the raw content of the file at fileIndex (its position in the
+// ListFiles result) into w. It opens the HTTP2 side stream the device expects for the
+// transfer and copies exactly info.Size bytes.
+func (c *Connection) DownloadFile(w io.Writer, fileIndex int, info FileInfo) error {
+	streamId := fileStreamId(fileIndex)
+	golog.Info("downloading dyld shared cache file", "module", logModule, "udid", c.udid,
+		"path", info.FilePath, "bytes", info.Size, "streamId", streamId)
+	stream, err := http.NewFileStreamReadWriter(c.h, streamId)
+	if err != nil {
+		return fmt.Errorf("DownloadFile: %w", err)
+	}
+	err = xpc.EncodeMessage(stream, xpc.Message{
+		Flags: xpc.FileTransferStreamResponseFlag | xpc.AlwaysSetFlag,
+		Body:  nil,
+		Id:    0,
+	})
+	if err != nil {
+		return fmt.Errorf("DownloadFile: failed to open file stream %d: %w", streamId, err)
+	}
+	if err := copyFileChunks(w, stream, info.Size); err != nil {
+		return fmt.Errorf("DownloadFile: %s: %w", info.FilePath, err)
+	}
+	return nil
+}
+
+// fileStreamId maps a file index to the HTTP2 stream id the device streams its content
+// on: the n-th file uses the n-th even stream id.
+func fileStreamId(fileIndex int) uint32 {
+	return uint32(fileIndex+1) * 2
+}
+
+// parseFileCount extracts the number of offered files from the reply to the initial
+// DSCFilePaths request.
+func parseFileCount(resp map[string]interface{}) (int, error) {
+	var count int64
+	switch v := resp["DSCFilePaths"].(type) {
+	case uint64:
+		if v > math.MaxInt64 {
+			return 0, fmt.Errorf("parseFileCount: implausible file count %d", v)
+		}
+		count = int64(v)
+	case int64:
+		count = v
+	default:
+		return 0, fmt.Errorf("parseFileCount: unexpected type %T for DSCFilePaths in %+v", resp["DSCFilePaths"], resp)
+	}
+	if count < 0 || count > maxFileCount {
+		return 0, fmt.Errorf("parseFileCount: implausible file count %d", count)
+	}
+	return int(count), nil
+}
+
+// parseFileInfo extracts path and expected length from a per-file metadata message.
+func parseFileInfo(resp map[string]interface{}) (FileInfo, error) {
+	entry, ok := resp["DSCFilePaths"].(map[string]interface{})
+	if !ok {
+		return FileInfo{}, fmt.Errorf("parseFileInfo: missing DSCFilePaths dictionary in %+v", resp)
+	}
+	filePath, ok := entry["filePath"].(string)
+	if !ok || filePath == "" {
+		return FileInfo{}, fmt.Errorf("parseFileInfo: missing filePath in %+v", entry)
+	}
+	transfer, ok := entry["fileTransfer"].(xpc.FileTransfer)
+	if !ok {
+		return FileInfo{}, fmt.Errorf("parseFileInfo: missing fileTransfer in %+v", entry)
+	}
+	return FileInfo{FilePath: filePath, Size: transfer.TransferSize}, nil
+}
+
+// copyFileChunks copies exactly size bytes from the file stream to w, reassembling the
+// chunked HTTP2 DATA frames the device sends.
+func copyFileChunks(w io.Writer, r io.Reader, size uint64) error {
+	if size > math.MaxInt64 {
+		return fmt.Errorf("copyFileChunks: implausible file size %d", size)
+	}
+	n, err := io.Copy(w, io.LimitReader(r, int64(size)))
+	if err != nil {
+		return fmt.Errorf("copyFileChunks: transfer failed after %d of %d bytes: %w", n, size, err)
+	}
+	if uint64(n) != size {
+		return fmt.Errorf("copyFileChunks: device ended stream after %d of %d bytes", n, size)
+	}
+	return nil
+}

--- a/ios/fetchsymbols/fetchsymbols_test.go
+++ b/ios/fetchsymbols/fetchsymbols_test.go
@@ -1,0 +1,284 @@
+package fetchsymbols
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/danielpaulus/go-ios/ios/xpc"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequestEnvelopeRoundtrip encodes the DSCFilePaths request the way ListFiles sends it
+// and verifies it decodes back to the same envelope, side-channel UUID included.
+func TestRequestEnvelopeRoundtrip(t *testing.T) {
+	sideChannel := uuid.New()
+	body := map[string]interface{}{
+		"XPCDictionary_sideChannel": sideChannel,
+		"DSCFilePaths":              []interface{}{},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	err := xpc.EncodeMessage(buf, xpc.Message{
+		Flags: xpc.AlwaysSetFlag | xpc.DataFlag | xpc.HeartbeatRequestFlag,
+		Body:  body,
+		Id:    1,
+	})
+	require.NoError(t, err)
+
+	decoded, err := xpc.DecodeMessage(buf)
+	require.NoError(t, err)
+	assert.Equal(t, xpc.AlwaysSetFlag|xpc.DataFlag|xpc.HeartbeatRequestFlag, decoded.Flags)
+	assert.Equal(t, body, decoded.Body)
+}
+
+// TestFileCountResponse decodes a fixture of the first reply (file count) and parses it.
+func TestFileCountResponse(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	err := xpc.EncodeMessage(buf, xpc.Message{
+		Flags: xpc.AlwaysSetFlag | xpc.DataFlag | xpc.HeartbeatReplyFlag,
+		Body:  map[string]interface{}{"DSCFilePaths": uint64(2)},
+	})
+	require.NoError(t, err)
+
+	decoded, err := xpc.DecodeMessage(buf)
+	require.NoError(t, err)
+	count, err := parseFileCount(decoded.Body)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestParseFileCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		resp    map[string]interface{}
+		want    int
+		wantErr bool
+	}{
+		{name: "uint64 count", resp: map[string]interface{}{"DSCFilePaths": uint64(3)}, want: 3},
+		{name: "int64 count", resp: map[string]interface{}{"DSCFilePaths": int64(1)}, want: 1},
+		{name: "zero files", resp: map[string]interface{}{"DSCFilePaths": uint64(0)}, want: 0},
+		{name: "missing key", resp: map[string]interface{}{}, wantErr: true},
+		{name: "wrong type", resp: map[string]interface{}{"DSCFilePaths": "3"}, wantErr: true},
+		{name: "negative count", resp: map[string]interface{}{"DSCFilePaths": int64(-1)}, wantErr: true},
+		{name: "implausible count", resp: map[string]interface{}{"DSCFilePaths": uint64(maxFileCount + 1)}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFileCount(tt.resp)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestFileMetadataResponse decodes a fixture of a per-file metadata message, including the
+// XPC file transfer object carrying the expected length, and parses it.
+func TestFileMetadataResponse(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	err := xpc.EncodeMessage(buf, xpc.Message{
+		Flags: xpc.AlwaysSetFlag | xpc.DataFlag,
+		Body: map[string]interface{}{
+			"DSCFilePaths": map[string]interface{}{
+				"filePath":     "/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e",
+				"fileTransfer": xpc.FileTransfer{MsgId: 1, TransferSize: 4096},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	decoded, err := xpc.DecodeMessage(buf)
+	require.NoError(t, err)
+	info, err := parseFileInfo(decoded.Body)
+	require.NoError(t, err)
+	assert.Equal(t, FileInfo{
+		FilePath: "/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e",
+		Size:     4096,
+	}, info)
+}
+
+func TestParseFileInfoErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		resp map[string]interface{}
+	}{
+		{name: "missing entry", resp: map[string]interface{}{}},
+		{name: "entry not a dict", resp: map[string]interface{}{"DSCFilePaths": uint64(1)}},
+		{name: "missing file path", resp: map[string]interface{}{"DSCFilePaths": map[string]interface{}{
+			"fileTransfer": xpc.FileTransfer{MsgId: 1, TransferSize: 1},
+		}}},
+		{name: "empty file path", resp: map[string]interface{}{"DSCFilePaths": map[string]interface{}{
+			"filePath":     "",
+			"fileTransfer": xpc.FileTransfer{MsgId: 1, TransferSize: 1},
+		}}},
+		{name: "missing file transfer", resp: map[string]interface{}{"DSCFilePaths": map[string]interface{}{
+			"filePath": "/a",
+		}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseFileInfo(tt.resp)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// chunkReader returns at most chunkSize bytes per Read call to simulate chunked arrival.
+type chunkReader struct {
+	data      []byte
+	chunkSize int
+}
+
+func (c *chunkReader) Read(p []byte) (int, error) {
+	if len(c.data) == 0 {
+		return 0, io.EOF
+	}
+	n := c.chunkSize
+	if n > len(c.data) {
+		n = len(c.data)
+	}
+	if n > len(p) {
+		n = len(p)
+	}
+	copy(p, c.data[:n])
+	c.data = c.data[n:]
+	return n, nil
+}
+
+func TestCopyFileChunksReassemblesChunks(t *testing.T) {
+	payload := bytes.Repeat([]byte("0123456789abcdef"), 1024)
+	out := bytes.NewBuffer(nil)
+	err := copyFileChunks(out, &chunkReader{data: payload, chunkSize: 1000}, uint64(len(payload)))
+	require.NoError(t, err)
+	assert.Equal(t, payload, out.Bytes())
+}
+
+func TestCopyFileChunksShortStream(t *testing.T) {
+	payload := []byte("not enough data")
+	err := copyFileChunks(io.Discard, bytes.NewReader(payload), uint64(len(payload)+1))
+	assert.ErrorContains(t, err, "ended stream")
+}
+
+func TestCopyFileChunksPropagatesReadError(t *testing.T) {
+	readErr := errors.New("stream broken")
+	r := io.MultiReader(bytes.NewReader([]byte("abc")), errReader{err: readErr})
+	err := copyFileChunks(io.Discard, r, 10)
+	assert.ErrorIs(t, err, readErr)
+}
+
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
+
+func TestFileStreamId(t *testing.T) {
+	assert.Equal(t, uint32(2), fileStreamId(0))
+	assert.Equal(t, uint32(4), fileStreamId(1))
+	assert.Equal(t, uint32(6), fileStreamId(2))
+}
+
+func TestCachePath(t *testing.T) {
+	base := filepath.Join("cache", "17.5_21F79")
+	tests := []struct {
+		name       string
+		devicePath string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "device path keeps layout",
+			devicePath: "/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e",
+			want:       filepath.Join(base, "System", "Library", "Caches", "com.apple.dyld", "dyld_shared_cache_arm64e"),
+		},
+		{
+			name:       "relative path",
+			devicePath: "some/file",
+			want:       filepath.Join(base, "some", "file"),
+		},
+		{
+			name:       "traversal is neutralized",
+			devicePath: "/../../etc/passwd",
+			want:       filepath.Join(base, "etc", "passwd"),
+		},
+		{
+			name:       "backslash traversal is neutralized",
+			devicePath: `..\..\etc\passwd`,
+			want:       filepath.Join(base, "etc", "passwd"),
+		},
+		{name: "empty path", devicePath: "", wantErr: true},
+		{name: "root only", devicePath: "/", wantErr: true},
+		{name: "dots only", devicePath: "/../..", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CachePath(base, tt.devicePath)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsCached(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "cachefile")
+	assert.False(t, IsCached(dest, 4), "missing file must not count as cached")
+
+	require.NoError(t, os.WriteFile(dest, []byte("data"), 0o644))
+	assert.True(t, IsCached(dest, 4))
+	assert.False(t, IsCached(dest, 5), "size mismatch must not count as cached")
+	assert.False(t, IsCached(dir, 4), "directory must not count as cached")
+}
+
+func TestWriteFileAtomically(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.bin")
+
+	err := writeFileAtomically(dest, func(w io.Writer) error {
+		_, err := w.Write([]byte("content"))
+		return err
+	})
+	require.NoError(t, err)
+	content, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("content"), content)
+	_, err = os.Stat(dest + ".download")
+	assert.True(t, os.IsNotExist(err), "temp file must be gone after success")
+}
+
+func TestWriteFileAtomicallyFailureLeavesNoFile(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.bin")
+	writeErr := errors.New("transfer interrupted")
+
+	err := writeFileAtomically(dest, func(w io.Writer) error {
+		_, _ = w.Write([]byte("partial"))
+		return writeErr
+	})
+	assert.ErrorIs(t, err, writeErr)
+	_, statErr := os.Stat(dest)
+	assert.True(t, os.IsNotExist(statErr), "failed download must not leave a destination file")
+	_, statErr = os.Stat(dest + ".download")
+	assert.True(t, os.IsNotExist(statErr), "failed download must not leave a temp file")
+}
+
+func TestProgressWriterReportsRunningTotal(t *testing.T) {
+	var reported []uint64
+	w := &progressWriter{w: io.Discard, progress: func(written uint64) { reported = append(reported, written) }}
+	_, err := w.Write([]byte("abc"))
+	require.NoError(t, err)
+	_, err = w.Write([]byte("de"))
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{3, 5}, reported)
+}

--- a/ios/http/http.go
+++ b/ios/http/http.go
@@ -162,7 +162,11 @@ func (r *HttpConnection) readDataFrame() error {
 				if d.StreamEnded() {
 					s.ended = true
 				}
-				if err := r.replenishReceiveWindow(d.StreamID, uint32(len(d.Data())), s.ended); err != nil {
+				// Flow control accounts for the whole DATA frame payload, including the
+				// Pad Length byte and padding (RFC 7540 §6.9.1), so replenish by the frame
+				// header Length, not just the unpadded data d.Data() exposes. Crediting only
+				// the unpadded length would leak window on padded frames and eventually stall.
+				if err := r.replenishReceiveWindow(d.StreamID, d.Length, s.ended); err != nil {
 					return fmt.Errorf("readDataFrame: %w", err)
 				}
 			}

--- a/ios/http/http.go
+++ b/ios/http/http.go
@@ -20,6 +20,19 @@ const (
 	ServerClient = StreamId(3)
 )
 
+// fileStreamWindowUpdateThreshold is how many received bytes are batched before the
+// flow-control windows (connection and file stream) are replenished. It must stay well
+// below the advertised initial window size (1 MiB) so large transfers never stall.
+const fileStreamWindowUpdateThreshold = 256 * 1024
+
+// fileStream buffers the raw content the device sends on an additional HTTP2 stream
+// during an XPC file transfer. ended is set once the device half-closes the stream.
+type fileStream struct {
+	buf    bytes.Buffer
+	ended  bool
+	isOpen atomic.Bool
+}
+
 // HttpConnection is a wrapper around a http2.Framer that provides a simple interface to read and write http2 streams for iOS17+.
 type HttpConnection struct {
 	framer             *http2.Framer
@@ -28,6 +41,8 @@ type HttpConnection struct {
 	closer             io.Closer
 	csIsOpen           *atomic.Bool
 	scIsOpen           *atomic.Bool
+	fileStreams        map[uint32]*fileStream
+	pendingWindow      map[uint32]uint32
 }
 
 func (r *HttpConnection) Close() error {
@@ -80,6 +95,8 @@ func NewHttpConnection(rw io.ReadWriteCloser) (*HttpConnection, error) {
 		closer:             rw,
 		csIsOpen:           &atomic.Bool{},
 		scIsOpen:           &atomic.Bool{},
+		fileStreams:        map[uint32]*fileStream{},
+		pendingWindow:      map[uint32]uint32{},
 	}, nil
 }
 
@@ -137,7 +154,17 @@ func (r *HttpConnection) readDataFrame() error {
 			case 3:
 				r.serverClientStream.Write(d.Data())
 			default:
-				return fmt.Errorf("readDataFrame: unknown stream id %d", d.StreamID)
+				s, ok := r.fileStreams[d.StreamID]
+				if !ok {
+					return fmt.Errorf("readDataFrame: unknown stream id %d", d.StreamID)
+				}
+				s.buf.Write(d.Data())
+				if d.StreamEnded() {
+					s.ended = true
+				}
+				if err := r.replenishReceiveWindow(d.StreamID, uint32(len(d.Data())), s.ended); err != nil {
+					return fmt.Errorf("readDataFrame: %w", err)
+				}
 			}
 			return nil
 		case http2.FrameGoAway:
@@ -199,4 +226,89 @@ func (h HttpStreamReadWriter) Write(p []byte) (n int, err error) {
 		return h.h.WriteServerClientStream(p)
 	}
 	return 0, fmt.Errorf("Write: unknown stream id %d", h.streamId)
+}
+
+// replenishReceiveWindow grants received bytes back to the device's flow-control windows
+// (connection and file stream) so transfers larger than the initial window size keep
+// flowing. Increments are batched until fileStreamWindowUpdateThreshold to limit frame
+// overhead; flush forces out any remainder (used when a stream ends).
+func (r *HttpConnection) replenishReceiveWindow(streamId uint32, received uint32, flush bool) error {
+	pending := r.pendingWindow[streamId] + received
+	if pending < fileStreamWindowUpdateThreshold && !flush {
+		r.pendingWindow[streamId] = pending
+		return nil
+	}
+	delete(r.pendingWindow, streamId)
+	if pending == 0 {
+		return nil
+	}
+	if err := r.framer.WriteWindowUpdate(uint32(InitStream), pending); err != nil {
+		return fmt.Errorf("replenishReceiveWindow: could not update connection window: %w", err)
+	}
+	if err := r.framer.WriteWindowUpdate(streamId, pending); err != nil {
+		return fmt.Errorf("replenishReceiveWindow: could not update window of stream %d: %w", streamId, err)
+	}
+	return nil
+}
+
+// registerFileStream reserves an additional stream id for an XPC file transfer so that
+// incoming DATA frames on it are buffered instead of rejected.
+func (r *HttpConnection) registerFileStream(streamId uint32) (*fileStream, error) {
+	switch StreamId(streamId) {
+	case InitStream, ClientServer, ServerClient:
+		return nil, fmt.Errorf("registerFileStream: stream id %d is reserved", streamId)
+	}
+	if _, ok := r.fileStreams[streamId]; ok {
+		return nil, fmt.Errorf("registerFileStream: stream id %d is already registered", streamId)
+	}
+	s := &fileStream{}
+	r.fileStreams[streamId] = s
+	return s, nil
+}
+
+// readFileStream reads buffered file content of the given stream, pumping frames off the
+// connection as needed. It returns io.EOF once the device half-closed the stream and all
+// buffered content was consumed.
+func (r *HttpConnection) readFileStream(streamId uint32, p []byte) (int, error) {
+	s, ok := r.fileStreams[streamId]
+	if !ok {
+		return 0, fmt.Errorf("readFileStream: stream id %d is not registered", streamId)
+	}
+	for s.buf.Len() == 0 {
+		if s.ended {
+			return 0, io.EOF
+		}
+		if err := r.readDataFrame(); err != nil {
+			return 0, fmt.Errorf("readFileStream: %w", err)
+		}
+	}
+	return s.buf.Read(p)
+}
+
+// FileStreamReadWriter reads and writes an additional HTTP2 stream used by RemoteXPC file
+// transfers (e.g. com.apple.dt.remoteFetchSymbols): the client opens the stream and the
+// device streams the raw file content back on it. Read returns io.EOF once the device
+// half-closes the stream. Like HttpConnection it is not safe for concurrent use.
+type FileStreamReadWriter struct {
+	h        *HttpConnection
+	streamId uint32
+	stream   *fileStream
+}
+
+// NewFileStreamReadWriter registers the given stream id (must not be one of the reserved
+// XPC streams 0, 1 and 3) on the connection and returns a ReadWriter for it.
+func NewFileStreamReadWriter(h *HttpConnection, streamId uint32) (FileStreamReadWriter, error) {
+	s, err := h.registerFileStream(streamId)
+	if err != nil {
+		return FileStreamReadWriter{}, fmt.Errorf("NewFileStreamReadWriter: %w", err)
+	}
+	return FileStreamReadWriter{h: h, streamId: streamId, stream: s}, nil
+}
+
+func (f FileStreamReadWriter) Read(p []byte) (int, error) {
+	return f.h.readFileStream(f.streamId, p)
+}
+
+func (f FileStreamReadWriter) Write(p []byte) (int, error) {
+	return f.h.write(p, f.streamId, &f.stream.isOpen)
 }

--- a/ios/http/http_test.go
+++ b/ios/http/http_test.go
@@ -143,6 +143,52 @@ func TestFileStreamChunkReassembly(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond, "expected window updates for %d bytes, got %d", len(payload), s.fileStreamWindow.Load())
 }
 
+// TestFileStreamPaddedFramesCreditFullLength verifies flow-control accounting credits the
+// whole DATA frame payload, including padding, back to the window (RFC 7540 §6.9.1).
+// Crediting only the unpadded data would leak window on every padded frame and stall.
+func TestFileStreamPaddedFramesCreditFullLength(t *testing.T) {
+	const streamId = uint32(2)
+	h, s := startFakeXpcServer(t, streamId)
+	s.framer.AllowIllegalWrites = true // send exactly-sized padded frames without the framer rejecting them
+
+	stream, err := NewFileStreamReadWriter(h, streamId)
+	require.NoError(t, err)
+
+	// One data byte plus 1 pad-length byte plus padding per frame. Send enough frames that
+	// the full-frame accounting crosses the 256 KiB threshold while the unpadded data
+	// (1 byte/frame) never would.
+	const dataPerFrame = 1
+	const padPerFrame = 250
+	frameWireLen := dataPerFrame + 1 + padPerFrame // data + pad-length byte + padding
+	frames := (fileStreamWindowUpdateThreshold / frameWireLen) + 2
+	payload := bytes.Repeat([]byte("x"), dataPerFrame*frames)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		pad := make([]byte, padPerFrame)
+		for i := 0; i < frames; i++ {
+			if err := s.framer.WriteDataPadded(streamId, false, []byte("x"), pad); err != nil {
+				serverErr <- err
+				return
+			}
+		}
+		serverErr <- s.framer.WriteData(streamId, true, nil)
+	}()
+
+	received, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	require.NoError(t, <-serverErr)
+	assert.Equal(t, payload, received)
+
+	// The window must be credited by the full frame payload length (data + pad byte +
+	// padding), not just the 1 data byte per frame.
+	wantWindow := int64(frameWireLen * frames)
+	require.Eventually(t, func() bool {
+		return s.fileStreamWindow.Load() == wantWindow
+	}, 5*time.Second, 10*time.Millisecond,
+		"expected window credit of %d (full padded frame length), got %d", wantWindow, s.fileStreamWindow.Load())
+}
+
 func TestFileStreamUnknownStreamStillErrors(t *testing.T) {
 	const streamId = uint32(2)
 	h, s := startFakeXpcServer(t, streamId)

--- a/ios/http/http_test.go
+++ b/ios/http/http_test.go
@@ -1,0 +1,176 @@
+package http
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+)
+
+// fakeXpcServer speaks just enough http2 to answer the handshake NewHttpConnection
+// performs and to push frames to the client afterwards.
+type fakeXpcServer struct {
+	framer *http2.Framer
+	// fileStreamWindow accumulates WINDOW_UPDATE increments the client granted for the
+	// file transfer stream under test.
+	fileStreamWindow atomic.Int64
+}
+
+// startFakeXpcServer completes the server side of the handshake and starts a drain
+// goroutine that keeps consuming client frames so client writes never block on the
+// synchronous in-memory pipe.
+func startFakeXpcServer(t *testing.T, fileStreamId uint32) (*HttpConnection, *fakeXpcServer) {
+	t.Helper()
+	clientConn, serverConn := net.Pipe()
+	deadline := time.Now().Add(10 * time.Second)
+	require.NoError(t, clientConn.SetDeadline(deadline))
+	require.NoError(t, serverConn.SetDeadline(deadline))
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+
+	s := &fakeXpcServer{}
+	handshakeDone := make(chan error, 1)
+	go func() {
+		preface := make([]byte, len(http2.ClientPreface))
+		if _, err := io.ReadFull(serverConn, preface); err != nil {
+			handshakeDone <- err
+			return
+		}
+		f := http2.NewFramer(serverConn, serverConn)
+		s.framer = f
+		// client settings and window update
+		for i := 0; i < 2; i++ {
+			if _, err := f.ReadFrame(); err != nil {
+				handshakeDone <- err
+				return
+			}
+		}
+		if err := f.WriteSettings(http2.Setting{ID: http2.SettingInitialWindowSize, Val: 1 << 20}); err != nil {
+			handshakeDone <- err
+			return
+		}
+		// client settings ack
+		if _, err := f.ReadFrame(); err != nil {
+			handshakeDone <- err
+			return
+		}
+		handshakeDone <- nil
+		// drain all further client frames (headers, data, window updates)
+		for {
+			frame, err := f.ReadFrame()
+			if err != nil {
+				return
+			}
+			if wu, ok := frame.(*http2.WindowUpdateFrame); ok && wu.StreamID == fileStreamId {
+				s.fileStreamWindow.Add(int64(wu.Increment))
+			}
+		}
+	}()
+
+	h, err := NewHttpConnection(clientConn)
+	require.NoError(t, err)
+	require.NoError(t, <-handshakeDone)
+	return h, s
+}
+
+// TestFileStreamChunkReassembly downloads a payload that arrives in many DATA frames on a
+// file transfer side stream, interleaved with data for the regular server-client stream,
+// and verifies chunk reassembly, EOF on END_STREAM, buffering of the interleaved stream
+// and flow-control window replenishment.
+func TestFileStreamChunkReassembly(t *testing.T) {
+	const streamId = uint32(2)
+	h, s := startFakeXpcServer(t, streamId)
+
+	stream, err := NewFileStreamReadWriter(h, streamId)
+	require.NoError(t, err)
+	// opening the stream from the client side must not fail (headers + payload frame)
+	_, err = stream.Write([]byte("xpc open message"))
+	require.NoError(t, err)
+
+	payload := bytes.Repeat([]byte("dyld-shared-cache!"), 20*1024) // 360 KiB, above the window update threshold
+	interleaved := []byte("reply-channel-data")
+
+	serverErr := make(chan error, 1)
+	go func() {
+		const chunkSize = 16000
+		for i := 0; i < len(payload); i += chunkSize {
+			end := i + chunkSize
+			if end > len(payload) {
+				end = len(payload)
+			}
+			if err := s.framer.WriteData(streamId, false, payload[i:end]); err != nil {
+				serverErr <- err
+				return
+			}
+			if i == 0 {
+				// push data for the regular server-client stream in the middle of the
+				// file transfer, it must get buffered instead of corrupting the file
+				if err := s.framer.WriteData(uint32(ServerClient), false, interleaved); err != nil {
+					serverErr <- err
+					return
+				}
+			}
+		}
+		serverErr <- s.framer.WriteData(streamId, true, nil)
+	}()
+
+	received, err := io.ReadAll(stream)
+	require.NoError(t, err)
+	require.NoError(t, <-serverErr)
+	assert.Equal(t, payload, received)
+
+	// reading again keeps returning EOF
+	_, err = stream.Read(make([]byte, 1))
+	assert.ErrorIs(t, err, io.EOF)
+
+	// the interleaved frame must be readable on the regular server-client stream
+	scBuf := make([]byte, len(interleaved))
+	_, err = io.ReadFull(NewStreamReadWriter(h, ServerClient), scBuf)
+	require.NoError(t, err)
+	assert.Equal(t, interleaved, scBuf)
+
+	// the client must have granted the full payload size back to the stream window
+	require.Eventually(t, func() bool {
+		return s.fileStreamWindow.Load() == int64(len(payload))
+	}, 5*time.Second, 10*time.Millisecond, "expected window updates for %d bytes, got %d", len(payload), s.fileStreamWindow.Load())
+}
+
+func TestFileStreamUnknownStreamStillErrors(t *testing.T) {
+	const streamId = uint32(2)
+	h, s := startFakeXpcServer(t, streamId)
+
+	stream, err := NewFileStreamReadWriter(h, streamId)
+	require.NoError(t, err)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		// data for a stream that was never registered must be rejected
+		serverErr <- s.framer.WriteData(6, false, []byte("bogus"))
+	}()
+
+	_, err = stream.Read(make([]byte, 1))
+	assert.ErrorContains(t, err, "unknown stream id 6")
+	require.NoError(t, <-serverErr)
+}
+
+func TestNewFileStreamReadWriterRejectsInvalidIds(t *testing.T) {
+	h := &HttpConnection{fileStreams: map[uint32]*fileStream{}, pendingWindow: map[uint32]uint32{}}
+
+	for _, reserved := range []uint32{uint32(InitStream), uint32(ClientServer), uint32(ServerClient)} {
+		_, err := NewFileStreamReadWriter(h, reserved)
+		assert.ErrorContains(t, err, "reserved", "stream id %d", reserved)
+	}
+
+	_, err := NewFileStreamReadWriter(h, 2)
+	require.NoError(t, err)
+	_, err = NewFileStreamReadWriter(h, 2)
+	assert.ErrorContains(t, err, "already registered")
+}

--- a/ios/xpc/encoding.go
+++ b/ios/xpc/encoding.go
@@ -44,7 +44,10 @@ const (
 	HeartbeatRequestFlag = uint32(0x00010000)
 	HeartbeatReplyFlag   = uint32(0x00020000)
 	FileOpenFlag         = uint32(0x00100000)
-	InitHandshakeFlag    = uint32(0x00400000)
+	// FileTransferStreamResponseFlag opens an additional HTTP2 stream on which the device
+	// streams the raw content of a file transfer back to the client.
+	FileTransferStreamResponseFlag = uint32(0x00200000)
+	InitHandshakeFlag              = uint32(0x00400000)
 )
 
 type wrapperHeader struct {
@@ -551,8 +554,28 @@ func encodeObject(w io.Writer, e interface{}) error {
 		if err := encodeDictionary(w, e.(map[string]interface{})); err != nil {
 			return err
 		}
+	case FileTransfer:
+		if err := encodeFileTransfer(w, e.(FileTransfer)); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("can not encode type %v", t)
+	}
+	return nil
+}
+
+// encodeFileTransfer is the inverse of decodeFileTransfer: a file transfer object carries
+// a message id and a dictionary whose property 's' holds the transfer length.
+func encodeFileTransfer(w io.Writer, ft FileTransfer) error {
+	header := struct {
+		t     xpcType
+		msgId uint64
+	}{fileTransferType, ft.MsgId}
+	if err := binary.Write(w, binary.LittleEndian, header); err != nil {
+		return fmt.Errorf("encodeFileTransfer: failed to write header: %w", err)
+	}
+	if err := encodeDictionary(w, map[string]interface{}{"s": ft.TransferSize}); err != nil {
+		return fmt.Errorf("encodeFileTransfer: failed to write transfer length: %w", err)
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ Usage:
   ios diskspace [options]
   ios dproxy [--binary] [--mode=<all(default)|usbmuxd|utun>] [--iface=<iface>] [options]
   ios erase [--force] [options]
+  ios fetchsymbols [--path=<dir>] [options]
   ios file ls [--app=<bundleID> | --app-group=<groupID> | --crash | --temp] [--path=<path>] [options]
   ios file pull [--app=<bundleID> | --app-group=<groupID> | --crash | --temp] --remote=<remotePath> --local=<localPath> [options]
   ios file push [--app=<bundleID> | --app-group=<groupID> | --crash | --temp] --local=<localPath> --remote=<remotePath> [options]
@@ -286,6 +287,12 @@ The commands work as following:
                                                                   The --binary flag will dump everything in raw binary without any decoding.
 
     ios erase [--force] [options]                                 Erase the device. It will prompt you to input y+Enter unless --force is specified.
+
+    ios fetchsymbols [--path=<dir>] [options]                     Download the dyld shared cache from the device for local symbolication
+                                                                  using RemoteXPC (iOS 17+). Requires tunnel.
+                                                                  Beware: this is a multi-gigabyte download. Files are cached per
+                                                                  iOS version and build under <dir> (default ./ios-symbols);
+                                                                  already cached files are skipped.
 
     ios file ls [--app=<bundleID> | --app-group=<groupID> | --crash | --temp] [--path=<path>] [options]
                                                                   List files using RemoteXPC (iOS 17+). Requires tunnel.

--- a/testdata/help/global.golden
+++ b/testdata/help/global.golden
@@ -42,6 +42,7 @@ Commands:
   diskspace                       Print disk usage.
   dproxy                          Start debug proxy.
   erase                           Erase device.
+  fetchsymbols                    Download the dyld shared cache for local symbolication (multi-GB, iOS 17+).
   file ls                         List files in app/group/temp/crash container.
   file pull                       Pull file from device.
   file push                       Push file to device.


### PR DESCRIPTION
## Problem

Resolving symbol addresses of a remote iOS process currently requires parsing Mach-O headers over GDB RSP memory reads. Only Xcode can download the dyld shared cache ("Preparing debugger support"), so go-ios users have no way to get device libraries locally for fast symbol resolution, crash symbolication or offline analysis (#700).

## Design

New RemoteXPC client for `com.apple.dt.remoteFetchSymbols`, mirroring pymobiledevice3's [`RemoteFetchSymbolsService`](https://github.com/doronz88/pymobiledevice3/blob/master/pymobiledevice3/services/remote_fetch_symbols.py) and the file-transfer stream handling in its [`RemoteXPCConnection`](https://github.com/doronz88/pymobiledevice3/blob/master/pymobiledevice3/remote/remotexpc.py):

1. Send `{"XPCDictionary_sideChannel": <uuid>, "DSCFilePaths": []}` (wanting-reply flag) → the reply carries the file count.
2. Receive one metadata message per file on the reply channel: `filePath` plus an XPC file-transfer object whose `s` property is the expected byte length (go-ios already decodes this as `xpc.FileTransfer`).
3. For file *i*, open HTTP2 stream `(i+1)*2` with an empty XPC wrapper flagged `FILE_TX_STREAM_RESPONSE` (`0x00200000`); the device streams the raw file bytes as DATA frames on that stream, terminated by `END_STREAM`.
4. Store files under `<dir>/<ProductVersion>_<BuildVersion>/<on-device path>` so the multi-GB download is cached per iOS version/build and reused across devices.

This is RemoteXPC only — no dtx/nskeyedarchiver code is touched.

## Implementation

- **`ios/http`**: file-transfer side streams for the existing `HttpConnection` — `NewFileStreamReadWriter` registers an extra stream id, DATA frames for it are buffered (interleaved stream 1/3 frames keep working), `END_STREAM` surfaces as `io.EOF`, and received bytes are granted back to the connection + stream flow-control windows (batched at 256 KiB, force-flushed at stream end) so multi-gigabyte transfers don't stall on the 1 MiB initial window.
- **`ios/xpc`**: new `FileTransferStreamResponseFlag` const; `FileTransfer` encode support (inverse of the existing decoder) for codec symmetry and fixture tests.
- **`ios/fetchsymbols`**: `New/ListFiles/DownloadFile/DownloadToCache` client plus caching helpers: traversal-safe `CachePath` (device-controlled paths cannot escape the cache dir), `IsCached` (size match), atomic temp-file + rename writes so interrupted downloads never look cached, and a progress callback.
- **CLI**: `ios fetchsymbols [--path=<dir>]` (default `./ios-symbols`), gated on a running tunnel, prints an explicit multi-gigabyte-download warning with file count/total size before transferring, logs progress every 512 MiB, skips already-cached files, JSON summary output. Registered in the command registry, `needsAutomaticTunnelInfo`, help catalog and usage doc.

## Options considered

1. **Reuse `ios/fileservice`'s raw data connection** — rejected: remoteFetchSymbols does not use the `com.apple.coredevice.fileservice.data` wire protocol; its content arrives on extra HTTP2 streams of the *same* XPC connection.
2. **Give `xpc.Connection` a built-in file-transfer API** — rejected for now: `xpc` stays transport-agnostic; the side-stream mechanics live in `ios/http` (which owns the HTTP2 framing) and the service package composes them. Smallest surface change to shared code.
3. **Concurrent downloads (pymobiledevice3 uses 4 workers)** — rejected: `HttpConnection` is intentionally single-threaded like all other go-ios XPC services; files download sequentially. Simpler, and throughput is tunnel-bound anyway. *(Preferred: option 2/3 as implemented.)*
4. **Prompt y/N before downloading** — rejected in favor of explicit opt-in messaging: the command itself is the opt-in, and a prompt would break automation; a clear warning with total size is printed before the transfer starts.

## Test plan

- `go build ./...` and `go test ./...` pass; `gofmt -l` clean on changed files.
- Unit tests added:
  - `ios/fetchsymbols`: DSCFilePaths request envelope encode/decode roundtrip (side-channel UUID included), file-count and per-file metadata fixture decode + parsing (incl. the `fileTransfer` expected length), chunk reassembly (`copyFileChunks`) incl. short-stream and error propagation, cache-path traversal safety, cached-size checks, atomic write semantics, progress reporting.
  - `ios/http`: fake in-memory HTTP2 server test that streams a 360 KiB payload in 16 KB DATA frames on a file stream — verifies reassembly, EOF on `END_STREAM`, buffering of interleaved reply-channel data, full flow-control window replenishment, and rejection of unknown/duplicate/reserved stream ids.
- **Follow-up**: the real download path gets validated via e2e on an iOS 17+ farm device (needs tunnel + several GB of transfer, so it is not part of the device-free unit suite).

Fixes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk