### PR TITLE
ci: add least-privilege permissions to test workflow (CodeQL)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,14 @@ on:
   pull_request:
 
 name: Unit tests
+
+# Least-privilege default token scope for this pure-CI workflow. Every job here
+# (lint / build / unit tests on GitHub-hosted runners) only reads the checked-out
+# code, so read-only access is sufficient. Jobs needing more grant it narrowly at
+# the job level (see the real-device job's own permissions block).
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a least-privilege top-level `permissions:` block to `.github/workflows/test.yml`:

```yaml
permissions:
  contents: read
```

This workflow previously had no `permissions:` block, so `GITHUB_TOKEN` defaulted to the broad read/write scope. All of its jobs are pure, read-only CI on GitHub-hosted runners:

- **lint** — `actions/checkout` + `go vet ./...`
- **test_on_windows** — `actions/checkout` + `go build`
- **test_on_linux** — `actions/checkout` + `make build` + `go test -race ./...` + `gofmt` check

None of them write to the repo, comment on PRs, publish packages, or need any write scope, so `contents: read` is sufficient. The `real-device` job already declares its own `permissions: contents: read`, which is unaffected.

## CodeQL alerts resolved

- `actions/missing-workflow-permissions` on `.github/workflows/test.yml:7` (lint)
- `actions/missing-workflow-permissions` on `.github/workflows/test.yml:23` (test_on_windows)
- `actions/missing-workflow-permissions` on `.github/workflows/test.yml:43` (test_on_linux)

## Deliberately NOT touched (out of scope for this PR)

**Release / publish / OIDC workflows** — `release.yml`, `release-canary.yml`, `deploy.yml`.

These require `id-token: write` (npm OIDC trusted publishing) plus `contents: write` (the changelog commit / tag push), so a naive `contents: read` block would **break publishing**. Per `AGENTS.md` ("Releasing" + "Rules"), any change to the release/publish/packaging path must be proven on `release-canary.yml` first. The correct follow-up (for a human + a canary run) would grant, per the jobs that actually publish/tag:

```yaml
permissions:
  contents: write   # push changelog commit / create tag & release
  id-token: write   # npm OIDC trusted publishing
```

...pinned to the specific job(s) that need it, with read-only defaults elsewhere. `deploy.yml`'s `missing-workflow-permissions` alert (line 7) is left in the same bucket because it sits on the publish path.

**`real-device.yml` untrusted-checkout / TOCTOU (high)** — left as-is. This is the intentional, reviewed `/test-devices` mechanism that checks out fork-PR HEAD onto the self-hosted device runners, and is only triggerable by OWNER/MEMBER/COLLABORATOR comments (see AGENTS.md "Real-device CI"). Changing it is a design decision, not a mechanical permissions fix.

**`ios/tunnel/srp.go:23` weak-hashing (SHA-1)** — out of scope. SRP legitimately uses SHA-1 as mandated by Apple's pairing protocol; it is not a general-purpose hash choice.

## Validation

`test.yml` still parses as valid YAML, and the `real-device` job retains its own `contents: read` block. No release, publish, or device workflow was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
