### PR TITLE
test(e2e): real-device coverage for instruments network/fps + file ls

### DIFF
--- a/test/e2e/harness/harness.go
+++ b/test/e2e/harness/harness.go
@@ -222,6 +222,52 @@ func StreamSmoke(t *testing.T, udid string, window time.Duration, args ...string
 	return b
 }
 
+// StreamNDJSON runs a self-terminating streaming ios command (one that stops on
+// its own, e.g. via --duration) and returns each non-empty stdout line decoded
+// as a JSON object. Unlike StreamSmoke it does not kill the process — the
+// command must exit on its own within timeout, which is asserted (a command that
+// hangs past its --duration is a real bug, not something to paper over by
+// killing it). Fails the test if the command errors, does not terminate, or
+// emits a stdout line that is not a well-formed JSON object.
+func StreamNDJSON(t *testing.T, udid string, timeout time.Duration, args ...string) []map[string]any {
+	t.Helper()
+	var out, stderr bytes.Buffer
+	cmd := exec.Command(iosBin, append(args, "--udid="+udid)...)
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("ios %v: start: %v", args, err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ios %v: %v\nstderr: %s\nstdout: %s", args, err, stderr.String(), snippet(out.Bytes()))
+		}
+	case <-time.After(timeout):
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		<-done
+		t.Fatalf("ios %v: did not terminate within %s (command should self-stop via --duration)\nstdout so far: %s", args, timeout, snippet(out.Bytes()))
+	}
+
+	var samples []map[string]any
+	for _, line := range bytes.Split(out.Bytes(), []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("ios %v: stdout line is not a JSON object: %v\nline: %s", args, err, snippet(line))
+		}
+		samples = append(samples, m)
+	}
+	return samples
+}
+
 // StreamInTempDir runs a streaming ios command in a fresh temp directory for
 // window, then kills its process group, and returns the directory so the caller
 // can inspect files the command wrote there (e.g. pcap's dump-*.pcap).

--- a/test/e2e/preios17/instruments_stream_test.go
+++ b/test/e2e/preios17/instruments_stream_test.go
@@ -8,7 +8,11 @@
 package preios17_test
 
 import (
+	"bufio"
+	"encoding/json"
 	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -48,15 +52,38 @@ func TestInstrumentsFPS(t *testing.T) {
 	})
 }
 
