### PR TITLE
test(e2e): retry preios17 device commands on transient usbmuxd/transport drops

### DIFF
--- a/test/e2e/harness/harness.go
+++ b/test/e2e/harness/harness.go
@@ -178,6 +178,184 @@ func RunForDevice(t *testing.T, udid string, args ...string) []byte {
 	return RunIOS(t, append(args, "--udid="+udid)...)
 }
 
+// transientTransportSignatures are the stderr fragments (matched
+// case-insensitively) that identify a *transient* usbmuxd / USB-transport drop
+// on the flaky pre-iOS17 CI device (udid 5b98c87e…, iOS 12.5.7). That device
+// intermittently falls off usbmuxd mid-suite; when it does, an otherwise-good
+// command fails with one of these transport-layer errors — never with an
+// assertion or a genuine command error. Retrying ONLY on these signatures lets a
+// single infra hiccup self-heal without masking real bugs. Keep this list here,
+// in one place; do not broaden it to cover anything but known transport drops.
+var transientTransportSignatures = []string{
+	"broken pipe",                    // write unix @->/var/run/usbmuxd: write: broken pipe
+	"sent: 0",                        // DeviceConnection failed writing all bytes ... sent: 0
+	"sent:0",                         // same, no space
+	"could not connect to rsd",       // got RST frame with error code: STREAM_CLOSED
+	"failed to get tunnel info",      // tunnel/RSD info lost when the device drops
+	"stream_closed",                  // HTTP/2 RST frame after the connection resets
+	"connection reset",               // generic peer/USB reset
+	"timed out waiting for response", // dtx: Timed out waiting for response for message:N channel:0
+}
+
+// matchTransientTransport reports the first transient-transport signature found
+// in stderr (case-insensitive), or "" if none matched. A non-empty result means
+// the failure looks like a transport drop worth retrying.
+func matchTransientTransport(stderr []byte) string {
+	lower := strings.ToLower(string(stderr))
+	for _, sig := range transientTransportSignatures {
+		if strings.Contains(lower, sig) {
+			return sig
+		}
+	}
+	return ""
+}
+
+const (
+	// transientRetryAttempts bounds how many times a device-touching command is
+	// retried when it fails with a transient-transport signature.
+	transientRetryAttempts = 3
+	// transientRetryBackoff is the pause between those attempts (~2s), giving
+	// usbmuxd time to re-enumerate the device after a drop.
+	transientRetryBackoff = 2 * time.Second
+)
+
+// RunForDeviceResilient runs `ios <args> --udid=<udid>` under the standard bounded
+// runner and returns stdout. On success it returns immediately. On failure it
+// retries ONLY when stderr matches a transient-transport signature (see
+// transientTransportSignatures) — a genuine command error or a wedge fails the
+// test straight away, so real bugs are never masked. Each retry is logged with
+// the matched signature; after transientRetryAttempts it fails with the last
+// error. Use it for the pre-iOS17 device commands that a mid-suite usbmuxd drop
+// would otherwise red-wall.
+func RunForDeviceResilient(t *testing.T, udid string, args ...string) []byte {
+	t.Helper()
+	var (
+		out, stderr []byte
+		err         error
+	)
+	for attempt := 1; attempt <= transientRetryAttempts; attempt++ {
+		out, stderr, err = runBounded(commandTimeout, nil, append(args, "--udid="+udid)...)
+		if err == nil {
+			return out
+		}
+		sig := matchTransientTransport(stderr)
+		if sig == "" {
+			// Not a known transient transport drop — fail fast, do not mask.
+			t.Fatalf("ios %v: %v\nstderr: %s\nstdout: %s", args, err, stderr, out)
+		}
+		if attempt < transientRetryAttempts {
+			t.Logf("ios %v: transient transport drop (matched %q), retry %d/%d after %s",
+				args, sig, attempt, transientRetryAttempts-1, transientRetryBackoff)
+			time.Sleep(transientRetryBackoff)
+		}
+	}
+	t.Fatalf("ios %v: still failing after %d attempts (transient transport drops): %v\nstderr: %s\nstdout: %s",
+		args, transientRetryAttempts, err, stderr, out)
+	return nil
+}
+
+// SmokeArrResilient is SmokeJSONArray wrapped in the transient-transport retry
+// (see RunForDeviceResilient): it re-runs the command on a usbmuxd drop, then
+// applies the identical non-empty-array + element-key assertions. Assertions are
+// unchanged — only transport drops are retried.
+func SmokeArrResilient(t *testing.T, udid string, elemKeys []string, args ...string) []any {
+	t.Helper()
+	out := RunForDeviceResilient(t, udid, args...)
+	if len(bytes.TrimSpace(out)) == 0 {
+		t.Fatalf("ios %v: empty output", args)
+	}
+	var a []any
+	if err := json.Unmarshal(out, &a); err != nil {
+		t.Fatalf("ios %v: not a JSON array: %v\n%s", args, err, snippet(out))
+	}
+	if len(a) == 0 {
+		t.Fatalf("ios %v: empty array", args)
+	}
+	if first, ok := a[0].(map[string]any); ok {
+		for _, k := range elemKeys {
+			if _, ok := first[k]; !ok {
+				t.Fatalf("ios %v: array element missing key %q (got %v)", args, k, keysOf(first))
+			}
+		}
+	}
+	return a
+}
+
+// AuditAfterLaunchResilient is AuditAfterLaunch with the launch run through the
+// transient-transport retry so a usbmuxd drop on the flaky pre-iOS17 device does
+// not red-wall the audit. The audit poll below already tolerates transient
+// failures (it retries until issues appear or it times out), so only the launch
+// needs the resilient runner. Assertions are unchanged.
+func AuditAfterLaunchResilient(t *testing.T, udid, bundleID string) {
+	t.Helper()
+	RunForDeviceResilient(t, udid, "launch", bundleID)
+
+	var issues []any
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		out, _, err := TryRun(t, "ax", "audit", "--udid="+udid)
+		if err == nil && json.Unmarshal(out, &issues) == nil && len(issues) > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ax audit reported no issues within 30s for %s after launching %s", udid, bundleID)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	for i, raw := range issues {
+		m, _ := raw.(map[string]any)
+		if _, ok := m["issueType"]; !ok {
+			t.Fatalf("ax audit issue %d missing issueType: %v", i, m)
+		}
+	}
+}
+
+// StreamSmokeResilient is StreamSmoke wrapped in the transient-transport retry:
+// if the stream produces no output AND its stderr shows a transient usbmuxd drop,
+// it restarts the stream (up to transientRetryAttempts) instead of failing. A
+// stream that produces output, or that fails without a transient signature, is
+// handled exactly as StreamSmoke would — assertions are unchanged.
+func StreamSmokeResilient(t *testing.T, udid string, window time.Duration, args ...string) []byte {
+	t.Helper()
+	for attempt := 1; attempt <= transientRetryAttempts; attempt++ {
+		out, stderr := streamOnce(t, udid, window, args...)
+		if len(bytes.TrimSpace(out)) != 0 {
+			return out
+		}
+		sig := matchTransientTransport(stderr)
+		if sig == "" || attempt == transientRetryAttempts {
+			t.Fatalf("ios %v: no streamed output within %s\nstderr: %s", args, window, stderr)
+		}
+		t.Logf("ios %v: transient transport drop (matched %q), retry %d/%d after %s",
+			args, sig, attempt, transientRetryAttempts-1, transientRetryBackoff)
+		time.Sleep(transientRetryBackoff)
+	}
+	return nil
+}
+
+// streamOnce runs a streaming ios command for window, killing its process group
+// afterwards, and returns whatever it wrote to stdout and stderr. It makes no
+// assertions — callers (StreamSmoke, StreamSmokeResilient) decide what non-empty
+// output means.
+func streamOnce(t *testing.T, udid string, window time.Duration, args ...string) (stdout, stderr []byte) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	cmd := exec.Command(iosBin, append(args, "--udid="+udid)...)
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} // own group so we can kill children too
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("ios %v: start: %v", args, err)
+	}
+
+	time.Sleep(window)
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	_ = cmd.Wait() // returns the kill signal error; ignored
+
+	return out.Bytes(), errBuf.Bytes()
+}
+
 // Devices returns the parsed GO_IOS_E2E_DEVICES list.
 func Devices() []string { return append([]string(nil), devices...) }
 
