### PR TITLE
feat(clihelp): add examples field to help catalog and document pcap

### DIFF
--- a/internal/clihelp/help.go
+++ b/internal/clihelp/help.go
@@ -232,7 +232,7 @@ func (c *Catalog) renderGlobal(version string) string {
 		}
 		writeAlignedPair(&b, command.Path, summary, maxWidth)
 	}
-	b.WriteString("Run 'ios help <command>' or 'ios <command> --help' for command details.\n")
+	b.WriteString("\nRun 'ios help <command>' or 'ios <command> --help' for command details.\n")
 	return b.String()
 }
 
@@ -271,7 +271,7 @@ func (c *Catalog) resolvePathFromArgs(tokens []string) (string, bool, bool) {
 		candidateTokens = append(candidateTokens, token)
 	}
 	if len(candidateTokens) == 0 {
-		return "", true, false
+		return "", false, true
 	}
 	for _, path := range c.commandPathList {
 		commandTokens := strings.Fields(path)

--- a/internal/clihelp/help.go
+++ b/internal/clihelp/help.go
@@ -21,10 +21,11 @@ type Option struct {
 }
 
 type Command struct {
-	Path    string   `yaml:"path"`
-	Usage   string   `yaml:"usage"`
-	Summary string   `yaml:"summary"`
-	Aliases []string `yaml:"aliases"`
+	Path     string   `yaml:"path"`
+	Usage    string   `yaml:"usage"`
+	Summary  string   `yaml:"summary"`
+	Aliases  []string `yaml:"aliases"`
+	Examples []string `yaml:"examples"`
 }
 
 type Catalog struct {
@@ -183,6 +184,13 @@ func (c *Catalog) Render(version, topic string) (string, error) {
 	}
 	b.WriteString("Usage:\n")
 	fmt.Fprintf(&b, "  %s\n\n", command.Usage)
+	if len(command.Examples) > 0 {
+		b.WriteString("Examples:\n")
+		for _, example := range command.Examples {
+			fmt.Fprintf(&b, "  %s\n", example)
+		}
+		b.WriteString("\n")
+	}
 	b.WriteString("Global options:\n")
 	writeAlignedOptions(&b, c.GlobalOptions)
 	return b.String(), nil
@@ -224,7 +232,7 @@ func (c *Catalog) renderGlobal(version string) string {
 		}
 		writeAlignedPair(&b, command.Path, summary, maxWidth)
 	}
-	b.WriteString("\nRun 'ios help <command>' or 'ios <command> --help' for command details.\n")
+	b.WriteString("Run 'ios help <command>' or 'ios <command> --help' for command details.\n")
 	return b.String()
 }
 
@@ -263,7 +271,7 @@ func (c *Catalog) resolvePathFromArgs(tokens []string) (string, bool, bool) {
 		candidateTokens = append(candidateTokens, token)
 	}
 	if len(candidateTokens) == 0 {
-		return "", false, true
+		return "", true, false
 	}
 	for _, path := range c.commandPathList {
 		commandTokens := strings.Fields(path)

--- a/internal/clihelp/help.yaml
+++ b/internal/clihelp/help.yaml
@@ -165,6 +165,10 @@ commands:
   - path: pcap
     usage: ios pcap [options] [--pid=<processID>] [--process=<processName>]
     summary: Capture network packets.
+    examples:
+      - "ios pcap                             # stream all traffic to stdout"
+      - "ios pcap --process=myapp             # capture one process only"
+      - "ios pcap --pid=1234 > capture.pcap   # save for Wireshark / mitmproxy analysis"
   - path: prepare
     usage: ios prepare [--skip-all] [--skip=<option>]... [--certfile=<cert_file_path>] [--orgname=<org_name>] [--p12password=<p12password>] [--locale=<locale>] [--lang=<lang>] [options]
     summary: Prepare device for automation.

--- a/internal/clihelp/render_test.go
+++ b/internal/clihelp/render_test.go
@@ -38,3 +38,20 @@ func TestRender_Command(t *testing.T) {
 		t.Fatalf("missing command usage: %q", out)
 	}
 }
+
+func TestRender_CommandExamples(t *testing.T) {
+    c, err := Load()
+    if err != nil {
+        t.Fatalf("load help catalog: %v", err)
+    }
+    out, err := c.Render("test-version", "pcap")
+    if err != nil {
+        t.Fatalf("render pcap: %v", err)
+    }
+    if !strings.Contains(out, "Examples:") {
+        t.Fatalf("missing examples section: %q", out)
+    }
+    if !strings.Contains(out, "capture.pcap") {
+        t.Fatalf("missing pcap example: %q", out)
+    }
+}

--- a/internal/clihelp/render_test.go
+++ b/internal/clihelp/render_test.go
@@ -40,18 +40,18 @@ func TestRender_Command(t *testing.T) {
 }
 
 func TestRender_CommandExamples(t *testing.T) {
-    c, err := Load()
-    if err != nil {
-        t.Fatalf("load help catalog: %v", err)
-    }
-    out, err := c.Render("test-version", "pcap")
-    if err != nil {
-        t.Fatalf("render pcap: %v", err)
-    }
-    if !strings.Contains(out, "Examples:") {
-        t.Fatalf("missing examples section: %q", out)
-    }
-    if !strings.Contains(out, "capture.pcap") {
-        t.Fatalf("missing pcap example: %q", out)
-    }
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("load help catalog: %v", err)
+	}
+	out, err := c.Render("test-version", "pcap")
+	if err != nil {
+		t.Fatalf("render pcap: %v", err)
+	}
+	if !strings.Contains(out, "Examples:") {
+		t.Fatalf("missing examples section: %q", out)
+	}
+	if !strings.Contains(out, "capture.pcap") {
+		t.Fatalf("missing pcap example: %q", out)
+	}
 }


### PR DESCRIPTION
Hi Daniel,

I've been quietly following `go-ios` for a while, especially since the iOS 17 tunnel era (Issue #265). I still remember your comment about using `ios pcap` to capture the QUIC and JSON RPC traffic when you were reverse-engineering the new `CoreDevice` framework. That "Exciting weeks ahead!" spirit really stuck with me.

Since `pcap` is such a powerful tool for traffic analysis (and probably the most under-documented one in the CLI), I added a small `examples` field to the help catalog and documented the `pcap` command with a few practical snippets (like filtering by process and saving to a file for Wireshark/mitmproxy).

Changes:
- `help.go`: Added `Examples []string` to the `Command` struct and rendered it in `Render()`.
- `help.yaml`: Added practical examples for `pcap`.
- `render_test.go`: Added a quick test.

Thanks for keeping this project alive and kicking across platforms!