-// TestInstrumentsNetwork streams network-monitoring samples and asserts the
-// command self-terminates and emits well-formed {"type": <number>, "data": ...}
-// envelopes.
+// networkStreamSeconds bounds the network stream. The instruments
+// network-monitoring service only emits samples when there is actual network
+// activity (an idle device produces none), so we stream for a longer window
+// while generating traffic (launch/kill churn) and assert well-formed
+// {"type": <number>, "data": ...} envelopes arrived before the command
+// self-terminated via --duration.
+const networkStreamSeconds = 20
+
+// TestInstrumentsNetwork streams network-monitoring samples while generating
+// traffic on the device and asserts the command self-terminates and emits
+// well-formed {"type": <number>, "data": ...} envelopes.
 func TestInstrumentsNetwork(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) {
-		samples := streamNDJSON(t, udid, instrumentsSampleWindow,
-			"instruments", "network", "--duration="+strconv.Itoa(instrSampleDurationSeconds))
+		output, stop := startBackground(t, udid, syscall.SIGTERM,
+			"instruments", "network", "--duration="+strconv.Itoa(networkStreamSeconds))
+		defer stop()
+
+		// Generate network traffic for most of the streaming window by churning
+		// app launches (Settings phones home on launch on these OS versions).
+		deadline := time.Now().Add(time.Duration(networkStreamSeconds-3) * time.Second)
+		for time.Now().Before(deadline) {
+			runIOSForDevice(t, udid, "launch", "com.apple.Preferences")
+			runIOSForDevice(t, udid, "launch", "com.apple.mobilesafari")
+			time.Sleep(2 * time.Second)
+		}
+
+		// Let the --duration-bounded command reach its deadline and flush.
+		time.Sleep(6 * time.Second)
+
+		samples := parseNetworkSamples(t, output())
 		if len(samples) == 0 {
-			t.Fatalf("instruments network: no samples in %ds window", instrSampleDurationSeconds)
+			t.Fatalf("instruments network: no samples in %ds window even with generated traffic", networkStreamSeconds)
 		}
 		for i, s := range samples {
 			if _, ok := s["type"].(float64); !ok {
@@ -70,6 +97,29 @@ func TestInstrumentsNetwork(t *testing.T) {
 		}
 		logInstrumentsSamples(t, "network", udid, samples)
 	})
+}
+
+// parseNetworkSamples decodes the JSON-object lines the streaming command wrote,
+// ignoring any interleaved non-JSON log noise from the background runner.
+func parseNetworkSamples(t *testing.T, out string) []map[string]any {
+	t.Helper()
+	var samples []map[string]any
+	sc := bufio.NewScanner(strings.NewReader(out))
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			continue
+		}
+		if _, ok := m["type"]; ok {
+			samples = append(samples, m)
+		}
+	}
+	return samples
 }
 
 func logInstrumentsSamples(t *testing.T, kind, udid string, samples []map[string]any) {

--- a/test/e2e/preios17/instruments_stream_test.go
+++ b/test/e2e/preios17/instruments_stream_test.go
@@ -1,0 +1,86 @@
+//go:build e2e
+
+// Streaming instruments/DTX commands on pre-iOS17 devices: these reach the
+// graphics (FPS) and network-monitoring DTX services over usbmuxd with only a
+// mounted Developer Disk Image (done in TestMain) and NO tunnel. The tunnel
+// suite proves the same commands over the iOS 17+ tunnel; this proves them on
+// the classic transport.
+package preios17_test
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+// instrumentsSampleWindow bounds a --duration=<n> streaming run: the command
+// must self-terminate within it (slack over the sampling duration for DTX
+// connection setup and teardown).
+const (
+	instrSampleDurationSeconds = 5
+	instrumentsSampleWindow    = 30 * time.Second
+)
+
+// TestInstrumentsFPS streams frames-per-second samples from the graphics OpenGL
+// service and asserts the command self-terminates and emits well-formed
+// {"fps": <number>} samples (an idle screen still emits CoreAnimation frames).
+func TestInstrumentsFPS(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		samples := streamNDJSON(t, udid, instrumentsSampleWindow,
+			"instruments", "fps", "--duration="+strconv.Itoa(instrSampleDurationSeconds))
+		if len(samples) == 0 {
+			t.Fatalf("instruments fps: no samples in %ds window", instrSampleDurationSeconds)
+		}
+		for i, s := range samples {
+			v, ok := s["fps"]
+			if !ok {
+				t.Fatalf("instruments fps sample %d missing \"fps\": %v", i, s)
+			}
+			f, ok := v.(float64)
+			if !ok {
+				t.Fatalf("instruments fps sample %d \"fps\" not numeric: %T %v", i, v, v)
+			}
+			if f < 0 {
+				t.Fatalf("instruments fps sample %d negative fps: %v", i, f)
+			}
+		}
+		logInstrumentsSamples(t, "fps", udid, samples)
+	})
+}
+
+// TestInstrumentsNetwork streams network-monitoring samples and asserts the
+// command self-terminates and emits well-formed {"type": <number>, "data": ...}
+// envelopes.
+func TestInstrumentsNetwork(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		samples := streamNDJSON(t, udid, instrumentsSampleWindow,
+			"instruments", "network", "--duration="+strconv.Itoa(instrSampleDurationSeconds))
+		if len(samples) == 0 {
+			t.Fatalf("instruments network: no samples in %ds window", instrSampleDurationSeconds)
+		}
+		for i, s := range samples {
+			if _, ok := s["type"].(float64); !ok {
+				t.Fatalf("instruments network sample %d \"type\" missing or not numeric: %v", i, s)
+			}
+			if d, ok := s["data"]; ok && d != nil {
+				if _, ok := d.(map[string]any); !ok {
+					t.Fatalf("instruments network sample %d \"data\" not an object: %T", i, d)
+				}
+			}
+		}
+		logInstrumentsSamples(t, "network", udid, samples)
+	})
+}
+
+func logInstrumentsSamples(t *testing.T, kind, udid string, samples []map[string]any) {
+	t.Helper()
+	const max = 5
+	shown := samples
+	if len(shown) > max {
+		shown = shown[:max]
+	}
+	t.Logf("instruments %s [%s]: %d samples, first %d:", kind, udid, len(samples), len(shown))
+	for i, s := range shown {
+		t.Logf("  sample %d: %v", i, s)
+	}
+}

--- a/test/e2e/preios17/instruments_stream_test.go
+++ b/test/e2e/preios17/instruments_stream_test.go
@@ -8,11 +8,7 @@
 package preios17_test
 
 import (
-	"bufio"
-	"encoding/json"
 	"strconv"
-	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -21,8 +17,9 @@ import (
 // must self-terminate within it (slack over the sampling duration for DTX
 // connection setup and teardown).
 const (
-	instrSampleDurationSeconds = 5
-	instrumentsSampleWindow    = 30 * time.Second
+	fpsDurationSeconds      = 5
+	networkDurationSeconds  = 8
+	instrumentsSampleWindow = 30 * time.Second
 )
 
 // TestInstrumentsFPS streams frames-per-second samples from the graphics OpenGL
@@ -31,9 +28,9 @@ const (
 func TestInstrumentsFPS(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) {
 		samples := streamNDJSON(t, udid, instrumentsSampleWindow,
-			"instruments", "fps", "--duration="+strconv.Itoa(instrSampleDurationSeconds))
+			"instruments", "fps", "--duration="+strconv.Itoa(fpsDurationSeconds))
 		if len(samples) == 0 {
-			t.Fatalf("instruments fps: no samples in %ds window", instrSampleDurationSeconds)
+			t.Fatalf("instruments fps: no samples in %ds window", fpsDurationSeconds)
 		}
 		for i, s := range samples {
 			v, ok := s["fps"]
@@ -52,39 +49,16 @@ func TestInstrumentsFPS(t *testing.T) {
 	})
 }
 
-// networkStreamSeconds bounds the network stream. The instruments
-// network-monitoring service only emits samples when there is actual network
-// activity (an idle device produces none), so we stream for a longer window
-// while generating traffic (launch/kill churn) and assert well-formed
-// {"type": <number>, "data": ...} envelopes arrived before the command
-// self-terminated via --duration.
-const networkStreamSeconds = 20
-
-// TestInstrumentsNetwork streams network-monitoring samples while generating
-// traffic on the device and asserts the command self-terminates and emits
-// well-formed {"type": <number>, "data": ...} envelopes.
+// TestInstrumentsNetwork streams network-monitoring samples and asserts the
+// command self-terminates and that every sample it emits is a well-formed
+// {"type": <number>, "data": ...} envelope. The network service only reports
+// samples when the device has real traffic, so a quiescent CI device can emit
+// zero; the count is logged, not required (see the tunnel suite's network test
+// for why traffic is not force-generated here).
 func TestInstrumentsNetwork(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) {
-		output, stop := startBackground(t, udid, syscall.SIGTERM,
-			"instruments", "network", "--duration="+strconv.Itoa(networkStreamSeconds))
-		defer stop()
-
-		// Generate network traffic for most of the streaming window by churning
-		// app launches (Settings phones home on launch on these OS versions).
-		deadline := time.Now().Add(time.Duration(networkStreamSeconds-3) * time.Second)
-		for time.Now().Before(deadline) {
-			runIOSForDevice(t, udid, "launch", "com.apple.Preferences")
-			runIOSForDevice(t, udid, "launch", "com.apple.mobilesafari")
-			time.Sleep(2 * time.Second)
-		}
-
-		// Let the --duration-bounded command reach its deadline and flush.
-		time.Sleep(6 * time.Second)
-
-		samples := parseNetworkSamples(t, output())
-		if len(samples) == 0 {
-			t.Fatalf("instruments network: no samples in %ds window even with generated traffic", networkStreamSeconds)
-		}
+		samples := streamNDJSON(t, udid, instrumentsSampleWindow,
+			"instruments", "network", "--duration="+strconv.Itoa(networkDurationSeconds))
 		for i, s := range samples {
 			if _, ok := s["type"].(float64); !ok {
 				t.Fatalf("instruments network sample %d \"type\" missing or not numeric: %v", i, s)
@@ -97,29 +71,6 @@ func TestInstrumentsNetwork(t *testing.T) {
 		}
 		logInstrumentsSamples(t, "network", udid, samples)
 	})
-}
-
-// parseNetworkSamples decodes the JSON-object lines the streaming command wrote,
-// ignoring any interleaved non-JSON log noise from the background runner.
-func parseNetworkSamples(t *testing.T, out string) []map[string]any {
-	t.Helper()
-	var samples []map[string]any
-	sc := bufio.NewScanner(strings.NewReader(out))
-	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	for sc.Scan() {
-		line := strings.TrimSpace(sc.Text())
-		if !strings.HasPrefix(line, "{") {
-			continue
-		}
-		var m map[string]any
-		if err := json.Unmarshal([]byte(line), &m); err != nil {
-			continue
-		}
-		if _, ok := m["type"]; ok {
-			samples = append(samples, m)
-		}
-	}
-	return samples
 }
 
 func logInstrumentsSamples(t *testing.T, kind, udid string, samples []map[string]any) {

--- a/test/e2e/preios17/main_test.go
+++ b/test/e2e/preios17/main_test.go
@@ -60,6 +60,10 @@ func streamSmoke(t *testing.T, udid string, window time.Duration, args ...string
 	return harness.StreamSmoke(t, udid, window, args...)
 }
 
+func streamNDJSON(t *testing.T, udid string, timeout time.Duration, args ...string) []map[string]any {
+	return harness.StreamNDJSON(t, udid, timeout, args...)
+}
+
 func startBackground(t *testing.T, udid string, stopSig syscall.Signal, args ...string) (output func() string, stop func()) {
 	return harness.StartBackground(t, udid, stopSig, args...)
 }

--- a/test/e2e/tunnel/file_test.go
+++ b/test/e2e/tunnel/file_test.go
@@ -8,7 +8,11 @@ import "testing"
 // exist is volatile, but assert count is consistent with the files array and a
 // path is reported.
 
-func fileLs(t *testing.T, udid, mode string) {
+// fileLs runs `ios file ls <mode>`, asserts the JSON envelope (path/files/count
+// are self-consistent) and that every listed entry is a non-empty filename
+// string (fileservice.ListDirectory returns a []string of names). It returns the
+// decoded file names so callers can make stronger per-domain assertions.
+func fileLs(t *testing.T, udid, mode string) []string {
 	t.Helper()
 	m := smokeObj(t, udid, []string{"count", "files", "path"}, "file", "ls", mode)
 	files, _ := m["files"].([]any)
@@ -19,12 +23,37 @@ func fileLs(t *testing.T, udid, mode string) {
 	if p, _ := m["path"].(string); p == "" {
 		t.Fatalf("file ls %s: empty path", mode)
 	}
+	names := make([]string, 0, len(files))
+	for i, f := range files {
+		name, ok := f.(string)
+		if !ok {
+			t.Fatalf("file ls %s: entry %d is not a filename string: %T %v", mode, i, f, f)
+		}
+		if name == "" {
+			t.Fatalf("file ls %s: entry %d is an empty filename", mode, i)
+		}
+		names = append(names, name)
+	}
+	t.Logf("file ls %s [%s]: %d entries: %v", mode, udid, len(names), names)
+	return names
 }
 
+// TestFileLsCrash lists the system crash-logs domain root. This domain reliably
+// contains entries on a real device (crash .ips files and standard subdirectories
+// such as Retired / DiagnosticLogs), so require a non-empty listing — an empty
+// crash domain root would be surprising and worth investigating rather than
+// silently passing.
 func TestFileLsCrash(t *testing.T) {
-	forEachDevice(t, func(t *testing.T, udid string) { fileLs(t, udid, "--crash") })
+	forEachDevice(t, func(t *testing.T, udid string) {
+		names := fileLs(t, udid, "--crash")
+		if len(names) == 0 {
+			t.Fatalf("file ls --crash: empty listing for the system crash-logs domain root (unexpected on a real device)")
+		}
+	})
 }
 
+// TestFileLsTemp lists the app temporary domain root. It may legitimately be
+// empty, so only the envelope + entry shape (asserted in fileLs) are checked.
 func TestFileLsTemp(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) { fileLs(t, udid, "--temp") })
 }

--- a/test/e2e/tunnel/helpers_test.go
+++ b/test/e2e/tunnel/helpers_test.go
@@ -10,6 +10,7 @@ package tunnel_test
 import (
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/danielpaulus/go-ios/test/e2e/harness"
 )
@@ -40,6 +41,10 @@ func runIOSForDevice(t *testing.T, udid string, args ...string) []byte {
 
 func startBackground(t *testing.T, udid string, stopSig syscall.Signal, args ...string) (output func() string, stop func()) {
 	return harness.StartBackground(t, udid, stopSig, args...)
+}
+
+func streamNDJSON(t *testing.T, udid string, timeout time.Duration, args ...string) []map[string]any {
+	return harness.StreamNDJSON(t, udid, timeout, args...)
 }
 
 func forEachDevice(t *testing.T, fn func(t *testing.T, udid string)) {

--- a/test/e2e/tunnel/instruments_fps_test.go
+++ b/test/e2e/tunnel/instruments_fps_test.go
@@ -1,0 +1,52 @@
+//go:build e2e
+
+package tunnel_test
+
+import (
+	"testing"
+	"time"
+)
+
+// instrumentsSampleWindow bounds a --duration=<fpsDurationSeconds> streaming
+// run: the command must terminate on its own within this window (a few seconds
+// of slack over the sampling duration for connection setup and teardown).
+const (
+	fpsDurationSeconds      = 5
+	networkDurationSeconds  = 5
+	instrumentsSampleWindow = 30 * time.Second
+)
+
+// TestInstrumentsFPS streams frames-per-second samples from the instruments
+// graphics (OpenGL) service over the iOS 17+ tunnel for a bounded duration and
+// asserts the command self-terminates and emits well-formed {"fps": <number>}
+// samples. Even an idle screen still emits CoreAnimation frame samples, so at
+// least one sample must arrive within the window.
+func TestInstrumentsFPS(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		assertFPSSamples(t, udid)
+	})
+}
+
+func assertFPSSamples(t *testing.T, udid string) {
+	t.Helper()
+	samples := streamNDJSON(t, udid, instrumentsSampleWindow,
+		"instruments", "fps", "--duration="+itoa(fpsDurationSeconds))
+
+	if len(samples) == 0 {
+		t.Fatalf("instruments fps: no samples in %ds window (idle screen still emits frames)", fpsDurationSeconds)
+	}
+	for i, s := range samples {
+		v, ok := s["fps"]
+		if !ok {
+			t.Fatalf("instruments fps sample %d missing \"fps\" field: %v", i, s)
+		}
+		f, ok := v.(float64)
+		if !ok {
+			t.Fatalf("instruments fps sample %d \"fps\" is not numeric: %T %v", i, v, v)
+		}
+		if f < 0 {
+			t.Fatalf("instruments fps sample %d has negative fps: %v", i, f)
+		}
+	}
+	logSamples(t, "fps", udid, samples)
+}

--- a/test/e2e/tunnel/instruments_network_test.go
+++ b/test/e2e/tunnel/instruments_network_test.go
@@ -3,98 +3,41 @@
 package tunnel_test
 
 import (
-	"bufio"
-	"encoding/json"
 	"strconv"
-	"strings"
-	"syscall"
 	"testing"
-	"time"
 )
 
-// The instruments network-monitoring service only emits samples when there is
-// actual network activity — an idle device produces none (go-ios's own README
-// notes "open apple maps or similar to force network traffic"). So we stream for
-// a longer, --duration-bounded window while generating traffic on the device (a
-// networked app plus repeated launch/kill churn), then assert well-formed
-// {"type": <number>, "data": ...} envelopes arrived and the command self-stopped.
-const (
-	networkStreamSeconds = 20
-	// networkApp is a system app that phones home on launch, generating traffic.
-	networkApp = "com.apple.AppStore"
-)
+// The instruments network-monitoring service only emits samples when the device
+// has actual network activity; a quiescent CI device can legitimately produce
+// zero samples in a short window (go-ios's own README notes "open apple maps to
+// force network traffic"). Driving traffic by hammering app launches over the
+// same instruments/DTX transport that carries the network stream destabilises
+// that shared channel (launch/kill time out), so we do NOT do that. Instead this
+// test pins the reliable contract: the command connects to the network service,
+// streams for its bounded --duration, self-terminates cleanly, and every sample
+// it DOES emit is a well-formed {"type": <number>, "data": ...} envelope. The
+// sample count is logged (real on-device data when traffic happens to occur) but
+// not required, mirroring how the suite treats other volatile streamed output.
+
+const networkStreamSeconds = 8
 
 func TestInstrumentsNetwork(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) {
-		assertNetworkSamples(t, udid)
-	})
-}
+		samples := streamNDJSON(t, udid, instrumentsSampleWindow,
+			"instruments", "network", "--duration="+itoa(networkStreamSeconds))
 
-func assertNetworkSamples(t *testing.T, udid string) {
-	t.Helper()
-
-	// Start the bounded network stream in the background so we can drive traffic
-	// on the device while it collects samples. --duration makes it self-terminate.
-	output, stop := startBackground(t, udid, syscall.SIGTERM,
-		"instruments", "network", "--duration="+strconv.Itoa(networkStreamSeconds))
-	defer stop()
-
-	// Generate network traffic for most of the streaming window: launch a
-	// networked app (phones home) and churn launch/kill so the network service
-	// has activity to report.
-	deadline := time.Now().Add(time.Duration(networkStreamSeconds-3) * time.Second)
-	runIOSForDevice(t, udid, "launch", networkApp)
-	for time.Now().Before(deadline) {
-		runIOSForDevice(t, udid, "launch", "com.apple.Preferences")
-		runIOSForDevice(t, udid, "launch", networkApp)
-		time.Sleep(2 * time.Second)
-	}
-	runIOSForDevice(t, udid, "kill", networkApp)
-
-	// Give the --duration-bounded command time to reach its deadline and flush
-	// its final samples, then read what it collected. The deferred stop() cleans
-	// up the (by now self-terminated) process group.
-	time.Sleep(6 * time.Second)
-
-	samples := parseNetworkSamples(t, output())
-	if len(samples) == 0 {
-		t.Fatalf("instruments network: no samples in %ds window even with generated traffic (real service/CLI issue?)", networkStreamSeconds)
-	}
-	for i, s := range samples {
-		if _, ok := s["type"].(float64); !ok {
-			t.Fatalf("instruments network sample %d \"type\" missing or not numeric: %v", i, s)
-		}
-		if d, ok := s["data"]; ok && d != nil {
-			if _, ok := d.(map[string]any); !ok {
-				t.Fatalf("instruments network sample %d \"data\" is not an object: %T", i, d)
+		for i, s := range samples {
+			if _, ok := s["type"].(float64); !ok {
+				t.Fatalf("instruments network sample %d \"type\" missing or not numeric: %v", i, s)
+			}
+			if d, ok := s["data"]; ok && d != nil {
+				if _, ok := d.(map[string]any); !ok {
+					t.Fatalf("instruments network sample %d \"data\" is not an object: %T", i, d)
+				}
 			}
 		}
-	}
-	logSamples(t, "network", udid, samples)
-}
-
-// parseNetworkSamples decodes the JSON-object lines the streaming command wrote
-// to stdout, ignoring any non-JSON log noise the background runner may have
-// interleaved on the same stream.
-func parseNetworkSamples(t *testing.T, out string) []map[string]any {
-	t.Helper()
-	var samples []map[string]any
-	sc := bufio.NewScanner(strings.NewReader(out))
-	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	for sc.Scan() {
-		line := strings.TrimSpace(sc.Text())
-		if !strings.HasPrefix(line, "{") {
-			continue
-		}
-		var m map[string]any
-		if err := json.Unmarshal([]byte(line), &m); err != nil {
-			continue
-		}
-		if _, ok := m["type"]; ok {
-			samples = append(samples, m)
-		}
-	}
-	return samples
+		logSamples(t, "network", udid, samples)
+	})
 }
 
 // itoa is a tiny local alias so the streaming tests read cleanly.

--- a/test/e2e/tunnel/instruments_network_test.go
+++ b/test/e2e/tunnel/instruments_network_test.go
@@ -1,0 +1,66 @@
+//go:build e2e
+
+package tunnel_test
+
+import (
+	"strconv"
+	"testing"
+)
+
+// TestInstrumentsNetwork streams network-monitoring samples from the instruments
+// network service over the iOS 17+ tunnel for a bounded duration and asserts the
+// command self-terminates and emits well-formed samples. Each sample is a
+// {"type": <number>, "data": {...}} object (see networkSampleOutput in
+// cmd_device_debug.go). The service reports interface and per-connection
+// counters; go-ios keeps the decoded payload under "data", whose exact shape
+// varies by message type, so we assert the envelope (numeric type + data map)
+// rather than a fixed inner schema.
+func TestInstrumentsNetwork(t *testing.T) {
+	forEachDevice(t, func(t *testing.T, udid string) {
+		assertNetworkSamples(t, udid)
+	})
+}
+
+func assertNetworkSamples(t *testing.T, udid string) {
+	t.Helper()
+	samples := streamNDJSON(t, udid, instrumentsSampleWindow,
+		"instruments", "network", "--duration="+itoa(networkDurationSeconds))
+
+	if len(samples) == 0 {
+		t.Fatalf("instruments network: no samples in %ds window", networkDurationSeconds)
+	}
+	for i, s := range samples {
+		if _, ok := s["type"]; !ok {
+			t.Fatalf("instruments network sample %d missing \"type\": %v", i, s)
+		}
+		if _, ok := s["type"].(float64); !ok {
+			t.Fatalf("instruments network sample %d \"type\" is not numeric: %T", i, s["type"])
+		}
+		// "data" is present (may be null for some message types), but when it is
+		// an object it must decode as a map — the CLI marshals it as such.
+		if d, ok := s["data"]; ok && d != nil {
+			if _, ok := d.(map[string]any); !ok {
+				t.Fatalf("instruments network sample %d \"data\" is not an object: %T", i, d)
+			}
+		}
+	}
+	logSamples(t, "network", udid, samples)
+}
+
+// itoa is a tiny local alias so the streaming tests read cleanly.
+func itoa(n int) string { return strconv.Itoa(n) }
+
+// logSamples t.Logs a handful of the real decoded samples so `go test -v` shows
+// actual on-device data (fps values / network envelopes) in the CI logs.
+func logSamples(t *testing.T, kind, udid string, samples []map[string]any) {
+	t.Helper()
+	const max = 5
+	shown := samples
+	if len(shown) > max {
+		shown = shown[:max]
+	}
+	t.Logf("instruments %s [%s]: %d samples, first %d:", kind, udid, len(samples), len(shown))
+	for i, s := range shown {
+		t.Logf("  sample %d: %v", i, s)
+	}
+}

--- a/test/e2e/tunnel/instruments_network_test.go
+++ b/test/e2e/tunnel/instruments_network_test.go
@@ -3,18 +3,27 @@
 package tunnel_test
 
 import (
+	"bufio"
+	"encoding/json"
 	"strconv"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
-// TestInstrumentsNetwork streams network-monitoring samples from the instruments
-// network service over the iOS 17+ tunnel for a bounded duration and asserts the
-// command self-terminates and emits well-formed samples. Each sample is a
-// {"type": <number>, "data": {...}} object (see networkSampleOutput in
-// cmd_device_debug.go). The service reports interface and per-connection
-// counters; go-ios keeps the decoded payload under "data", whose exact shape
-// varies by message type, so we assert the envelope (numeric type + data map)
-// rather than a fixed inner schema.
+// The instruments network-monitoring service only emits samples when there is
+// actual network activity — an idle device produces none (go-ios's own README
+// notes "open apple maps or similar to force network traffic"). So we stream for
+// a longer, --duration-bounded window while generating traffic on the device (a
+// networked app plus repeated launch/kill churn), then assert well-formed
+// {"type": <number>, "data": ...} envelopes arrived and the command self-stopped.
+const (
+	networkStreamSeconds = 20
+	// networkApp is a system app that phones home on launch, generating traffic.
+	networkApp = "com.apple.AppStore"
+)
+
 func TestInstrumentsNetwork(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) {
 		assertNetworkSamples(t, udid)
@@ -23,21 +32,38 @@ func TestInstrumentsNetwork(t *testing.T) {
 
 func assertNetworkSamples(t *testing.T, udid string) {
 	t.Helper()
-	samples := streamNDJSON(t, udid, instrumentsSampleWindow,
-		"instruments", "network", "--duration="+itoa(networkDurationSeconds))
 
+	// Start the bounded network stream in the background so we can drive traffic
+	// on the device while it collects samples. --duration makes it self-terminate.
+	output, stop := startBackground(t, udid, syscall.SIGTERM,
+		"instruments", "network", "--duration="+strconv.Itoa(networkStreamSeconds))
+	defer stop()
+
+	// Generate network traffic for most of the streaming window: launch a
+	// networked app (phones home) and churn launch/kill so the network service
+	// has activity to report.
+	deadline := time.Now().Add(time.Duration(networkStreamSeconds-3) * time.Second)
+	runIOSForDevice(t, udid, "launch", networkApp)
+	for time.Now().Before(deadline) {
+		runIOSForDevice(t, udid, "launch", "com.apple.Preferences")
+		runIOSForDevice(t, udid, "launch", networkApp)
+		time.Sleep(2 * time.Second)
+	}
+	runIOSForDevice(t, udid, "kill", networkApp)
+
+	// Give the --duration-bounded command time to reach its deadline and flush
+	// its final samples, then read what it collected. The deferred stop() cleans
+	// up the (by now self-terminated) process group.
+	time.Sleep(6 * time.Second)
+
+	samples := parseNetworkSamples(t, output())
 	if len(samples) == 0 {
-		t.Fatalf("instruments network: no samples in %ds window", networkDurationSeconds)
+		t.Fatalf("instruments network: no samples in %ds window even with generated traffic (real service/CLI issue?)", networkStreamSeconds)
 	}
 	for i, s := range samples {
-		if _, ok := s["type"]; !ok {
-			t.Fatalf("instruments network sample %d missing \"type\": %v", i, s)
-		}
 		if _, ok := s["type"].(float64); !ok {
-			t.Fatalf("instruments network sample %d \"type\" is not numeric: %T", i, s["type"])
+			t.Fatalf("instruments network sample %d \"type\" missing or not numeric: %v", i, s)
 		}
-		// "data" is present (may be null for some message types), but when it is
-		// an object it must decode as a map — the CLI marshals it as such.
 		if d, ok := s["data"]; ok && d != nil {
 			if _, ok := d.(map[string]any); !ok {
 				t.Fatalf("instruments network sample %d \"data\" is not an object: %T", i, d)
@@ -47,11 +73,35 @@ func assertNetworkSamples(t *testing.T, udid string) {
 	logSamples(t, "network", udid, samples)
 }
 
+// parseNetworkSamples decodes the JSON-object lines the streaming command wrote
+// to stdout, ignoring any non-JSON log noise the background runner may have
+// interleaved on the same stream.
+func parseNetworkSamples(t *testing.T, out string) []map[string]any {
+	t.Helper()
+	var samples []map[string]any
+	sc := bufio.NewScanner(strings.NewReader(out))
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			continue
+		}
+		if _, ok := m["type"]; ok {
+			samples = append(samples, m)
+		}
+	}
+	return samples
+}
+
 // itoa is a tiny local alias so the streaming tests read cleanly.
 func itoa(n int) string { return strconv.Itoa(n) }
 
 // logSamples t.Logs a handful of the real decoded samples so `go test -v` shows
-// actual on-device data (fps values / network envelopes) in the CI logs.
+// actual on-device data in the CI logs.
 func logSamples(t *testing.T, kind, udid string, samples []map[string]any) {
 	t.Helper()
 	const max = 5


### PR DESCRIPTION
## What this adds

Real-device e2e coverage for device-touching CLI commands that previously had **only device-free unit tests** (dispatch + fixture output formatting), never validated against a real device:

- **`ios instruments fps --duration=<s>`** and **`ios instruments network --duration=<s>`** (PR #806) — stream instruments graphics FPS / network-monitoring samples over DTX.
- **`ios file ls`** (fileservice / iOS17 RemoteXPC, PR #802) — strengthened the existing listing assertions.

### Harness
- `harness.StreamNDJSON` runs a **self-terminating** (`--duration`-bounded) streaming command, asserts it exits on its own within a timeout — a command that hangs past its `--duration` is treated as a real bug, not killed away — and decodes each stdout line as a JSON object.

### tunnel suite (iOS 17+) and pre-iOS17 suite
- `TestInstrumentsFPS`: asserts >=1 well-formed `{"fps": <number>}` sample (fps >= 0); logs real samples. (An idle screen still emits CoreAnimation frames.)
- `TestInstrumentsNetwork`: asserts the command streams, self-terminates cleanly, and every emitted line is a well-formed `{"type": <number>, "data": ...}` envelope; logs the sample count.
- `file ls`: every entry asserted a non-empty filename string; `--crash` domain root required non-empty.

FPS + network run in BOTH the tunnel suite (over the iOS 17+ tunnel) and the pre-iOS17 suite (over usbmuxd + DDI, no tunnel).

## Real-device finding (behavioural, worth noting)

`ios instruments network` emits **zero samples on a quiescent CI device** within a short window, on every runner — this is expected: the network-monitoring DTX service only reports when the device has real traffic (go-ios's own README says "open apple maps or similar to force network traffic"). An intermediate attempt to force traffic by hammering `launch`/`kill` over the shared instruments/DTX transport **destabilised that channel** (launch/kill timed out) and still produced no samples, so the test pins the reliable contract instead: connect, stream for `--duration`, self-terminate, and require every emitted sample to be a well-formed envelope. FPS, by contrast, reliably emits samples even on an idle screen. No product bug in #806 — the commands connect, stream, and terminate correctly.

## Captured real output

Ran on iPhone `00008120-...` (macOS runner, iOS 17+), iPhone `00008110-...` (Linux runner, iOS 17+), and pre-iOS17 device `5b98c87e...` (Linux runner).

**instruments fps** (all 5 samples per run were well-formed `{"fps": N}`):
- Linux iOS17: `fps:0, 0, 3, 23, 60`
- macOS iOS17: `fps:0, 0, 0, 0, 0`
- Linux preios17: `fps:0, 0, 0, 0, 0`

**instruments network**: `0 samples` on every runner (idle device — see finding above); command streamed for `--duration` and exited cleanly; the envelope-shape assertion holds vacuously and the count is logged.

**file ls --crash** (non-empty listing of real crash logs):
- macOS iOS17: `82 entries` (SpringBoard-*.ips, SiriSearchFeedback-*.ips, coreduetd.cpu_resource-*.ips, JetsamEvent-*.ips, ...)
- Linux iOS17: `128 entries` (stacks-*.ips, OTAUpdate-*.ips, WebDriverAgentRunner-Runner-*.ips, KitchenSinkUITests-Runner-*.ips, ...)

**file ls --temp**: `1 entry` `[go-ios-e2e-perf.bin]` on both iOS17 devices.

## Run status

All three new tests **PASSED on every runner**. The Linux runner was fully green (all three e2e suites `ok`). The macOS tunnel suite reported a failure caused by the **pre-existing `TestTunnelLoad/.../file-roundtrip` flake** (an 8 MiB tunnel push/pull hung 7m35s and tripped the 10-minute go-test timeout) in `perf_test.go` — unrelated to this PR; all new tests had already run and passed minutes earlier.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J8eMENxJ1nec9CeHp4tjWk

🤖 Generated with [Claude Code](https://claude.com/claude-code)