@@ -258,19 +436,7 @@ func Smoke(t *testing.T, udid string, args ...string) []byte {
 // to inspect. Use this for commands that run until killed.
 func StreamSmoke(t *testing.T, udid string, window time.Duration, args ...string) []byte {
 	t.Helper()
-	var out bytes.Buffer
-	cmd := exec.Command(iosBin, append(args, "--udid="+udid)...)
-	cmd.Stdout = &out
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} // own group so we can kill children too
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("ios %v: start: %v", args, err)
-	}
-
-	time.Sleep(window)
-	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	_ = cmd.Wait() // returns the kill signal error; ignored
-
-	b := out.Bytes()
+	b, _ := streamOnce(t, udid, window, args...)
 	if len(bytes.TrimSpace(b)) == 0 {
 		t.Fatalf("ios %v: no streamed output within %s", args, window)
 	}

--- a/test/e2e/preios17/accessibility_test.go
+++ b/test/e2e/preios17/accessibility_test.go
@@ -14,6 +14,6 @@ import (
 // (named case IDs via deviceBeginAuditCaseIDs:).
 func TestAccessibilityAudit(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) {
-		harness.AuditAfterLaunch(t, udid, knownSystemApp)
+		harness.AuditAfterLaunchResilient(t, udid, knownSystemApp)
 	})
 }

--- a/test/e2e/preios17/instruments_test.go
+++ b/test/e2e/preios17/instruments_test.go
@@ -15,7 +15,7 @@ import (
 // TestPs lists running processes via the instruments device-info service.
 func TestPs(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) {
-		smokeArr(t, udid, []string{"Name", "Pid"}, "ps")
+		smokeArrResilient(t, udid, []string{"Name", "Pid"}, "ps")
 	})
 }
 
@@ -24,7 +24,7 @@ func TestPs(t *testing.T) {
 func TestScreenshot(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) {
 		out := filepath.Join(t.TempDir(), "shot.png")
-		runIOSForDevice(t, udid, "screenshot", "--output="+out)
+		runIOSForDeviceResilient(t, udid, "screenshot", "--output="+out)
 
 		b, err := os.ReadFile(out)
 		if err != nil {
@@ -43,7 +43,7 @@ func TestScreenshot(t *testing.T) {
 // service and then kills it. Both report success (non-zero exit fails the test).
 func TestLaunchKill(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) {
-		runIOSForDevice(t, udid, "launch", knownSystemApp)
-		runIOSForDevice(t, udid, "kill", knownSystemApp)
+		runIOSForDeviceResilient(t, udid, "launch", knownSystemApp)
+		runIOSForDeviceResilient(t, udid, "kill", knownSystemApp)
 	})
 }

--- a/test/e2e/preios17/main_test.go
+++ b/test/e2e/preios17/main_test.go
@@ -36,6 +36,23 @@ func runIOSForDevice(t *testing.T, udid string, args ...string) []byte {
 	return harness.RunForDevice(t, udid, args...)
 }
 
+// The *Resilient helpers retry ONLY on a transient usbmuxd / USB-transport drop
+// on the flaky pre-iOS17 device (see the harness comment on
+// transientTransportSignatures) — never on assertion or genuine command errors.
+// The DTX/instruments and syslog tests use them so one infra hiccup mid-suite
+// self-heals instead of red-walling the whole PR fleet.
+func runIOSForDeviceResilient(t *testing.T, udid string, args ...string) []byte {
+	return harness.RunForDeviceResilient(t, udid, args...)
+}
+
+func smokeArrResilient(t *testing.T, udid string, elemKeys []string, args ...string) []any {
+	return harness.SmokeArrResilient(t, udid, elemKeys, args...)
+}
+
+func streamSmokeResilient(t *testing.T, udid string, window time.Duration, args ...string) []byte {
+	return harness.StreamSmokeResilient(t, udid, window, args...)
+}
+
 func smoke(t *testing.T, udid string, args ...string) []byte {
 	return harness.Smoke(t, udid, args...)
 }

--- a/test/e2e/preios17/stream_test.go
+++ b/test/e2e/preios17/stream_test.go
@@ -8,10 +8,12 @@ import (
 )
 
 // TestSyslog streams the device syslog (lockdown syslog_relay, no tunnel) and
-// asserts output is produced within the window.
+// asserts output is produced within the window. It uses the resilient stream
+// helper because a transient usbmuxd drop on the flaky pre-iOS17 device
+// otherwise leaves the stream empty and red-walls the run.
 func TestSyslog(t *testing.T) {
 	forEachDevice(t, func(t *testing.T, udid string) {
-		streamSmoke(t, udid, 8*time.Second, "syslog")
+		streamSmokeResilient(t, udid, 8*time.Second, "syslog")
 	})
 }
 


### PR DESCRIPTION
## Problem

On the `ganjalf` Linux runner the pre-iOS17 e2e device (udid `5b98c87e742570f10e22113b7dd8502638011e16`, iOS 12.5.7) intermittently **drops off usbmuxd mid-suite**. When it does, five tests in `test/e2e/preios17` fail hard with no retry, red-walling the entire PR fleet on a single infra hiccup:

- `TestAccessibilityAudit`
- `TestPs`
- `TestScreenshot`
- `TestLaunchKill`
- `TestSyslog`

The failures are always **transient transport-layer errors**, never assertion or genuine command failures, e.g.:

- `write unix @->/var/run/usbmuxd: write: broken pipe`
- `DeviceConnection failed writing all bytes ... sent: 0`
- `could not connect to RSD ... got RST frame with error code: STREAM_CLOSED`
- dtx `Timed out waiting for response for message:5 channel:0`

## Fix

This mirrors the **already-accepted pattern** in the tunnel screenshots strand (`test/e2e/tunnel/perf_test.go`), which retries the same class of transient RST/`STREAM_CLOSED` connection resets up to 4×.

A bounded retry is added to the harness (`RunForDeviceResilient` / `SmokeArrResilient` / `AuditAfterLaunchResilient` / `StreamSmokeResilient`). It:

- runs the command through the existing **bounded** runner (`runBounded`), so a wedge is still bounded and stack-dumped;
- retries **only** when stderr matches a known transient-transport signature (case-insensitive), among: `broken pipe`, `sent: 0` / `sent:0`, `could not connect to RSD`, `failed to get tunnel info`, `STREAM_CLOSED`, `connection reset`, `Timed out waiting for response`;
- retries at most **3 attempts** with **~2s backoff**, logging each retry with the matched signature via `t.Logf`;
- **fails immediately** on any other error (or empty output without a transient signature) — real bugs are never masked;
- after exhausting retries, `t.Fatalf`s with the last error.

The signature list lives in **one place** in `test/e2e/harness/harness.go` with a comment scoping it strictly to the flaky pre-iOS17 device's transport drops. **No assertion is weakened** — the schema/value checks (non-empty JSON array + element keys, PNG magic + size, audit issueType, streamed-output-within-window) are byte-for-byte the same.

This is **test-only** code under `test/e2e/` (build tag `e2e`); no production package is touched.

## Options considered

- **Bounded retry here (chosen).** Cheap, self-healing, scoped to a known-transient signature set, mirrors an existing accepted strand, and never masks a real failure. Downside: adds up to ~6s per affected command in the rare drop case.
- **Fix the physical device / cable.** The real root cause is a flaky USB link on that specific device. Worth doing, but it's a hardware/ops task on the self-hosted runner and can't gate PRs in the meantime; this change is orthogonal and still desirable once the cable is replaced.
- **Quarantine the device.** Dropping the pre-iOS17 device from CI would lose the *only* real-device coverage of the direct-over-usbmuxd DTX/instruments path (ps/screenshot/launch/kill without a tunnel), which is exactly what this suite exists to prove. Rejected.

## Verification

`go build -tags e2e ./test/e2e/...`, `go vet -tags e2e ./test/e2e/...`, and `gofmt -l` are all clean. The real-device workflow was dispatched on this branch to confirm the five preios17 tests still PASS on the healthy device (no regression); farm result linked in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)