### PR TITLE
refactor: extract reusable ios/uidriver from the CLI

### DIFF
--- a/cmd_ui.go
+++ b/cmd_ui.go
@@ -1,44 +1,36 @@
 package main
 
 import (
-	"bytes"
-	"encoding/base64"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
-	"net/url"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/danielpaulus/go-ios/ios/uidriver"
 	"github.com/docopt/docopt-go"
 )
 
 const (
-	defaultUIDriver      = "devicekit"
-	defaultWDAURL        = "http://127.0.0.1:8100"
-	defaultDeviceKitURL  = "http://127.0.0.1:12004"
-	uiDriverWDA          = "wda"
-	uiDriverDeviceKit    = "devicekit"
-	uiDriverAuto         = "auto"
-	deviceKitRPCProtocol = "2.0"
+	defaultUIDriver     = "devicekit"
+	defaultWDAURL       = uidriver.DefaultWDAURL
+	defaultDeviceKitURL = uidriver.DefaultDeviceKitURL
+	uiDriverWDA         = "wda"
+	uiDriverDeviceKit   = "devicekit"
+	uiDriverAuto        = "auto"
 )
 
+// uiClient wires the CLI arguments to a reusable uidriver.Driver. Argument
+// parsing, backend resolution and output formatting live here; all HTTP work
+// is delegated to the ios/uidriver package.
 type uiClient struct {
 	driver       string
 	wdaURL       string
 	deviceKitURL string
-	httpClient   *http.Client
 	sessionID    string
-}
-
-type uiHTTPResponse struct {
-	StatusCode int
-	Header     http.Header
-	Body       []byte
 }
 
 func runUICommand(ctx commandContext) {
@@ -51,26 +43,26 @@ func runUICommand(ctx commandContext) {
 
 	switch {
 	case boolArg(ctx.Args, "status"):
-		client.printStatus()
+		printUIResponse(client.driverOrExit().Status())
 	case boolArg(ctx.Args, "api") || boolArg(ctx.Args, "raw"):
 		client.api(ctx)
 	case boolArg(ctx.Args, "tap"):
-		client.tap(requiredIntArg(ctx.Args, "--x"), requiredIntArg(ctx.Args, "--y"))
+		printUIResponse(client.driverOrExit().Tap(requiredIntArg(ctx.Args, "--x"), requiredIntArg(ctx.Args, "--y")))
 	case boolArg(ctx.Args, "swipe"):
-		client.swipe(
+		printUIResponse(client.driverOrExit().Swipe(
 			requiredIntArg(ctx.Args, "--from-x"),
 			requiredIntArg(ctx.Args, "--from-y"),
 			requiredIntArg(ctx.Args, "--to-x"),
 			requiredIntArg(ctx.Args, "--to-y"),
 			optionalFloatArg(ctx.Args, "--duration", 0),
-		)
+		))
 	case boolArg(ctx.Args, "longpress"):
-		client.longPress(requiredIntArg(ctx.Args, "--x"), requiredIntArg(ctx.Args, "--y"), optionalFloatArg(ctx.Args, "--duration", 1))
+		printUIResponse(client.driverOrExit().LongPress(requiredIntArg(ctx.Args, "--x"), requiredIntArg(ctx.Args, "--y"), optionalFloatArg(ctx.Args, "--duration", 1)))
 	case boolArg(ctx.Args, "type"):
-		client.typeText(requiredStringArg(ctx.Args, "--text"))
+		printUIResponse(client.driverOrExit().Type(requiredStringArg(ctx.Args, "--text")))
 	case boolArg(ctx.Args, "button"):
 		button, _ := ctx.Args.String("<button>")
-		client.button(button)
+		printUIResponse(client.driverOrExit().PressButton(button))
 	case boolArg(ctx.Args, "screenshot"):
 		output, _ := ctx.Args.String("--output")
 		client.screenshot(output)
@@ -78,7 +70,7 @@ func runUICommand(ctx commandContext) {
 		output, _ := ctx.Args.String("--output")
 		client.source(output)
 	case boolArg(ctx.Args, "size"):
-		client.size()
+		printUIResponse(client.driverOrExit().WindowSize())
 	case boolArg(ctx.Args, "orientation"):
 		client.orientation(ctx)
 	case boolArg(ctx.Args, "app"):
@@ -113,123 +105,70 @@ func newUIClient(args docopt.Opts) uiClient {
 		deviceKitURL = defaultDeviceKitURL
 	}
 	sessionID, _ := args.String("--session-id")
-	client := uiClient{
+	return uiClient{
 		driver:       driver,
 		wdaURL:       strings.TrimRight(wdaURL, "/"),
 		deviceKitURL: strings.TrimRight(deviceKitURL, "/"),
-		httpClient:   &http.Client{Timeout: 60 * time.Second},
 		sessionID:    sessionID,
 	}
-	client.resolveDriver()
-	return client
 }
 
-func (c *uiClient) resolveDriver() {
+// resolveBackend maps the CLI --driver value (wda/devicekit/auto) to a concrete
+// uidriver.Backend and its base URL, probing health for the auto mode.
+func (c uiClient) resolveBackend() (uidriver.Backend, string) {
 	switch c.driver {
-	case uiDriverWDA, uiDriverDeviceKit:
-		return
+	case uiDriverWDA:
+		return uidriver.BackendWDA, c.wdaURL
+	case uiDriverDeviceKit:
+		return uidriver.BackendDeviceKit, c.deviceKitURL
 	case uiDriverAuto:
-		if c.deviceKitHealthy() {
-			c.driver = uiDriverDeviceKit
-			return
+		if d, err := uidriver.New(uidriver.BackendDeviceKit, c.deviceKitURL); err == nil && d.Healthy() {
+			return uidriver.BackendDeviceKit, c.deviceKitURL
 		}
-		if c.wdaHealthy() {
-			c.driver = uiDriverWDA
-			return
+		if d, err := uidriver.New(uidriver.BackendWDA, c.wdaURL); err == nil && d.Healthy() {
+			return uidriver.BackendWDA, c.wdaURL
 		}
 		logFatal("no UI automation backend reachable; start DeviceKit on 127.0.0.1:12004 or WDA on 127.0.0.1:8100, or pass --driver and --*-url")
+		return "", ""
 	default:
 		logFatal("unknown --driver: " + c.driver)
+		return "", ""
 	}
 }
 
-func (c uiClient) printStatus() {
-	switch c.driver {
-	case uiDriverDeviceKit:
-		printUIResponse(c.deviceKitHTTP(http.MethodGet, "/health", nil))
-	case uiDriverWDA:
-		printUIResponse(c.wdaHTTP(http.MethodGet, "/status", nil))
+// driverOrExit builds a uidriver.Driver for the resolved backend or exits on error.
+func (c uiClient) driverOrExit() *uidriver.Driver {
+	backend, baseURL := c.resolveBackend()
+	opts := []uidriver.Option{uidriver.WithTimeout(60 * time.Second)}
+	if c.sessionID != "" {
+		opts = append(opts, uidriver.WithSessionID(c.sessionID))
 	}
+	d, err := uidriver.New(backend, baseURL, opts...)
+	exitIfError("failed creating ui driver", err)
+	return d
 }
 
-func (c *uiClient) api(ctx commandContext) {
-	switch c.driver {
-	case uiDriverDeviceKit:
-		methodName := requiredStringArg(ctx.Args, "--rpc-method")
-		params := rawParamsFromArgs(ctx)
-		printUIResponse(c.deviceKitRPC(methodName, params))
-	case uiDriverWDA:
+func (c uiClient) api(ctx commandContext) {
+	d := c.driverOrExit()
+	switch d.Backend() {
+	case uidriver.BackendDeviceKit:
+		printUIResponse(d.API(uidriver.APIRequest{
+			RPCMethod: requiredStringArg(ctx.Args, "--rpc-method"),
+			RPCParams: rawParamsFromArgs(ctx),
+		}))
+	case uidriver.BackendWDA:
 		method, _ := ctx.Args.String("--method")
-		if method == "" {
-			method = http.MethodGet
-		}
-		httpPath := requiredStringArg(ctx.Args, "--http-path")
-		body := requestBodyFromArgs(ctx)
-		printUIResponse(c.wdaHTTP(strings.ToUpper(method), httpPath, body))
+		printUIResponse(d.API(uidriver.APIRequest{
+			Method: method,
+			Path:   requiredStringArg(ctx.Args, "--http-path"),
+			Body:   requestBodyFromArgs(ctx),
+		}))
 	}
 }
 
-func (c *uiClient) tap(x, y int) {
-	switch c.driver {
-	case uiDriverDeviceKit:
-		printUIResponse(c.deviceKitRPC("device.io.tap", map[string]interface{}{"x": x, "y": y}))
-	case uiDriverWDA:
-		printUIResponse(c.wdaHTTP(http.MethodPost, wdaPath("session", c.wdaSession(), "wda", "tap", strconv.Itoa(x), strconv.Itoa(y)), nil))
-	}
-}
-
-func (c *uiClient) swipe(fromX, fromY, toX, toY int, duration float64) {
-	switch c.driver {
-	case uiDriverDeviceKit:
-		printUIResponse(c.deviceKitRPC("device.io.swipe", map[string]interface{}{"fromX": fromX, "fromY": fromY, "toX": toX, "toY": toY, "duration": duration}))
-	case uiDriverWDA:
-		body := map[string]interface{}{"fromX": fromX, "fromY": fromY, "toX": toX, "toY": toY, "duration": duration}
-		printUIResponse(c.wdaHTTP(http.MethodPost, wdaPath("session", c.wdaSession(), "wda", "dragfromtoforduration"), mustJSON(body)))
-	}
-}
-
-func (c *uiClient) longPress(x, y int, duration float64) {
-	switch c.driver {
-	case uiDriverDeviceKit:
-		printUIResponse(c.deviceKitRPC("device.io.longpress", map[string]interface{}{"x": x, "y": y, "duration": duration}))
-	case uiDriverWDA:
-		body := map[string]interface{}{"x": x, "y": y, "duration": duration}
-		printUIResponse(c.wdaHTTP(http.MethodPost, wdaPath("session", c.wdaSession(), "wda", "touchAndHold"), mustJSON(body)))
-	}
-}
-
-func (c *uiClient) typeText(text string) {
-	switch c.driver {
-	case uiDriverDeviceKit:
-		printUIResponse(c.deviceKitRPC("device.io.text", map[string]interface{}{"text": text}))
-	case uiDriverWDA:
-		printUIResponse(c.wdaHTTP(http.MethodPost, wdaPath("session", c.wdaSession(), "keys"), mustJSON(textBody(text))))
-	}
-}
-
-func (c *uiClient) button(button string) {
-	switch c.driver {
-	case uiDriverDeviceKit:
-		printUIResponse(c.deviceKitRPC("device.io.button", map[string]interface{}{"button": button}))
-	case uiDriverWDA:
-		if strings.EqualFold(button, "home") {
-			printUIResponse(c.wdaHTTP(http.MethodPost, wdaPath("session", c.wdaSession(), "wda", "homescreen"), nil))
-			return
-		}
-		logFatal("WDA only supports the home button through this command; use --driver=devicekit for lock/volume buttons")
-	}
-}
-
-func (c *uiClient) screenshot(output string) {
-	var image []byte
-	switch c.driver {
-	case uiDriverDeviceKit:
-		resp := c.deviceKitRPC("device.screenshot", map[string]interface{}{})
-		image = decodeBase64Response(resp.Body)
-	case uiDriverWDA:
-		resp := c.wdaHTTP(http.MethodGet, wdaPath("session", c.wdaSession(), "screenshot"), nil)
-		image = decodeBase64Response(resp.Body)
-	}
+func (c uiClient) screenshot(output string) {
+	image, err := c.driverOrExit().Screenshot()
+	exitIfError("failed capturing screenshot", err)
 	if output == "" || output == "-" {
 		_, err := os.Stdout.Write(image)
 		exitIfError("failed writing screenshot", err)
@@ -238,56 +177,33 @@ func (c *uiClient) screenshot(output string) {
 	exitIfError("failed writing screenshot", os.WriteFile(output, image, 0644))
 }
 
-func (c *uiClient) source(output string) {
-	var resp uiHTTPResponse
-	switch c.driver {
-	case uiDriverDeviceKit:
-		resp = c.deviceKitRPC("device.dump.ui", map[string]interface{}{})
-	case uiDriverWDA:
-		resp = c.wdaHTTP(http.MethodGet, wdaPath("session", c.wdaSession(), "source"), nil)
-	}
-	writeOrPrintResponse(resp, output)
+func (c uiClient) source(output string) {
+	resp, err := c.driverOrExit().Source()
+	writeOrPrintResponse(resp, err, output)
 }
 
-func (c *uiClient) size() {
-	switch c.driver {
-	case uiDriverDeviceKit:
-		printUIResponse(c.deviceKitRPC("device.info", map[string]interface{}{}))
-	case uiDriverWDA:
-		printUIResponse(c.wdaHTTP(http.MethodGet, wdaPath("session", c.wdaSession(), "window", "size"), nil))
-	}
-}
-
-func (c *uiClient) orientation(ctx commandContext) {
-	switch {
-	case boolArg(ctx.Args, "set"):
+func (c uiClient) orientation(ctx commandContext) {
+	d := c.driverOrExit()
+	if boolArg(ctx.Args, "set") {
 		orientation, _ := ctx.Args.String("<orientation>")
 		if orientation == "" {
 			orientation = requiredStringArg(ctx.Args, "--orientation")
 		}
-		switch c.driver {
-		case uiDriverDeviceKit:
-			printUIResponse(c.deviceKitRPC("device.io.orientation.set", map[string]interface{}{"orientation": orientation}))
-		case uiDriverWDA:
-			printUIResponse(c.wdaHTTP(http.MethodPost, wdaPath("session", c.wdaSession(), "orientation"), mustJSON(map[string]string{"orientation": orientation})))
-		}
-	default:
-		switch c.driver {
-		case uiDriverDeviceKit:
-			printUIResponse(c.deviceKitRPC("device.io.orientation.get", map[string]interface{}{}))
-		case uiDriverWDA:
-			printUIResponse(c.wdaHTTP(http.MethodGet, wdaPath("session", c.wdaSession(), "orientation"), nil))
-		}
+		printUIResponse(d.SetOrientation(orientation))
+		return
 	}
+	printUIResponse(d.Orientation())
 }
 
-func (c *uiClient) app(ctx commandContext) {
+func (c uiClient) app(ctx commandContext) {
+	d := c.driverOrExit()
 	switch {
 	case boolArg(ctx.Args, "foreground"):
-		if c.driver != uiDriverDeviceKit {
+		resp, err := d.AppForeground()
+		if err == uidriver.ErrForegroundUnsupported {
 			logFatal("app foreground is only available with --driver=devicekit")
 		}
-		printUIResponse(c.deviceKitRPC("device.apps.foreground", map[string]interface{}{}))
+		printUIResponse(resp, err)
 	default:
 		bundleID, _ := ctx.Args.String("<bundleID>")
 		if bundleID == "" {
@@ -295,151 +211,50 @@ func (c *uiClient) app(ctx commandContext) {
 		}
 		switch {
 		case boolArg(ctx.Args, "launch"):
-			c.appWithBundleID("launch", bundleID)
+			printUIResponse(d.AppLaunch(bundleID))
 		case boolArg(ctx.Args, "terminate"):
-			c.appWithBundleID("terminate", bundleID)
+			printUIResponse(d.AppTerminate(bundleID))
 		default:
 			logFatal("unknown ui app command")
 		}
 	}
 }
 
-func (c *uiClient) appWithBundleID(action string, bundleID string) {
-	switch c.driver {
-	case uiDriverDeviceKit:
-		printUIResponse(c.deviceKitRPC("device.apps."+action, map[string]interface{}{"bundleId": bundleID}))
-	case uiDriverWDA:
-		printUIResponse(c.wdaHTTP(http.MethodPost, wdaPath("session", c.wdaSession(), "wda", "apps", action), mustJSON(map[string]string{"bundleId": bundleID})))
+func (c uiClient) stream(ctx commandContext) {
+	d := c.driverOrExit()
+	opts := uidriver.StreamOptions{H264: boolArg(ctx.Args, "h264")}
+	opts.FPS, _ = ctx.Args.String("--fps")
+	opts.Quality, _ = ctx.Args.String("--quality")
+	opts.Scale, _ = ctx.Args.String("--scale")
+	opts.Bitrate, _ = ctx.Args.String("--bitrate")
+	body, err := d.Stream(context.Background(), opts)
+	if err == uidriver.ErrStreamUnsupported {
+		logFatal("WDA stream supports mjpeg only; use --driver=devicekit for h264")
 	}
-}
-
-func (c *uiClient) stream(ctx commandContext) {
-	streamType := "mjpeg"
-	if boolArg(ctx.Args, "h264") {
-		streamType = "h264"
-	}
-	query := url.Values{}
-	addQueryArg(ctx.Args, query, "--fps", "fps")
-	addQueryArg(ctx.Args, query, "--quality", "quality")
-	addQueryArg(ctx.Args, query, "--scale", "scale")
-	addQueryArg(ctx.Args, query, "--bitrate", "bitrate")
-	endpoint := "/" + streamType
-	if encoded := query.Encode(); encoded != "" {
-		endpoint += "?" + encoded
-	}
-	switch c.driver {
-	case uiDriverDeviceKit:
-		c.pipeHTTP(c.deviceKitURL + endpoint)
-	case uiDriverWDA:
-		if streamType != "mjpeg" {
-			logFatal("WDA stream supports mjpeg only; use --driver=devicekit for h264")
-		}
-		c.pipeHTTP(c.wdaURL + endpoint)
-	}
-}
-
-func (c *uiClient) wdaSession() string {
-	if c.sessionID != "" {
-		return c.sessionID
-	}
-	resp := c.wdaHTTP(http.MethodPost, "/session", mustJSON(map[string]interface{}{
-		"capabilities":        map[string]interface{}{},
-		"desiredCapabilities": map[string]interface{}{},
-	}))
-	sessionID := extractSessionID(resp.Body)
-	if sessionID == "" {
-		logFatal("WDA did not return a session id")
-	}
-	c.sessionID = sessionID
-	return sessionID
-}
-
-func (c uiClient) deviceKitHealthy() bool {
-	resp, err := c.httpClient.Get(c.deviceKitURL + "/health")
-	if err != nil {
-		return false
-	}
-	defer func() { _ = resp.Body.Close() }()
-	return resp.StatusCode >= 200 && resp.StatusCode < 300
-}
-
-func (c uiClient) wdaHealthy() bool {
-	resp, err := c.httpClient.Get(c.wdaURL + "/status")
-	if err != nil {
-		return false
-	}
-	defer func() { _ = resp.Body.Close() }()
-	return resp.StatusCode >= 200 && resp.StatusCode < 300
-}
-
-func (c uiClient) deviceKitRPC(method string, params interface{}) uiHTTPResponse {
-	body := mustJSON(map[string]interface{}{
-		"jsonrpc": deviceKitRPCProtocol,
-		"method":  method,
-		"params":  params,
-		"id":      1,
-	})
-	return c.deviceKitHTTP(http.MethodPost, "/rpc", body)
-}
-
-func (c uiClient) deviceKitHTTP(method string, endpoint string, body []byte) uiHTTPResponse {
-	return c.doHTTP(method, c.deviceKitURL, endpoint, body)
-}
-
-func (c uiClient) wdaHTTP(method string, endpoint string, body []byte) uiHTTPResponse {
-	return c.doHTTP(method, c.wdaURL, endpoint, body)
-}
-
-func (c uiClient) doHTTP(method string, baseURL string, endpoint string, body []byte) uiHTTPResponse {
-	if !strings.HasPrefix(endpoint, "/") {
-		endpoint = "/" + endpoint
-	}
-	req, err := http.NewRequest(method, baseURL+endpoint, bytes.NewReader(body))
-	exitIfError("failed creating UI request", err)
-	req.Header.Set("Accept", "application/json")
-	if len(body) > 0 {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	resp, err := c.httpClient.Do(req)
-	exitIfError("UI request failed", err)
-	defer func() { _ = resp.Body.Close() }()
-	respBody, err := io.ReadAll(resp.Body)
-	exitIfError("failed reading UI response", err)
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		fmt.Fprintln(os.Stderr, string(respBody))
-		os.Exit(1)
-	}
-	return uiHTTPResponse{StatusCode: resp.StatusCode, Header: resp.Header, Body: respBody}
-}
-
-func (c uiClient) pipeHTTP(rawURL string) {
-	resp, err := c.httpClient.Get(rawURL)
 	exitIfError("stream request failed", err)
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		body, _ := io.ReadAll(resp.Body)
-		fmt.Fprintln(os.Stderr, string(body))
-		os.Exit(1)
-	}
-	_, err = io.Copy(os.Stdout, resp.Body)
+	defer func() { _ = body.Close() }()
+	_, err = io.Copy(os.Stdout, body)
 	exitIfError("stream copy failed", err)
 }
 
-func printUIResponse(resp uiHTTPResponse) {
+// printUIResponse pretty-prints a driver response, exiting on a non-nil error.
+func printUIResponse(resp uidriver.Response, err error) {
+	exitIfError("ui request failed", err)
 	if len(resp.Body) == 0 {
 		return
 	}
 	var data interface{}
-	if err := json.Unmarshal(resp.Body, &data); err != nil {
+	if uerr := json.Unmarshal(resp.Body, &data); uerr != nil {
 		fmt.Print(string(resp.Body))
 		return
 	}
 	fmt.Println(convertToJSONString(data))
 }
 
-func writeOrPrintResponse(resp uiHTTPResponse, output string) {
+func writeOrPrintResponse(resp uidriver.Response, err error, output string) {
+	exitIfError("ui request failed", err)
 	if output == "" || output == "-" {
-		printUIResponse(resp)
+		printUIResponse(resp, nil)
 		return
 	}
 	exitIfError("failed writing output", os.WriteFile(output, resp.Body, 0644))
@@ -481,17 +296,6 @@ func rawParamsFromArgs(ctx commandContext) interface{} {
 	return decoded
 }
 
-func textBody(text string) map[string]interface{} {
-	return map[string]interface{}{
-		"text":  text,
-		"value": []string{text},
-	}
-}
-
-func wdaPath(parts ...string) string {
-	return "/" + path.Join(parts...)
-}
-
 func requiredStringArg(args docopt.Opts, name string) string {
 	value, _ := args.String(name)
 	if value == "" {
@@ -516,70 +320,4 @@ func optionalFloatArg(args docopt.Opts, name string, fallback float64) float64 {
 	floatValue, err := strconv.ParseFloat(value, 64)
 	exitIfError("failed parsing "+name, err)
 	return floatValue
-}
-
-func mustJSON(data interface{}) []byte {
-	body, err := json.Marshal(data)
-	exitIfError("failed encoding UI request body", err)
-	return body
-}
-
-func decodeBase64Response(body []byte) []byte {
-	encoded := findBase64Value(body)
-	if encoded == "" {
-		logFatal("response did not contain a base64 image")
-	}
-	image, err := base64.StdEncoding.DecodeString(encoded)
-	exitIfError("failed decoding base64 image", err)
-	return image
-}
-
-func findBase64Value(body []byte) string {
-	var decoded interface{}
-	if err := json.Unmarshal(body, &decoded); err != nil {
-		return ""
-	}
-	return findBase64String(decoded)
-}
-
-func findBase64String(value interface{}) string {
-	switch typed := value.(type) {
-	case string:
-		return typed
-	case map[string]interface{}:
-		for _, key := range []string{"value", "result", "image", "screenshot", "data"} {
-			if nested, ok := typed[key]; ok {
-				if result := findBase64String(nested); result != "" {
-					return result
-				}
-			}
-		}
-	}
-	return ""
-}
-
-func extractSessionID(body []byte) string {
-	var decoded map[string]interface{}
-	if err := json.Unmarshal(body, &decoded); err != nil {
-		return ""
-	}
-	if sessionID, ok := decoded["sessionId"].(string); ok {
-		return sessionID
-	}
-	if value, ok := decoded["value"].(map[string]interface{}); ok {
-		if sessionID, ok := value["sessionId"].(string); ok {
-			return sessionID
-		}
-		if sessionID, ok := value["session_id"].(string); ok {
-			return sessionID
-		}
-	}
-	return ""
-}
-
-func addQueryArg(args docopt.Opts, query url.Values, argName string, queryName string) {
-	value, _ := args.String(argName)
-	if value != "" {
-		query.Set(queryName, value)
-	}
 }

--- a/ios/uidriver/uidriver.go
+++ b/ios/uidriver/uidriver.go
@@ -1,0 +1,659 @@
+// Package uidriver is a reusable client for driving on-device UI automation
+// backends over HTTP. It talks to a running WebDriverAgent (WDA, default
+// :8100) or DeviceKit (default :12004) instance — typically reached through a
+// forwarded local port — and exposes the common automation actions (tap,
+// swipe, type, screenshot, source, app control, streaming, …) as a clean,
+// exported API.
+//
+// The client is deliberately decoupled from the go-ios CLI: construct a Driver
+// against a backend base URL and call its methods. All methods return values
+// and errors rather than terminating the process, so the driver is safe to
+// embed in the CLI, the REST API, or any other caller.
+package uidriver
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios/golog"
+)
+
+const logModule = "go-ios/uidriver"
+
+// Backend identifies which UI automation backend a Driver talks to.
+type Backend string
+
+const (
+	// BackendWDA drives a WebDriverAgent instance (WebDriver JSON wire protocol).
+	BackendWDA Backend = "wda"
+	// BackendDeviceKit drives a DeviceKit instance (JSON-RPC 2.0).
+	BackendDeviceKit Backend = "devicekit"
+
+	// DefaultWDAURL is the default forwarded WebDriverAgent address.
+	DefaultWDAURL = "http://127.0.0.1:8100"
+	// DefaultDeviceKitURL is the default forwarded DeviceKit address.
+	DefaultDeviceKitURL = "http://127.0.0.1:12004"
+
+	// DefaultTimeout is the default per-request HTTP timeout.
+	DefaultTimeout = 60 * time.Second
+
+	deviceKitRPCProtocol = "2.0"
+)
+
+// Response is the raw result of a backend HTTP call. Body holds the raw
+// response bytes (usually JSON); callers can unmarshal it as needed.
+type Response struct {
+	StatusCode int         `json:"statusCode"`
+	Header     http.Header `json:"-"`
+	Body       []byte      `json:"body"`
+}
+
+// UnmarshalBody decodes the response body into v.
+func (r Response) UnmarshalBody(v interface{}) error {
+	return json.Unmarshal(r.Body, v)
+}
+
+// Driver is a UI automation client bound to a single backend (WDA or
+// DeviceKit) reachable at a base URL. Construct it with New. A Driver is safe
+// for sequential use; it lazily establishes a WDA session on first use of a
+// session-scoped action.
+type Driver struct {
+	backend    Backend
+	baseURL    string
+	httpClient *http.Client
+	timeout    time.Duration
+	sessionID  string
+	// udid is optional, used only to enrich log lines.
+	udid string
+}
+
+// Option configures a Driver.
+type Option func(*Driver)
+
+// WithHTTPClient overrides the HTTP client used for requests.
+func WithHTTPClient(c *http.Client) Option {
+	return func(d *Driver) {
+		if c != nil {
+			d.httpClient = c
+		}
+	}
+}
+
+// WithTimeout sets the per-request HTTP timeout (ignored if WithHTTPClient is
+// also supplied).
+func WithTimeout(timeout time.Duration) Option {
+	return func(d *Driver) { d.timeout = timeout }
+}
+
+// WithSessionID pre-seeds a WDA session id so the Driver skips session
+// creation. Ignored by the DeviceKit backend.
+func WithSessionID(sessionID string) Option {
+	return func(d *Driver) { d.sessionID = sessionID }
+}
+
+// WithUDID attaches a device udid used only to enrich log lines.
+func WithUDID(udid string) Option {
+	return func(d *Driver) { d.udid = udid }
+}
+
+// New constructs a Driver for the given backend at baseURL (for example
+// "http://127.0.0.1:8100" for WDA or "http://127.0.0.1:12004" for DeviceKit).
+// The base URL is typically the local end of a forwarded connection to the
+// device. A trailing slash is trimmed.
+func New(backend Backend, baseURL string, opts ...Option) (*Driver, error) {
+	switch backend {
+	case BackendWDA, BackendDeviceKit:
+	default:
+		return nil, fmt.Errorf("uidriver: unknown backend %q", backend)
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, errors.New("uidriver: baseURL must not be empty")
+	}
+	d := &Driver{
+		backend: backend,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		timeout: DefaultTimeout,
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	if d.httpClient == nil {
+		d.httpClient = &http.Client{Timeout: d.timeout}
+	}
+	return d, nil
+}
+
+// Backend returns the backend this Driver targets.
+func (d *Driver) Backend() Backend { return d.backend }
+
+// BaseURL returns the (trailing-slash-trimmed) backend base URL.
+func (d *Driver) BaseURL() string { return d.baseURL }
+
+// SessionID returns the current WDA session id (empty until one is created).
+func (d *Driver) SessionID() string { return d.sessionID }
+
+// Healthy reports whether the backend answers its health/status endpoint with
+// a 2xx status.
+func (d *Driver) Healthy() bool {
+	endpoint := "/status"
+	if d.backend == BackendDeviceKit {
+		endpoint = "/health"
+	}
+	resp, err := d.httpClient.Get(d.baseURL + endpoint)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// Status returns the backend status/health payload.
+func (d *Driver) Status() (Response, error) {
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitHTTP(http.MethodGet, "/health", nil)
+	default:
+		return d.wdaHTTP(http.MethodGet, "/status", nil)
+	}
+}
+
+// Tap taps the screen at absolute coordinates (x, y).
+func (d *Driver) Tap(x, y int) (Response, error) {
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitRPC("device.io.tap", map[string]interface{}{"x": x, "y": y})
+	default:
+		session, err := d.wdaSession()
+		if err != nil {
+			return Response{}, err
+		}
+		return d.wdaHTTP(http.MethodPost, wdaPath("session", session, "wda", "tap", strconv.Itoa(x), strconv.Itoa(y)), nil)
+	}
+}
+
+// Swipe drags from (fromX, fromY) to (toX, toY) over the given duration in
+// seconds (0 lets the backend choose).
+func (d *Driver) Swipe(fromX, fromY, toX, toY int, duration float64) (Response, error) {
+	body := map[string]interface{}{"fromX": fromX, "fromY": fromY, "toX": toX, "toY": toY, "duration": duration}
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitRPC("device.io.swipe", body)
+	default:
+		session, err := d.wdaSession()
+		if err != nil {
+			return Response{}, err
+		}
+		payload, err := marshalJSON(body)
+		if err != nil {
+			return Response{}, err
+		}
+		return d.wdaHTTP(http.MethodPost, wdaPath("session", session, "wda", "dragfromtoforduration"), payload)
+	}
+}
+
+// LongPress presses and holds at (x, y) for duration seconds.
+func (d *Driver) LongPress(x, y int, duration float64) (Response, error) {
+	body := map[string]interface{}{"x": x, "y": y, "duration": duration}
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitRPC("device.io.longpress", body)
+	default:
+		session, err := d.wdaSession()
+		if err != nil {
+			return Response{}, err
+		}
+		payload, err := marshalJSON(body)
+		if err != nil {
+			return Response{}, err
+		}
+		return d.wdaHTTP(http.MethodPost, wdaPath("session", session, "wda", "touchAndHold"), payload)
+	}
+}
+
+// Type sends text as keyboard input.
+func (d *Driver) Type(text string) (Response, error) {
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitRPC("device.io.text", map[string]interface{}{"text": text})
+	default:
+		session, err := d.wdaSession()
+		if err != nil {
+			return Response{}, err
+		}
+		payload, err := marshalJSON(textBody(text))
+		if err != nil {
+			return Response{}, err
+		}
+		return d.wdaHTTP(http.MethodPost, wdaPath("session", session, "keys"), payload)
+	}
+}
+
+// ErrButtonUnsupported is returned when a hardware button press is requested
+// against a backend that cannot perform it.
+var ErrButtonUnsupported = errors.New("uidriver: button not supported by this backend")
+
+// PressButton presses a hardware button by name (for example "home", "lock",
+// "volumeup"). WDA only supports "home"; other buttons require DeviceKit and
+// yield ErrButtonUnsupported on WDA.
+func (d *Driver) PressButton(name string) (Response, error) {
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitRPC("device.io.button", map[string]interface{}{"button": name})
+	default:
+		if strings.EqualFold(name, "home") {
+			session, err := d.wdaSession()
+			if err != nil {
+				return Response{}, err
+			}
+			return d.wdaHTTP(http.MethodPost, wdaPath("session", session, "wda", "homescreen"), nil)
+		}
+		return Response{}, fmt.Errorf("%w: WDA only supports the home button; use the DeviceKit backend for lock/volume buttons", ErrButtonUnsupported)
+	}
+}
+
+// Screenshot captures the screen and returns the decoded image bytes (PNG).
+func (d *Driver) Screenshot() ([]byte, error) {
+	var resp Response
+	var err error
+	switch d.backend {
+	case BackendDeviceKit:
+		resp, err = d.deviceKitRPC("device.screenshot", map[string]interface{}{})
+	default:
+		var session string
+		session, err = d.wdaSession()
+		if err != nil {
+			return nil, err
+		}
+		resp, err = d.wdaHTTP(http.MethodGet, wdaPath("session", session, "screenshot"), nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return decodeBase64Response(resp.Body)
+}
+
+// Source returns the current UI hierarchy (XML for WDA, backend-defined dump
+// for DeviceKit).
+func (d *Driver) Source() (Response, error) {
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitRPC("device.dump.ui", map[string]interface{}{})
+	default:
+		session, err := d.wdaSession()
+		if err != nil {
+			return Response{}, err
+		}
+		return d.wdaHTTP(http.MethodGet, wdaPath("session", session, "source"), nil)
+	}
+}
+
+// WindowSize returns the device window/screen size payload.
+func (d *Driver) WindowSize() (Response, error) {
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitRPC("device.info", map[string]interface{}{})
+	default:
+		session, err := d.wdaSession()
+		if err != nil {
+			return Response{}, err
+		}
+		return d.wdaHTTP(http.MethodGet, wdaPath("session", session, "window", "size"), nil)
+	}
+}
+
+// Orientation returns the current device orientation payload.
+func (d *Driver) Orientation() (Response, error) {
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitRPC("device.io.orientation.get", map[string]interface{}{})
+	default:
+		session, err := d.wdaSession()
+		if err != nil {
+			return Response{}, err
+		}
+		return d.wdaHTTP(http.MethodGet, wdaPath("session", session, "orientation"), nil)
+	}
+}
+
+// SetOrientation sets the device orientation (for example "PORTRAIT",
+// "LANDSCAPE").
+func (d *Driver) SetOrientation(orientation string) (Response, error) {
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitRPC("device.io.orientation.set", map[string]interface{}{"orientation": orientation})
+	default:
+		session, err := d.wdaSession()
+		if err != nil {
+			return Response{}, err
+		}
+		payload, err := marshalJSON(map[string]string{"orientation": orientation})
+		if err != nil {
+			return Response{}, err
+		}
+		return d.wdaHTTP(http.MethodPost, wdaPath("session", session, "orientation"), payload)
+	}
+}
+
+// AppLaunch launches the app identified by bundleID.
+func (d *Driver) AppLaunch(bundleID string) (Response, error) {
+	return d.appWithBundleID("launch", bundleID)
+}
+
+// AppTerminate terminates the app identified by bundleID.
+func (d *Driver) AppTerminate(bundleID string) (Response, error) {
+	return d.appWithBundleID("terminate", bundleID)
+}
+
+// ErrForegroundUnsupported is returned when app foregrounding is requested
+// against a backend that does not support it (WDA).
+var ErrForegroundUnsupported = errors.New("uidriver: app foreground not supported by this backend")
+
+// AppForeground brings the currently backgrounded app to the foreground. Only
+// supported by the DeviceKit backend; returns ErrForegroundUnsupported on WDA.
+func (d *Driver) AppForeground() (Response, error) {
+	if d.backend != BackendDeviceKit {
+		return Response{}, ErrForegroundUnsupported
+	}
+	return d.deviceKitRPC("device.apps.foreground", map[string]interface{}{})
+}
+
+func (d *Driver) appWithBundleID(action, bundleID string) (Response, error) {
+	switch d.backend {
+	case BackendDeviceKit:
+		return d.deviceKitRPC("device.apps."+action, map[string]interface{}{"bundleId": bundleID})
+	default:
+		session, err := d.wdaSession()
+		if err != nil {
+			return Response{}, err
+		}
+		payload, err := marshalJSON(map[string]string{"bundleId": bundleID})
+		if err != nil {
+			return Response{}, err
+		}
+		return d.wdaHTTP(http.MethodPost, wdaPath("session", session, "wda", "apps", action), payload)
+	}
+}
+
+// APIRequest is a raw passthrough to the backend.
+//
+// For the WDA backend, Method and Path are the HTTP verb and path (Body may be
+// nil), and RPCMethod/RPCParams are ignored.
+//
+// For the DeviceKit backend, RPCMethod is the JSON-RPC method name and
+// RPCParams its params (Method/Path/Body are ignored). If RPCParams is nil an
+// empty object is sent.
+type APIRequest struct {
+	// Method is the HTTP method for a WDA passthrough (defaults to GET).
+	Method string `json:"method,omitempty"`
+	// Path is the HTTP path for a WDA passthrough.
+	Path string `json:"path,omitempty"`
+	// Body is the raw HTTP request body for a WDA passthrough.
+	Body []byte `json:"body,omitempty"`
+	// RPCMethod is the JSON-RPC method name for a DeviceKit passthrough.
+	RPCMethod string `json:"rpcMethod,omitempty"`
+	// RPCParams are the JSON-RPC params for a DeviceKit passthrough.
+	RPCParams interface{} `json:"rpcParams,omitempty"`
+}
+
+// API performs a raw passthrough request against the backend. See APIRequest
+// for which fields apply to which backend.
+func (d *Driver) API(req APIRequest) (Response, error) {
+	switch d.backend {
+	case BackendDeviceKit:
+		if req.RPCMethod == "" {
+			return Response{}, errors.New("uidriver: RPCMethod is required for the DeviceKit backend")
+		}
+		params := req.RPCParams
+		if params == nil {
+			params = map[string]interface{}{}
+		}
+		return d.deviceKitRPC(req.RPCMethod, params)
+	default:
+		if req.Path == "" {
+			return Response{}, errors.New("uidriver: Path is required for the WDA backend")
+		}
+		method := req.Method
+		if method == "" {
+			method = http.MethodGet
+		}
+		return d.wdaHTTP(strings.ToUpper(method), req.Path, req.Body)
+	}
+}
+
+// StreamOptions configure a video/mjpeg stream request.
+type StreamOptions struct {
+	// H264 requests an h264 stream (DeviceKit only); otherwise mjpeg is used.
+	H264 bool
+	// FPS, Quality, Scale and Bitrate are optional query parameters passed
+	// through to the backend when non-empty.
+	FPS     string
+	Quality string
+	Scale   string
+	Bitrate string
+}
+
+// ErrStreamUnsupported is returned when the requested stream type is not
+// supported by the backend (for example h264 over WDA).
+var ErrStreamUnsupported = errors.New("uidriver: stream type not supported by this backend")
+
+// Stream opens a video stream against the backend and returns the raw response
+// body as an io.ReadCloser for the caller to pipe. The caller owns the returned
+// ReadCloser and must Close it. A non-2xx response is returned as an *HTTPError
+// with the response body included.
+func (d *Driver) Stream(ctx context.Context, opts StreamOptions) (io.ReadCloser, error) {
+	streamType := "mjpeg"
+	if opts.H264 {
+		streamType = "h264"
+	}
+	if d.backend == BackendWDA && streamType != "mjpeg" {
+		return nil, fmt.Errorf("%w: WDA stream supports mjpeg only; use the DeviceKit backend for h264", ErrStreamUnsupported)
+	}
+	query := url.Values{}
+	setIfNotEmpty(query, "fps", opts.FPS)
+	setIfNotEmpty(query, "quality", opts.Quality)
+	setIfNotEmpty(query, "scale", opts.Scale)
+	setIfNotEmpty(query, "bitrate", opts.Bitrate)
+	endpoint := "/" + streamType
+	if encoded := query.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	rawURL := d.baseURL + endpoint
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("uidriver: failed creating stream request: %w", err)
+	}
+	golog.Info("opening ui stream", "module", logModule, "backend", string(d.backend), "url", rawURL, "udid", d.udid)
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("uidriver: stream request failed: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return nil, &HTTPError{StatusCode: resp.StatusCode, Body: body}
+	}
+	return resp.Body, nil
+}
+
+// HTTPError is returned when a backend responds with a non-2xx status.
+type HTTPError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *HTTPError) Error() string {
+	msg := strings.TrimSpace(string(e.Body))
+	if msg == "" {
+		return fmt.Sprintf("uidriver: backend returned status %d", e.StatusCode)
+	}
+	return fmt.Sprintf("uidriver: backend returned status %d: %s", e.StatusCode, msg)
+}
+
+// wdaSession returns an existing session id or lazily creates one.
+func (d *Driver) wdaSession() (string, error) {
+	if d.sessionID != "" {
+		return d.sessionID, nil
+	}
+	payload, err := marshalJSON(map[string]interface{}{
+		"capabilities":        map[string]interface{}{},
+		"desiredCapabilities": map[string]interface{}{},
+	})
+	if err != nil {
+		return "", err
+	}
+	resp, err := d.wdaHTTP(http.MethodPost, "/session", payload)
+	if err != nil {
+		return "", err
+	}
+	sessionID := extractSessionID(resp.Body)
+	if sessionID == "" {
+		return "", errors.New("uidriver: WDA did not return a session id")
+	}
+	d.sessionID = sessionID
+	golog.Debug("created wda session", "module", logModule, "sessionID", sessionID, "udid", d.udid)
+	return sessionID, nil
+}
+
+func (d *Driver) deviceKitRPC(method string, params interface{}) (Response, error) {
+	body, err := marshalJSON(map[string]interface{}{
+		"jsonrpc": deviceKitRPCProtocol,
+		"method":  method,
+		"params":  params,
+		"id":      1,
+	})
+	if err != nil {
+		return Response{}, err
+	}
+	return d.deviceKitHTTP(http.MethodPost, "/rpc", body)
+}
+
+func (d *Driver) deviceKitHTTP(method, endpoint string, body []byte) (Response, error) {
+	return d.doHTTP(method, endpoint, body)
+}
+
+func (d *Driver) wdaHTTP(method, endpoint string, body []byte) (Response, error) {
+	return d.doHTTP(method, endpoint, body)
+}
+
+func (d *Driver) doHTTP(method, endpoint string, body []byte) (Response, error) {
+	if !strings.HasPrefix(endpoint, "/") {
+		endpoint = "/" + endpoint
+	}
+	req, err := http.NewRequest(method, d.baseURL+endpoint, bytes.NewReader(body))
+	if err != nil {
+		return Response{}, fmt.Errorf("uidriver: failed creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	golog.Debug("ui request", "module", logModule, "backend", string(d.backend), "method", method, "endpoint", endpoint, "udid", d.udid)
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return Response{}, fmt.Errorf("uidriver: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Response{}, fmt.Errorf("uidriver: failed reading response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return Response{}, &HTTPError{StatusCode: resp.StatusCode, Body: respBody}
+	}
+	return Response{StatusCode: resp.StatusCode, Header: resp.Header, Body: respBody}, nil
+}
+
+func marshalJSON(data interface{}) ([]byte, error) {
+	body, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("uidriver: failed encoding request body: %w", err)
+	}
+	return body, nil
+}
+
+func textBody(text string) map[string]interface{} {
+	return map[string]interface{}{
+		"text":  text,
+		"value": []string{text},
+	}
+}
+
+func wdaPath(parts ...string) string {
+	return "/" + path.Join(parts...)
+}
+
+func setIfNotEmpty(query url.Values, key, value string) {
+	if value != "" {
+		query.Set(key, value)
+	}
+}
+
+func decodeBase64Response(body []byte) ([]byte, error) {
+	encoded := findBase64Value(body)
+	if encoded == "" {
+		return nil, errors.New("uidriver: response did not contain a base64 image")
+	}
+	image, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("uidriver: failed decoding base64 image: %w", err)
+	}
+	return image, nil
+}
+
+func findBase64Value(body []byte) string {
+	var decoded interface{}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return ""
+	}
+	return findBase64String(decoded)
+}
+
+func findBase64String(value interface{}) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case map[string]interface{}:
+		for _, key := range []string{"value", "result", "image", "screenshot", "data"} {
+			if nested, ok := typed[key]; ok {
+				if result := findBase64String(nested); result != "" {
+					return result
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func extractSessionID(body []byte) string {
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return ""
+	}
+	if sessionID, ok := decoded["sessionId"].(string); ok {
+		return sessionID
+	}
+	if value, ok := decoded["value"].(map[string]interface{}); ok {
+		if sessionID, ok := value["sessionId"].(string); ok {
+			return sessionID
+		}
+		if sessionID, ok := value["session_id"].(string); ok {
+			return sessionID
+		}
+	}
+	return ""
+}

--- a/ios/uidriver/uidriver_test.go
+++ b/ios/uidriver/uidriver_test.go
@@ -1,0 +1,540 @@
+package uidriver_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/danielpaulus/go-ios/ios/uidriver"
+)
+
+// capturedRequest records what a test server received.
+type capturedRequest struct {
+	method string
+	path   string
+	query  string
+	body   []byte
+}
+
+// newRecordingServer returns a server that records the last request and replies
+// with the given status/body. Requests to the WDA /session endpoint always get
+// a session id so session-scoped actions can proceed.
+func newRecordingServer(t *testing.T, status int, respBody string) (*httptest.Server, *capturedRequest) {
+	t.Helper()
+	captured := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		// The WDA session-creation POST is bookkeeping; answer it and don't
+		// overwrite the recorded action request.
+		if r.URL.Path == "/session" && r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"sessionId":"sess-123"}`))
+			return
+		}
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.query = r.URL.RawQuery
+		captured.body = body
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, captured
+}
+
+func newDriver(t *testing.T, backend uidriver.Backend, baseURL string, opts ...uidriver.Option) *uidriver.Driver {
+	t.Helper()
+	d, err := uidriver.New(backend, baseURL, opts...)
+	if err != nil {
+		t.Fatalf("New(%s): %v", backend, err)
+	}
+	return d
+}
+
+func decodeJSONBody(t *testing.T, body []byte) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("body is not JSON object: %v (%s)", err, body)
+	}
+	return m
+}
+
+func TestNewValidation(t *testing.T) {
+	if _, err := uidriver.New("bogus", "http://x"); err == nil {
+		t.Fatal("expected error for unknown backend")
+	}
+	if _, err := uidriver.New(uidriver.BackendWDA, "  "); err == nil {
+		t.Fatal("expected error for empty baseURL")
+	}
+	d := newDriver(t, uidriver.BackendWDA, "http://127.0.0.1:8100/")
+	if d.BaseURL() != "http://127.0.0.1:8100" {
+		t.Fatalf("trailing slash not trimmed: %q", d.BaseURL())
+	}
+	if d.Backend() != uidriver.BackendWDA {
+		t.Fatalf("unexpected backend %q", d.Backend())
+	}
+}
+
+func TestDeviceKitTap(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{"result":"ok"}`)
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	resp, err := d.Tap(10, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if captured.method != http.MethodPost || captured.path != "/rpc" {
+		t.Fatalf("got %s %s, want POST /rpc", captured.method, captured.path)
+	}
+	rpc := decodeJSONBody(t, captured.body)
+	if rpc["jsonrpc"] != "2.0" || rpc["method"] != "device.io.tap" {
+		t.Fatalf("unexpected rpc envelope: %v", rpc)
+	}
+	params, _ := rpc["params"].(map[string]interface{})
+	if params["x"].(float64) != 10 || params["y"].(float64) != 20 {
+		t.Fatalf("unexpected params: %v", params)
+	}
+}
+
+func TestWDATap(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{"value":null}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	if _, err := d.Tap(5, 6); err != nil {
+		t.Fatal(err)
+	}
+	if captured.method != http.MethodPost {
+		t.Fatalf("method = %s", captured.method)
+	}
+	if captured.path != "/session/sess-123/wda/tap/5/6" {
+		t.Fatalf("path = %s", captured.path)
+	}
+	if d.SessionID() != "sess-123" {
+		t.Fatalf("session id not stored: %q", d.SessionID())
+	}
+}
+
+func TestWDASwipe(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	if _, err := d.Swipe(1, 2, 3, 4, 0.5); err != nil {
+		t.Fatal(err)
+	}
+	if captured.path != "/session/sess-123/wda/dragfromtoforduration" {
+		t.Fatalf("path = %s", captured.path)
+	}
+	body := decodeJSONBody(t, captured.body)
+	if body["fromX"].(float64) != 1 || body["toY"].(float64) != 4 || body["duration"].(float64) != 0.5 {
+		t.Fatalf("unexpected body: %v", body)
+	}
+}
+
+func TestDeviceKitSwipe(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	if _, err := d.Swipe(1, 2, 3, 4, 1.5); err != nil {
+		t.Fatal(err)
+	}
+	rpc := decodeJSONBody(t, captured.body)
+	if rpc["method"] != "device.io.swipe" {
+		t.Fatalf("method = %v", rpc["method"])
+	}
+}
+
+func TestWDAType(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	if _, err := d.Type("hello"); err != nil {
+		t.Fatal(err)
+	}
+	if captured.path != "/session/sess-123/keys" {
+		t.Fatalf("path = %s", captured.path)
+	}
+	body := decodeJSONBody(t, captured.body)
+	if body["text"] != "hello" {
+		t.Fatalf("text = %v", body["text"])
+	}
+	value, ok := body["value"].([]interface{})
+	if !ok || len(value) != 1 || value[0] != "hello" {
+		t.Fatalf("value = %v", body["value"])
+	}
+}
+
+func TestDeviceKitType(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	if _, err := d.Type("world"); err != nil {
+		t.Fatal(err)
+	}
+	rpc := decodeJSONBody(t, captured.body)
+	params := rpc["params"].(map[string]interface{})
+	if rpc["method"] != "device.io.text" || params["text"] != "world" {
+		t.Fatalf("unexpected: %v", rpc)
+	}
+}
+
+func TestWDAPressButtonHome(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	if _, err := d.PressButton("HOME"); err != nil {
+		t.Fatal(err)
+	}
+	if captured.path != "/session/sess-123/wda/homescreen" {
+		t.Fatalf("path = %s", captured.path)
+	}
+}
+
+func TestWDAPressButtonUnsupported(t *testing.T) {
+	srv, _ := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	_, err := d.PressButton("volumeup")
+	if !errors.Is(err, uidriver.ErrButtonUnsupported) {
+		t.Fatalf("want ErrButtonUnsupported, got %v", err)
+	}
+}
+
+func TestDeviceKitPressButton(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	if _, err := d.PressButton("lock"); err != nil {
+		t.Fatal(err)
+	}
+	rpc := decodeJSONBody(t, captured.body)
+	params := rpc["params"].(map[string]interface{})
+	if rpc["method"] != "device.io.button" || params["button"] != "lock" {
+		t.Fatalf("unexpected: %v", rpc)
+	}
+}
+
+func TestWDAOrientationGetSet(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{"value":"PORTRAIT"}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	if _, err := d.Orientation(); err != nil {
+		t.Fatal(err)
+	}
+	if captured.method != http.MethodGet || captured.path != "/session/sess-123/orientation" {
+		t.Fatalf("get: %s %s", captured.method, captured.path)
+	}
+
+	if _, err := d.SetOrientation("LANDSCAPE"); err != nil {
+		t.Fatal(err)
+	}
+	if captured.method != http.MethodPost || captured.path != "/session/sess-123/orientation" {
+		t.Fatalf("set: %s %s", captured.method, captured.path)
+	}
+	body := decodeJSONBody(t, captured.body)
+	if body["orientation"] != "LANDSCAPE" {
+		t.Fatalf("orientation = %v", body["orientation"])
+	}
+}
+
+func TestDeviceKitOrientation(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	if _, err := d.SetOrientation("PORTRAIT"); err != nil {
+		t.Fatal(err)
+	}
+	rpc := decodeJSONBody(t, captured.body)
+	if rpc["method"] != "device.io.orientation.set" {
+		t.Fatalf("method = %v", rpc["method"])
+	}
+}
+
+func TestWDAApp(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	if _, err := d.AppLaunch("com.example.app"); err != nil {
+		t.Fatal(err)
+	}
+	if captured.path != "/session/sess-123/wda/apps/launch" {
+		t.Fatalf("launch path = %s", captured.path)
+	}
+	body := decodeJSONBody(t, captured.body)
+	if body["bundleId"] != "com.example.app" {
+		t.Fatalf("bundleId = %v", body["bundleId"])
+	}
+
+	if _, err := d.AppTerminate("com.example.app"); err != nil {
+		t.Fatal(err)
+	}
+	if captured.path != "/session/sess-123/wda/apps/terminate" {
+		t.Fatalf("terminate path = %s", captured.path)
+	}
+}
+
+func TestDeviceKitApp(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	if _, err := d.AppLaunch("com.example.app"); err != nil {
+		t.Fatal(err)
+	}
+	rpc := decodeJSONBody(t, captured.body)
+	params := rpc["params"].(map[string]interface{})
+	if rpc["method"] != "device.apps.launch" || params["bundleId"] != "com.example.app" {
+		t.Fatalf("unexpected: %v", rpc)
+	}
+}
+
+func TestAppForegroundUnsupportedOnWDA(t *testing.T) {
+	srv, _ := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	_, err := d.AppForeground()
+	if !errors.Is(err, uidriver.ErrForegroundUnsupported) {
+		t.Fatalf("want ErrForegroundUnsupported, got %v", err)
+	}
+}
+
+func TestDeviceKitAppForeground(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	if _, err := d.AppForeground(); err != nil {
+		t.Fatal(err)
+	}
+	rpc := decodeJSONBody(t, captured.body)
+	if rpc["method"] != "device.apps.foreground" {
+		t.Fatalf("method = %v", rpc["method"])
+	}
+}
+
+func TestStatus(t *testing.T) {
+	// DeviceKit hits /health.
+	dkSrv, dkCaptured := newRecordingServer(t, http.StatusOK, `{"status":"ok"}`)
+	dk := newDriver(t, uidriver.BackendDeviceKit, dkSrv.URL)
+	resp, err := dk.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dkCaptured.method != http.MethodGet || dkCaptured.path != "/health" {
+		t.Fatalf("devicekit status: %s %s", dkCaptured.method, dkCaptured.path)
+	}
+	parsed := decodeJSONBody(t, resp.Body)
+	if parsed["status"] != "ok" {
+		t.Fatalf("status body = %v", parsed)
+	}
+
+	// WDA hits /status.
+	wdaSrv, wdaCaptured := newRecordingServer(t, http.StatusOK, `{"value":{"state":"success"}}`)
+	wda := newDriver(t, uidriver.BackendWDA, wdaSrv.URL)
+	if _, err := wda.Status(); err != nil {
+		t.Fatal(err)
+	}
+	if wdaCaptured.path != "/status" {
+		t.Fatalf("wda status path = %s", wdaCaptured.path)
+	}
+}
+
+func TestScreenshotDecodesBase64(t *testing.T) {
+	raw := []byte("this-is-a-png")
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	body, _ := json.Marshal(map[string]interface{}{"value": encoded})
+	srv, _ := newRecordingServer(t, http.StatusOK, string(body))
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	img, err := d.Screenshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(img) != string(raw) {
+		t.Fatalf("decoded image mismatch: %q", img)
+	}
+}
+
+func TestScreenshotNoImage(t *testing.T) {
+	srv, _ := newRecordingServer(t, http.StatusOK, `{"value":{}}`)
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	if _, err := d.Screenshot(); err == nil {
+		t.Fatal("expected error when no base64 image present")
+	}
+}
+
+func TestSourceAndWindowSize(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{"value":"<xml/>"}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	if _, err := d.Source(); err != nil {
+		t.Fatal(err)
+	}
+	if captured.path != "/session/sess-123/source" {
+		t.Fatalf("source path = %s", captured.path)
+	}
+	if _, err := d.WindowSize(); err != nil {
+		t.Fatal(err)
+	}
+	if captured.path != "/session/sess-123/window/size" {
+		t.Fatalf("window size path = %s", captured.path)
+	}
+}
+
+func TestAPIPassthroughWDA(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	if _, err := d.API(uidriver.APIRequest{Method: "post", Path: "/wda/deactivateApp", Body: []byte(`{"duration":2}`)}); err != nil {
+		t.Fatal(err)
+	}
+	if captured.method != http.MethodPost || captured.path != "/wda/deactivateApp" {
+		t.Fatalf("api: %s %s", captured.method, captured.path)
+	}
+	if string(captured.body) != `{"duration":2}` {
+		t.Fatalf("body = %s", captured.body)
+	}
+
+	// Missing path is an error.
+	if _, err := d.API(uidriver.APIRequest{}); err == nil {
+		t.Fatal("expected error for missing path")
+	}
+}
+
+func TestAPIPassthroughDeviceKit(t *testing.T) {
+	srv, captured := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	if _, err := d.API(uidriver.APIRequest{RPCMethod: "device.custom", RPCParams: map[string]interface{}{"k": "v"}}); err != nil {
+		t.Fatal(err)
+	}
+	rpc := decodeJSONBody(t, captured.body)
+	params := rpc["params"].(map[string]interface{})
+	if rpc["method"] != "device.custom" || params["k"] != "v" {
+		t.Fatalf("unexpected: %v", rpc)
+	}
+
+	// Missing rpc method is an error.
+	if _, err := d.API(uidriver.APIRequest{}); err == nil {
+		t.Fatal("expected error for missing rpc method")
+	}
+}
+
+func TestHTTPErrorOnNon2xx(t *testing.T) {
+	srv, _ := newRecordingServer(t, http.StatusBadRequest, `{"error":"bad"}`)
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+
+	_, err := d.Tap(1, 1)
+	var httpErr *uidriver.HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("want *HTTPError, got %v", err)
+	}
+	if httpErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d", httpErr.StatusCode)
+	}
+	if !strings.Contains(httpErr.Error(), "bad") {
+		t.Fatalf("error message missing body: %s", httpErr.Error())
+	}
+}
+
+func TestHealthy(t *testing.T) {
+	okSrv, _ := newRecordingServer(t, http.StatusOK, `{}`)
+	if !newDriver(t, uidriver.BackendDeviceKit, okSrv.URL).Healthy() {
+		t.Fatal("expected healthy")
+	}
+	badSrv, _ := newRecordingServer(t, http.StatusInternalServerError, `{}`)
+	if newDriver(t, uidriver.BackendWDA, badSrv.URL).Healthy() {
+		t.Fatal("expected unhealthy on 5xx")
+	}
+	if newDriver(t, uidriver.BackendWDA, "http://127.0.0.1:1").Healthy() {
+		t.Fatal("expected unhealthy on connection error")
+	}
+}
+
+func TestStreamPipesChunkedBody(t *testing.T) {
+	chunks := []string{"frame-1", "frame-2", "frame-3"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mjpeg" {
+			t.Errorf("stream path = %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("fps") != "30" || r.URL.Query().Get("quality") != "80" {
+			t.Errorf("stream query = %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "multipart/x-mixed-replace")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for _, c := range chunks {
+			_, _ = w.Write([]byte(c))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+	body, err := d.Stream(context.Background(), uidriver.StreamOptions{FPS: "30", Quality: "80"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = body.Close() }()
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != strings.Join(chunks, "") {
+		t.Fatalf("stream body = %q", got)
+	}
+}
+
+func TestStreamH264RejectedOnWDA(t *testing.T) {
+	srv, _ := newRecordingServer(t, http.StatusOK, `{}`)
+	d := newDriver(t, uidriver.BackendWDA, srv.URL)
+
+	_, err := d.Stream(context.Background(), uidriver.StreamOptions{H264: true})
+	if !errors.Is(err, uidriver.ErrStreamUnsupported) {
+		t.Fatalf("want ErrStreamUnsupported, got %v", err)
+	}
+}
+
+func TestStreamNon2xxReturnsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("no stream"))
+	}))
+	defer srv.Close()
+
+	d := newDriver(t, uidriver.BackendDeviceKit, srv.URL)
+	_, err := d.Stream(context.Background(), uidriver.StreamOptions{})
+	var httpErr *uidriver.HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("want *HTTPError, got %v", err)
+	}
+}
+
+func TestWithSessionIDSkipsCreation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/session" {
+			t.Errorf("session should not be created when WithSessionID is set")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	d := newDriver(t, uidriver.BackendWDA, srv.URL, uidriver.WithSessionID("preset"))
+	if _, err := d.Tap(1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if d.SessionID() != "preset" {
+		t.Fatalf("session id = %q", d.SessionID())
+	}
+}


### PR DESCRIPTION
## What

Extracts the private WDA/DeviceKit UI-automation HTTP client that lived inside `cmd_ui.go` (the `uiClient` type and its `wdaHTTP`/`deviceKitRPC`/`pipeHTTP` machinery) into a new, exported **`ios/uidriver`** package.

- `uidriver.New(backend, baseURL, opts...)` constructs a `Driver` bound to a backend (`BackendWDA` / `BackendDeviceKit`) at a base URL — typically the local end of a forwarded connection to WDA (`:8100`) or DeviceKit (`:12004`). Not tied to the CLI.
- Exported action methods: `Tap`, `Swipe`, `LongPress`, `Type`, `PressButton`, `Screenshot`, `Source`, `WindowSize`, `Orientation`/`SetOrientation`, `AppLaunch`/`AppTerminate`/`AppForeground`, `Status`, `API` (raw WDA-HTTP / DeviceKit-RPC passthrough), and `Stream` (returns the backend mjpeg/h264 body as an `io.ReadCloser` for callers to pipe).
- All methods return values + errors instead of `os.Exit`, so the package is embeddable. Request/response types (`Response`, `APIRequest`, `StreamOptions`, `HTTPError`, sentinel errors) are exported and JSON-tagged.
- Options: `WithHTTPClient`, `WithTimeout`, `WithSessionID`, `WithUDID`. Logging via `golog` with `const logModule = "go-ios/uidriver"`.

`cmd_ui.go` now keeps only CLI arg parsing, backend resolution (`wda`/`devicekit`/`auto`, with health probing for auto) and output formatting, delegating all HTTP work to the driver. **CLI behavior is unchanged** — every `ios ui ...` subcommand hits the same endpoints/methods/bodies as before, and non-2xx responses still exit 1 with the backend body surfaced.

## Why

This is the prerequisite for the REST `ui` endpoints wave: the REST API (and other embedders) can now drive UI automation through the same driver instead of shelling out or duplicating the HTTP wiring.

## Tests

Adds `ios/uidriver` unit tests that drive the client against an in-process `httptest.Server` standing in for WDA/DeviceKit, asserting the correct HTTP method/path/body for tap/swipe/type/button/orientation/app/status/screenshot/source/api, base64 screenshot decoding, `*HTTPError` on non-2xx, health probing, and the streaming helper against a chunked server. `go build ./... && go vet ./... && go test ./...` all pass; `gofmt` clean on changed files.

## Note for the REST ui-endpoints wave

Construct the driver against a forwarded WDA/DeviceKit address, e.g.
`d, err := uidriver.New(uidriver.BackendWDA, "http://127.0.0.1:<forwardedPort>", uidriver.WithUDID(udid))`,
then call the action methods. `Stream(ctx, opts)` returns an `io.ReadCloser` you own and must `Close`. `restapi/` was intentionally left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk