### PR TITLE
fix(tunnel): bind userspace tunnel listener on an ephemeral port to avoid collisions

### DIFF
--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -332,35 +332,28 @@ type TunnelManager struct {
 	firstUpdateCompleted bool
 	userspaceTUN         bool
 	closeOnce            sync.Once
-	portOffset           int
 	// udidFilter, when non-empty, restricts the manager to a single device so
 	// you can run one isolated tunnel agent per device.
 	udidFilter string
-	// basePort is the base for derived userspace listener ports (the agent's own
-	// tunnel-info port), so per-device agents on different ports don't collide.
-	basePort int
 }
 
 // NewTunnelManager creates a new TunnelManager instance for setting up device tunnels for all connected devices
 // If userspaceTUN is set to true, the network stack will run in user space.
 func NewTunnelManager(pm PairRecordManager, userspaceTUN bool) *TunnelManager {
-	return newTunnelManager(pm, userspaceTUN, "", ios.HttpApiPort())
+	return newTunnelManager(pm, userspaceTUN, "")
 }
 
-// NewTunnelManagerForDevice creates a TunnelManager bound to a specific
-// tunnel-info port. If udid is non-empty the manager only manages that one
-// device (ignoring all others), so you can run one isolated agent per device; an
-// empty udid manages all connected devices. basePort is the agent's tunnel-info
-// port: userspace listener ports are derived from it so multiple agents on
-// different ports (e.g. a general agent plus per-device agents) never clash.
-func NewTunnelManagerForDevice(pm PairRecordManager, userspaceTUN bool, udid string, basePort int) *TunnelManager {
-	return newTunnelManager(pm, userspaceTUN, udid, basePort)
+// NewTunnelManagerForDevice creates a TunnelManager optionally bound to a single
+// device. If udid is non-empty the manager only manages that one device
+// (ignoring all others), so you can run one isolated agent per device; an empty
+// udid manages all connected devices. Each userspace tunnel binds its local
+// listener on an OS-assigned ephemeral port, so multiple agents on one host never
+// collide and the actual port is advertised via the tunnel-info API.
+func NewTunnelManagerForDevice(pm PairRecordManager, userspaceTUN bool, udid string) *TunnelManager {
+	return newTunnelManager(pm, userspaceTUN, udid)
 }
 
-func newTunnelManager(pm PairRecordManager, userspaceTUN bool, udidFilter string, basePort int) *TunnelManager {
-	if basePort == 0 {
-		basePort = ios.HttpApiPort()
-	}
+func newTunnelManager(pm PairRecordManager, userspaceTUN bool, udidFilter string) *TunnelManager {
 	return &TunnelManager{
 		ts:                 manualPairingTunnelStart{},
 		dl:                 deviceList{},
@@ -370,8 +363,6 @@ func newTunnelManager(pm PairRecordManager, userspaceTUN bool, udidFilter string
 		startTunnelTimeout: 10 * time.Second,
 		userspaceTUN:       userspaceTUN,
 		udidFilter:         udidFilter,
-		basePort:           basePort,
-		portOffset:         1,
 	}
 }
 
@@ -448,12 +439,11 @@ func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 		if shouldSkipDevice(d, localFailed, time.Now()) {
 			continue
 		}
-		if m.userspaceTUN && d.UserspaceTUNPort == 0 {
-			m.mux.Lock()
-			d.UserspaceTUNPort = m.basePort + m.portOffset
-			m.portOffset++
-			m.mux.Unlock()
-		}
+		// The userspace tunnel listener binds an OS-assigned ephemeral port (see
+		// connectToUserspaceTunnelLockdown); the actual bound port comes back on the
+		// returned Tunnel and is what the tunnel-info API advertises. So we no longer
+		// pre-assign a derived port here — that could collide with another agent's
+		// listener on the same host.
 		t, err := m.startTunnel(ctx, d)
 		if err != nil {
 			golog.Warn("failed to start tunnel", "module", logModule, "udid", udid, "error", err)
@@ -593,10 +583,10 @@ func (m manualPairingTunnelStart) StartTunnel(ctx context.Context, device ios.De
 
 	if version.GreaterThan(semver.MustParse("17.4.0")) {
 		if userspaceTUN {
-			tun, err := ConnectUserSpaceTunnelLockdown(device, device.UserspaceTUNPort)
-			tun.UserspaceTUN = true
-			tun.UserspaceTUNPort = device.UserspaceTUNPort
-			return tun, err
+			// Pass 0 so the userspace listener binds an OS-assigned ephemeral port;
+			// the returned Tunnel carries the actual bound UserspaceTUNPort (and
+			// UserspaceTUN=true), which is what the tunnel-info API advertises.
+			return ConnectUserSpaceTunnelLockdown(device, device.UserspaceTUNPort)
 		}
 		return ConnectTunnelLockdown(device)
 	}

--- a/ios/tunnel/userspace_tunnel.go
+++ b/ios/tunnel/userspace_tunnel.go
@@ -216,10 +216,20 @@ func connectToUserspaceTunnelLockdown(ctx context.Context, device ios.DeviceEntr
 		return Tunnel{}, fmt.Errorf("could not setup tunnel interface. %w", err)
 	}
 
+	// ifacePort == 0 asks the OS for an ephemeral port. This is the normal path:
+	// the userspace TUN listener has no fixed port requirement, so binding an
+	// ephemeral port lets multiple per-device agents run on one host without the
+	// listener ports colliding. A non-zero ifacePort is still honored for
+	// backward compatibility. Either way we read the actually-bound port back
+	// below and advertise it, so callers never guess a port that may be taken.
 	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", ifacePort))
 	if err != nil {
 		return Tunnel{}, fmt.Errorf("could not setup listener. %w", err)
 	}
+	// Report the port the OS actually assigned so the tunnel-info API advertises a
+	// real, reachable port rather than the requested (possibly 0) value.
+	boundPort := listener.Addr().(*net.TCPAddr).Port
+	golog.Info("userspace tunnel listening", "module", logModule, "udid", device.Properties.SerialNumber, "userspaceTunPort", boundPort)
 
 	go listenToConns(iface, listener)
 
@@ -264,10 +274,12 @@ func connectToUserspaceTunnelLockdown(ctx context.Context, device ios.DeviceEntr
 		return doClose()
 	}
 	return Tunnel{
-		Address: tunnelInfo.ServerAddress,
-		RsdPort: int(tunnelInfo.ServerRSDPort),
-		Udid:    device.Properties.SerialNumber,
-		closer:  closeFunc,
+		Address:          tunnelInfo.ServerAddress,
+		RsdPort:          int(tunnelInfo.ServerRSDPort),
+		Udid:             device.Properties.SerialNumber,
+		UserspaceTUN:     true,
+		UserspaceTUNPort: boundPort,
+		closer:           closeFunc,
 	}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -1921,11 +1921,10 @@ func startTunnel(ctx context.Context, recordsPath string, tunnelInfoHost string,
 	if udid != "" {
 		slog.Info("restricting tunnel agent to a single device", "udid", udid, "tunnelInfoPort", tunnelInfoPort)
 	}
-	// Always derive userspace listener ports from THIS agent's tunnel-info port
-	// (not the global default), so several agents on different ports — e.g. a
-	// general agent plus per-device agents — never collide. An empty udid means
+	// Each userspace tunnel binds its local listener on an OS-assigned ephemeral
+	// port, so several agents on one host never collide. An empty udid means
 	// "manage all devices".
-	tm := tunnel.NewTunnelManagerForDevice(pm, userspaceTUN, udid, tunnelInfoPort)
+	tm := tunnel.NewTunnelManagerForDevice(pm, userspaceTUN, udid)
 
 	go func() {
 		ticker := time.NewTicker(1 * time.Second)

--- a/test/e2e/tunnel/perdevice_test.go
+++ b/test/e2e/tunnel/perdevice_test.go
@@ -174,9 +174,10 @@ func TestTunnelAgentAllDevices(t *testing.T) {
 // TestTunnelAgentMixed runs a general (all-devices) agent and a per-device agent
 // at the same time on different tunnel-info ports and proves they don't conflict:
 // they bind cleanly, each gets its own independent tunnel to the device with its
-// own userspace listener port (derived from its own tunnel-info port), and
-// stopping a device's tunnel on one agent never affects the other agent's tunnel.
-// People run go-ios like this in production, so it is verified, not assumed.
+// own userspace listener port (an OS-assigned ephemeral port, advertised as the
+// actual bound port), and stopping a device's tunnel on one agent never affects
+// the other agent's tunnel. People run go-ios like this in production, so it is
+// verified, not assumed.
 func TestTunnelAgentMixed(t *testing.T) {
 	devs := harness.Devices()
 	if len(devs) == 0 {
@@ -206,12 +207,20 @@ func TestTunnelAgentMixed(t *testing.T) {
 	if gen.UserspaceTUNPort == per.UserspaceTUNPort {
 		t.Fatalf("userspace listener port collision: both agents on %d", gen.UserspaceTUNPort)
 	}
-	// Each agent's userspace port is derived from its OWN tunnel-info port.
-	if gen.UserspaceTUNPort <= genPort || gen.UserspaceTUNPort > genPort+1000 {
-		t.Fatalf("general agent userspace port %d not derived from its tunnel-info port %d", gen.UserspaceTUNPort, genPort)
-	}
-	if per.UserspaceTUNPort != perPort+1 {
-		t.Fatalf("per-device agent userspace port = %d, want %d", per.UserspaceTUNPort, perPort+1)
+	// Each agent's userspace listener binds an OS-assigned ephemeral port, so the
+	// advertised port must be a real, valid port distinct from either agent's
+	// tunnel-info port (the two ports are independent now).
+	for _, tc := range []struct {
+		name string
+		port int
+		info int
+	}{{"general", gen.UserspaceTUNPort, genPort}, {"per-device", per.UserspaceTUNPort, perPort}} {
+		if tc.port <= 0 || tc.port > 65535 {
+			t.Fatalf("%s agent userspace port %d is not a valid ephemeral port", tc.name, tc.port)
+		}
+		if tc.port == tc.info {
+			t.Fatalf("%s agent userspace port %d collides with its tunnel-info port", tc.name, tc.port)
+		}
 	}
 
 	// Both tunnels to the same device must actually carry traffic simultaneously.


### PR DESCRIPTION
## Root cause

The userspace tunnel's local listener port collides when two per-device tunnel
agents run on one host. This started failing in real-device CI after a 2nd
device (iOS 26.5) was added to the office01 macOS runner.

- `TunnelManager` pre-computed the userspace TUN listener port as
  `d.UserspaceTUNPort = m.basePort + m.portOffset` (portOffset starts at 1), and
  `connectToUserspaceTunnelLockdown` bound it via
  `net.Listen("tcp", "localhost:<port>")`.
- Only the agent's *tunnel-info HTTP port* is guaranteed free (each per-device
  agent is started with a free `--tunnel-info-port`). The **derived** userspace
  TUN port had **no free-port guarantee**, so with two concurrent per-device
  agents on one host it collided → the second agent could never bind and its
  tunnel never came up:

  ```
  WARN failed to start tunnel ... error="could not setup listener. listen tcp 127.0.0.1:57472: bind: address already in use"
  ```

  `TestTunnelAgent/userspace/<udid>` on the second device then timed out after 90s.

## The fix

Bind the userspace TUN listener on an **OS-assigned ephemeral port** and
advertise the **actual** chosen port:

- `connectToUserspaceTunnelLockdown` passes `ifacePort` through to
  `net.Listen`; with `ifacePort == 0` the OS picks a free port. The actual bound
  port is read back via `listener.Addr().(*net.TCPAddr).Port` and set on the
  returned `Tunnel.UserspaceTUNPort` (with `UserspaceTUN = true`), so the
  tunnel-info API (`/tunnel/{udid}`, `/tunnels`) serves a real, reachable port.
  An explicit non-zero `ifacePort` is still honored for backward compatibility.
- `TunnelManager` no longer pre-assigns `basePort + portOffset`; the now-dead
  `basePort`/`portOffset` derivation is removed. The clobbering overwrite in
  `manualPairingTunnelStart.StartTunnel`
  (`tun.UserspaceTUNPort = device.UserspaceTUNPort`) is removed so it can't
  reset the real port back to a stale value.

The tunnel-info HTTP API port is untouched — only the userspace TUN listener
port becomes ephemeral. The two ports were previously entangled via `basePort`
(which defaulted to `ios.HttpApiPort()`); they are now fully independent.

## Options considered

- **Ephemeral bind (chosen).** Let the OS assign a free port and advertise the
  actual one. Zero collision surface, no retry loop, no shared coordination
  state, and mirrors the existing REST API ephemeral-port approach. The
  advertised port is always correct because it's read from the bound listener.
- **Test-only free-port range.** Only papers over the symptom in CI; production
  multi-agent hosts would still collide. Rejected.
- **Retry-on-EADDRINUSE.** Retrying a derived port on bind failure adds a retry
  loop and still races two agents onto the same next candidate; strictly worse
  than letting the OS pick. Rejected.
- **Per-agent port namespacing.** Deriving disjoint ranges per agent requires
  coordinating a base offset across independently-launched processes on one
  host — exactly the coordination the ephemeral bind avoids. Rejected.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
