### PR TITLE
fix(tunnel): surface netsh/ifconfig output and elevation hints in tunnel interface setup errors

### DIFF
--- a/ios/tunnel/runcmd_test.go
+++ b/ios/tunnel/runcmd_test.go
@@ -1,0 +1,50 @@
+package tunnel
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestRunCmdHelperProcess is not a real test: TestRunCmdFailureIncludesCommandAndOutput
+// re-executes the test binary with GO_IOS_WANT_RUNCMD_HELPER set so this helper acts
+// like netsh on Windows, which prints its error message to stdout (not stderr) and
+// exits non-zero.
+func TestRunCmdHelperProcess(t *testing.T) {
+	if os.Getenv("GO_IOS_WANT_RUNCMD_HELPER") != "1" {
+		t.Skip("helper process for TestRunCmdFailureIncludesCommandAndOutput")
+	}
+	fmt.Println("The parameter is incorrect.")
+	os.Exit(1)
+}
+
+func TestRunCmdFailureIncludesCommandAndOutput(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunCmdHelperProcess$", "-test.v")
+	cmd.Env = append(os.Environ(), "GO_IOS_WANT_RUNCMD_HELPER=1")
+
+	err := runCmd(cmd)
+	if err == nil {
+		t.Fatal("expected runCmd to fail")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "The parameter is incorrect.") {
+		t.Errorf("error does not contain the command's stdout output: %s", msg)
+	}
+	if !strings.Contains(msg, cmd.String()) {
+		t.Errorf("error does not contain the executed command line %q: %s", cmd.String(), msg)
+	}
+	if !strings.Contains(msg, "exit status 1") {
+		t.Errorf("error does not contain the exit status: %s", msg)
+	}
+}
+
+func TestRunCmdSuccess(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunCmdHelperProcess$")
+	// Without GO_IOS_WANT_RUNCMD_HELPER the helper test skips, so the command
+	// succeeds.
+	if err := runCmd(cmd); err != nil {
+		t.Fatalf("expected runCmd to succeed, got: %v", err)
+	}
+}

--- a/ios/tunnel/tunnel.go
+++ b/ios/tunnel/tunnel.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"math/big"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/danielpaulus/go-ios/ios"
@@ -175,12 +176,15 @@ func connectToTunnel(ctx context.Context, info tunnelListener, addr string, devi
 	}, nil
 }
 
+// runCmd runs an interface-configuration command (ifconfig, netsh, ...) and
+// captures its combined stdout and stderr. Some tools (netsh on Windows) write
+// their error messages to stdout, so capturing only stderr would surface an
+// empty error.
 func runCmd(cmd *exec.Cmd) error {
-	buf := new(bytes.Buffer)
-	cmd.Stderr = buf
-	err := cmd.Run()
+	golog.Debug("running interface setup command", "module", logModule, "cmd", cmd.String())
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("runCmd: failed to exeute command (stderr: %s): %w", buf.String(), err)
+		return fmt.Errorf("runCmd: failed to execute command '%s' (output: '%s'): %w", cmd.String(), strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }

--- a/ios/tunnel/tunnel_windows.go
+++ b/ios/tunnel/tunnel_windows.go
@@ -108,9 +108,11 @@ func setupTunnelInterface(tunnelInfo tunnelParameters) (io.ReadWriteCloser, erro
 	setIpAddr := exec.Command("netsh", "interface", "ipv6", "set", "address", tunname, fmt.Sprintf("%s/%d", tunnelInfo.ClientParameters.Address, prefixLength))
 	err = runCmd(setIpAddr)
 	if err != nil {
-		return nil, fmt.Errorf("setupTunnelInterface: failed to set IP address for interface: %w", err)
+		return nil, fmt.Errorf("setupTunnelInterface: failed to set IP address for interface: %w. "+
+			"Common causes: the process is not elevated (wintun and netsh require administrator rights) "+
+			"or the wintun adapter was not created properly. "+
+			"Run from an administrator shell, or use 'ios tunnel start --userspace' which does not need admin rights", err)
 	}
-	golog.Info("windows cmd", "module", logModule, "cmd", setIpAddr.String())
 
 	return initTUNwrapper(tunDevice), nil
 }


### PR DESCRIPTION
## Problem

On Windows, `ios tunnel start` fails for several users with an error that carries no diagnostic information at all (#545):

```
could not setup tunnel interface. setupTunnelInterface: failed to set IP address for interface: runCmd: failed to exeute command (stderr: ): exit status 1
```

The empty `stderr:` makes the failure undiagnosable — there is no way to tell from a bug report whether the cause is a missing elevation, a wintun adapter problem, or a bad netsh invocation.

## Root cause

`netsh` writes its error messages to **stdout**, not stderr. `runCmd` in `ios/tunnel/tunnel.go` captured only `cmd.Stderr`, so the actual netsh error text was discarded. Additionally, the netsh command line was only logged *after* a successful run, so failing invocations never appeared in the logs either.

## Fix

- `runCmd` now uses `CombinedOutput()` and returns an error containing the exact command line, the captured stdout+stderr, and the exit status. It also debug-logs the command before running it.
- The Windows `setupTunnelInterface` error now hints at the common causes: the process not being elevated (wintun/netsh require administrator rights) and suggests `ios tunnel start --userspace` as the fallback that needs no admin rights.
- Removed the after-success-only "windows cmd" info log (superseded by the pre-run debug log inside `runCmd`).
- Darwin (`tunnel_darwin.go`) routes its three `ifconfig` calls through the same `runCmd`, so it inherits the improved capture with no file changes needed.

## Options considered

1. **Capture combined stdout+stderr in the shared `runCmd`** (preferred): one small change fixes the silent-failure pattern for all callers on both Windows and macOS, and keeps error formatting testable OS-independently.
2. Separate stdout/stderr buffers reported as distinct fields: more code for no diagnostic gain — for netsh the interesting text is in stdout anyway, and interleaved combined output preserves ordering.
3. Windows-only fix in `setupTunnelInterface`: would leave the same blind spot in the Darwin ifconfig path.

## Test plan

- New device-free unit test `ios/tunnel/runcmd_test.go` (runs on any OS): re-executes the test binary as a helper process that, like netsh, prints its error to **stdout** and exits 1; asserts the returned error contains the captured output, the exact command line, and the exit status. Plus a success-path test.
- `go build ./...`, `go test ./...` pass locally (macOS); `GOOS=windows go build ./ios/... .` and `GOOS=windows go vet ./ios/tunnel/` pass. `gofmt -l` clean on changed files.

## Improves #545

This intentionally does **not** close #545: it makes the failure diagnosable and points users at the `--userspace` workaround, but the underlying netsh failure still needs a Windows repro with the now-captured netsh output to identify and fix the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk