### PR TITLE
test(e2e): bound ios commands + capture wedged-child stack; de-flake tunnel file round-trip

### DIFF
--- a/test/e2e/harness/harness.go
+++ b/test/e2e/harness/harness.go
@@ -103,18 +103,73 @@ func RepoRoot(t *testing.T) string {
 	return root
 }
 
+// commandTimeout bounds any single ios invocation in the e2e suites. It is far
+// above any legitimate command (even an 8 MiB tunnel file round-trip under load)
+// but well below go test's global timeout, so one wedged command fails its own
+// test — with a captured stack — instead of hanging until the whole suite
+// panics and takes every other test's result down with it.
+const commandTimeout = 3 * time.Minute
+
 // RunIOS executes the ios binary with the given args and returns stdout.
 // On non-zero exit it fails the test with stderr + stdout for debugging.
+// If the command exceeds commandTimeout it is treated as wedged (see
+// runBounded): the child is SIGQUIT'd so Go prints every goroutine's stack,
+// pinpointing where it blocked, and the test fails with that stack.
 func RunIOS(t *testing.T, args ...string) []byte {
 	t.Helper()
-	var stderr bytes.Buffer
-	cmd := exec.Command(iosBin, args...)
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
+	out, stderr, err := runBounded(commandTimeout, nil, args...)
 	if err != nil {
-		t.Fatalf("ios %v: %v\nstderr: %s\nstdout: %s", args, err, stderr.String(), out)
+		t.Fatalf("ios %v: %v\nstderr: %s\nstdout: %s", args, err, stderr, out)
 	}
 	return out
+}
+
+// runBounded runs the ios binary with the given args under a timeout. On a clean
+// finish it returns (stdout, stderr, exitErr) — exitErr nil only on exit 0. On
+// timeout the child is assumed wedged: it is sent SIGQUIT first, which makes the
+// Go runtime dump all goroutine stacks to stderr (GOTRACEBACK=all guarantees the
+// full dump), then SIGKILL, and it returns a timeout error with that stack still
+// in the returned stderr. The child runs in its own process group so the signal
+// reaches any grandchildren too.
+func runBounded(timeout time.Duration, stdin io.Reader, args ...string) (stdout, stderr []byte, err error) {
+	var o, e bytes.Buffer
+	cmd := exec.Command(iosBin, args...)
+	cmd.Stdin = stdin
+	cmd.Stdout = &o
+	cmd.Stderr = &e
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Env = append(os.Environ(), "GOTRACEBACK=all")
+	if err = cmd.Start(); err != nil {
+		return nil, nil, fmt.Errorf("start: %w", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err = <-done:
+		return o.Bytes(), e.Bytes(), err
+	case <-time.After(timeout):
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGQUIT) // dump goroutine stacks
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			<-done
+		}
+		return o.Bytes(), e.Bytes(), fmt.Errorf("timed out after %s (wedged)", timeout)
+	}
+}
+
+// TryRunForDeviceBounded runs `ios <args> --udid=<udid>` under a timeout WITHOUT
+// failing the test, returning stdout, stderr and the run error (nil on exit 0).
+// On timeout the child is SIGQUIT-dumped then killed (see runBounded), so the
+// returned stderr carries the wedged child's goroutine stacks. Use it where the
+// caller wants to retry a command that can transiently wedge under load rather
+// than fail the whole test on the first stall.
+func TryRunForDeviceBounded(t *testing.T, udid string, timeout time.Duration, args ...string) (stdout, stderr []byte, err error) {
+	t.Helper()
+	return runBounded(timeout, nil, append(args, "--udid="+udid)...)
 }
 
 // RunForDevice runs ios with --udid=<udid> appended.

--- a/test/e2e/tunnel/perf_test.go
+++ b/test/e2e/tunnel/perf_test.go
@@ -67,13 +67,37 @@ func loadFileRoundTrip(t *testing.T, udid string) {
 	}
 	const remote = "go-ios-e2e-perf.bin" // fixed name: overwritten each run, no accumulation
 
-	pushStart := time.Now()
-	runIOSForDevice(t, udid, "file", "push", "--temp", "--local="+local, "--remote="+remote)
-	pushDur := time.Since(pushStart)
+	// The file transfer contends with the two syslog streams and the screenshot
+	// loop for the tunnel. Like the screenshots strand, a transfer can transiently
+	// stall when iOS resets a connection under that concurrent load, so bound each
+	// attempt (a healthy 8 MiB round-trip is seconds, not minutes) and retry. On a
+	// bounded timeout the child is SIGQUIT-dumped, so its goroutine stacks land in
+	// stderr — logged on every failed attempt so a genuine wedge (e.g. an AFC read
+	// with no deadline) is always captured even when a later attempt recovers.
+	const attemptTimeout = 90 * time.Second
+	transfer := func(op string, args ...string) {
+		full := append([]string{"file", op, "--temp"}, args...)
+		var lastErr error
+		for attempt := 0; attempt < 3; attempt++ {
+			_, stderr, err := harness.TryRunForDeviceBounded(t, udid, attemptTimeout, full...)
+			if err == nil {
+				return
+			}
+			lastErr = err
+			t.Logf("file %s attempt %d failed (retrying): %v\nchild stderr:\n%s", op, attempt, err, stderr)
+			time.Sleep(1 * time.Second)
+		}
+		t.Fatalf("file %s failed after retries: %v", op, lastErr)
+	}
 
 	back := filepath.Join(t.TempDir(), "perf-download.bin")
+
+	pushStart := time.Now()
+	transfer("push", "--local="+local, "--remote="+remote)
+	pushDur := time.Since(pushStart)
+
 	pullStart := time.Now()
-	runIOSForDevice(t, udid, "file", "pull", "--temp", "--remote="+remote, "--local="+back)
+	transfer("pull", "--remote="+remote, "--local="+back)
 	pullDur := time.Since(pullStart)
 
 	got, err := os.ReadFile(back)


### PR DESCRIPTION
## Problem

`TestTunnelLoad/file-roundtrip` intermittently turns the **whole macOS tunnel e2e suite red** (e.g. run [31553848792](https://github.com/danielpaulus/go-ios/actions/runs/31553848792)). The panic:

```
panic: test timed out after 10m0s
	running tests:
		TestTunnelLoad/.../file-roundtrip (7m35s)
```

### Root cause (two compounding issues)

1. **The e2e harness had no per-command timeout.** `RunIOS` used `cmd.Output()` unbounded, so when a child `ios` command wedged, the parent blocked reading its pipe until **go test's global 10-minute panic** — which aborts the *entire* suite and masks whether every other test passed. The goroutine dump confirms it: the only "running" test is `file-roundtrip`, and the parent is stuck in `os/exec` pipe-copy `IO wait`.

2. **The wedge itself.** `TestTunnelLoad` deliberately contends the tunnel (8 MiB transfer + 2 syslog streams + 10 screenshots overlapping). Under that load iOS transiently resets connections — the `screenshots` strand already anticipates this and retries. The `file-roundtrip` strand did **not** retry and had no bound, so a mid-transfer stall hung forever. (Strong suspect: AFC's `readPacket` in `ios/afc/client.go` reads with no deadline — but that's unproven because the harness SIGKILLed the child before we could see its stack. This PR fixes that blind spot.)

## Fix (test-only)

- **`harness.RunIOS`** now runs under a **3-minute bound** (far above any legit command, well below the global timeout). On timeout the child is **`SIGQUIT`'d first** — with `GOTRACEBACK=all` the Go runtime dumps every goroutine's stack, so the *next* hang shows exactly where `ios` blocked (AFC read vs. RSD/tunnel setup) instead of an opaque parent-side pipe wait — then `SIGKILL`. `ios` installs no SIGQUIT handler (only SIGINT/SIGTERM), so the dump always fires. New `TryRunForDeviceBounded` helper for callers that want to retry.
- **`perf_test.go` file-roundtrip** bounds each push/pull at 90s and **retries up to 3×**, mirroring the screenshots strand's accepted "transient resets under load are expected" handling. The wedged-child goroutine stack is **logged on every failed attempt**, so a genuine wedge is always captured even when a later attempt recovers.

## Options considered

- **Just bump the global test timeout** — rejected: hides the hang, still burns 10+ min, still one wedge = whole suite red.
- **Add a read deadline in the AFC client (`ios/afc`)** — likely the real product fix, but it touches the tunnel data plane and must be verified on-device; I want the captured child stack from this PR to *prove* AFC is the blocking point before changing product code. Tracked as follow-up.
- **Soften the stress test (less contention)** — rejected: the whole point of `TestTunnelLoad` is to catch throughput/stability regressions under load.

## Verification

`go build -tags e2e ./test/e2e/...` and `go vet -tags e2e ./test/e2e/...` clean; gofmt clean. Dispatching the real-device workflow to confirm the file-roundtrip strand is green (and that the new bound/dump path behaves) before merge.