### PR TITLE
feat(remote): ios remote — minimal browser remote-control (WDA-free live screen)

### DIFF
--- a/cli_device_resolution.go
+++ b/cli_device_resolution.go
@@ -99,6 +99,7 @@ func needsAutomaticTunnelInfo(args docopt.Opts) bool {
 		"ostrace",
 		"pasteboard",
 		"ps",
+		"remote",
 		"resetlocation",
 		"runwda",
 		"runxctest",

--- a/cmd_device_registry.go
+++ b/cmd_device_registry.go
@@ -113,4 +113,5 @@ var deviceCommands = []command{
 	commandByBool("fsync", runFsyncCommand),
 	commandByBool("devmode", runDevModeCommand),
 	commandByBool("webinspector", runWebInspectorCommand),
+	commandByBool("remote", runRemoteCommand),
 }

--- a/cmd_remote.go
+++ b/cmd_remote.go
@@ -85,11 +85,19 @@ func runRemoteCommand(ctx commandContext) {
 	// applies to the DeviceKit runner (the one we can spawn), matched to driver.
 	manageRunner := !boolArg(ctx.Args, "--no-manage-runner") && runnerDriver == remote.DriverDeviceKit
 
+	// --fps/--bitrate tune the DeviceKit /h264 stream the browser decodes. They
+	// default to remote.DefaultFPS / remote.DefaultBitrate (well above the
+	// runner's own low defaults, for a smoother mirror).
+	fps := intArgDefault(ctx.Args, "--fps", remote.DefaultFPS)
+	bitrate := intArgDefault(ctx.Args, "--bitrate", remote.DefaultBitrate)
+
 	server, err := remote.NewServer(ctx.Device, remote.Config{
 		Driver:       driver,
 		DriverURL:    driverURL,
 		DeviceKitURL: deviceKitURL,
 		ManageRunner: manageRunner,
+		FPS:          fps,
+		Bitrate:      bitrate,
 	})
 	exitIfError("failed starting remote server", err)
 	defer server.Close()

--- a/cmd_remote.go
+++ b/cmd_remote.go
@@ -1,35 +1,113 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/remote"
+	"github.com/danielpaulus/go-ios/ios/tunnel"
 	"github.com/docopt/docopt-go"
 )
 
 // runRemoteCommand serves the `ios remote` browser remote-control. The live
-// screen is WDA-free (instruments screenshot service); input is routed through
-// the WebDriverAgent at --wda-url (default remote.DefaultWDAURL or
-// GO_IOS_WDA_URL).
+// screen is WDA-free (instruments screenshot service). Input is routed through a
+// UI automation driver — DeviceKit by default (WDA is broken on iOS 26; DeviceKit
+// works), selectable with --driver=<wda|devicekit>. The driver's base URL comes
+// from --devicekit-url (default remote.DefaultDeviceKitURL / GO_IOS_DEVICEKIT_URL)
+// or, for --driver=wda, --wda-url (default remote.DefaultWDAURL / GO_IOS_WDA_URL).
 func runRemoteCommand(ctx commandContext) {
 	port := portArg(ctx.Args)
 	if port == "" {
 		port = "8080"
 	}
 
-	wdaURL, _ := ctx.Args.String("--wda-url")
-	if wdaURL == "" {
-		wdaURL = os.Getenv("GO_IOS_WDA_URL")
-	}
-	if wdaURL == "" {
-		wdaURL = remote.DefaultWDAURL
+	driver, _ := ctx.Args.String("--driver")
+	switch driver {
+	case "", "auto":
+		driver = remote.DriverDeviceKit
+	case remote.DriverDeviceKit, remote.DriverWDA:
+	default:
+		exitIfError("invalid --driver for ios remote (use devicekit or wda)", fmt.Errorf("%q", driver))
 	}
 
-	server, err := remote.NewServer(ctx.Device, wdaURL)
+	var driverURL string
+	if driver == remote.DriverWDA {
+		driverURL, _ = ctx.Args.String("--wda-url")
+		if driverURL == "" {
+			driverURL = os.Getenv("GO_IOS_WDA_URL")
+		}
+		if driverURL == "" {
+			driverURL = remote.DefaultWDAURL
+		}
+	} else {
+		driverURL, _ = ctx.Args.String("--devicekit-url")
+		if driverURL == "" {
+			driverURL = os.Getenv("GO_IOS_DEVICEKIT_URL")
+		}
+		if driverURL == "" {
+			driverURL = remote.DefaultDeviceKitURL
+		}
+	}
+
+	// resolver re-fetches fresh tunnel/RSD info so the screen stream self-heals
+	// when the device's tunnel address changes. Non-fatal: on failure the screen
+	// service keeps using the last known address and retries.
+	tunnelInfo := tunnelInfoConfigFromArgs(ctx.Args)
+	udid := ctx.Device.Properties.SerialNumber
+	resolver := func() (ios.DeviceEntry, error) {
+		return refreshDeviceTunnelInfo(ctx.Device, udid, tunnelInfo)
+	}
+
+	server, err := remote.NewServer(ctx.Device, driver, driverURL, resolver)
 	exitIfError("failed starting remote server (developer disk image mounted?)", err)
 	defer server.Close()
 
 	exitIfError("remote server stopped", server.ListenAndServe(port))
+}
+
+// refreshDeviceTunnelInfo re-reads the device's tunnel info from the tunnel
+// daemon and attaches a fresh RSD provider, mirroring resolveDevice's automatic
+// path but WITHOUT exiting the process on failure — a transient tunnel gap must
+// not kill a long-running `ios remote`. On any error the previous device entry
+// is returned unchanged so the caller keeps using the last known address.
+func refreshDeviceTunnelInfo(device ios.DeviceEntry, udid string, tunnelInfo tunnelInfoConfig) (ios.DeviceEntry, error) {
+	info, err := tunnel.TunnelInfoForDevice(udid, tunnelInfo.Host, tunnelInfo.Port)
+	if err != nil {
+		return device, err
+	}
+	fresh, err := deviceWithTunnelInfo(udid, info)
+	if err != nil {
+		return device, err
+	}
+	return fresh, nil
+}
+
+// deviceWithTunnelInfo builds a DeviceEntry with an RSD provider for the given
+// tunnel, the non-fatal counterpart to deviceWithRsdProvider (which exits on
+// error).
+func deviceWithTunnelInfo(udid string, info tunnel.Tunnel) (ios.DeviceEntry, error) {
+	device, err := ios.GetDevice(udid)
+	if err != nil {
+		return device, err
+	}
+	rsdService, err := ios.NewWithAddrPortDevice(info.Address, info.RsdPort, device)
+	if err != nil {
+		return device, fmt.Errorf("connecting to RSD at %s:%d: %w", info.Address, info.RsdPort, err)
+	}
+	defer rsdService.Close()
+	rsdProvider, err := rsdService.Handshake()
+	if err != nil {
+		return device, fmt.Errorf("RSD handshake at %s:%d: %w", info.Address, info.RsdPort, err)
+	}
+	device1, err := ios.GetDeviceWithAddress(udid, info.Address, rsdProvider)
+	if err != nil {
+		return device, err
+	}
+	device1.UserspaceTUN = info.UserspaceTUN
+	device1.UserspaceTUNHost = ios.HttpApiHost()
+	device1.UserspaceTUNPort = info.UserspaceTUNPort
+	return device1, nil
 }
 
 // portArg reads --port. The global usage declares `ios forward … [--port=<mapping>]…`

--- a/cmd_remote.go
+++ b/cmd_remote.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/danielpaulus/go-ios/ios/remote"
+	"github.com/docopt/docopt-go"
 )
 
 // runRemoteCommand serves the `ios remote` browser remote-control. The live
@@ -11,7 +12,7 @@ import (
 // the WebDriverAgent at --wda-url (default remote.DefaultWDAURL or
 // GO_IOS_WDA_URL).
 func runRemoteCommand(ctx commandContext) {
-	port, _ := ctx.Args.String("--port")
+	port := portArg(ctx.Args)
 	if port == "" {
 		port = "8080"
 	}
@@ -29,4 +30,19 @@ func runRemoteCommand(ctx commandContext) {
 	defer server.Close()
 
 	exitIfError("remote server stopped", server.ListenAndServe(port))
+}
+
+// portArg reads --port. The global usage declares `ios forward … [--port=<mapping>]…`
+// as repeatable, so docopt surfaces --port as a []string for every command; a
+// plain args.String("--port") therefore returns "". Handle both shapes so
+// `ios remote --port=8090` works.
+func portArg(args docopt.Opts) string {
+	if list, ok := args["--port"].([]string); ok {
+		if len(list) > 0 {
+			return list[len(list)-1]
+		}
+		return ""
+	}
+	s, _ := args.String("--port")
+	return s
 }

--- a/cmd_remote.go
+++ b/cmd_remote.go
@@ -7,23 +7,25 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/remote"
-	"github.com/danielpaulus/go-ios/ios/tunnel"
 	"github.com/docopt/docopt-go"
 )
 
-// runRemoteCommand serves the `ios remote` browser remote-control. The live
-// screen is WDA-free (instruments screenshot service). Input is routed through a
-// UI automation driver — DeviceKit by default (WDA is broken on iOS 26; DeviceKit
-// works), selectable with --driver=<wda|devicekit>. The driver's base URL comes
-// from --devicekit-url (default remote.DefaultDeviceKitURL / GO_IOS_DEVICEKIT_URL)
-// or, for --driver=wda, --wda-url (default remote.DefaultWDAURL / GO_IOS_WDA_URL).
+// runRemoteCommand serves the `ios remote` browser remote-control. Both the live
+// screen and input come from a single supervised DeviceKit runner: the screen is
+// a passthrough of the runner's hardware video (H.264 at /video.h264, MJPEG at
+// /screen as a fallback) and input is routed through a UI automation driver —
+// DeviceKit by default (WDA is broken on iOS 26; DeviceKit works), selectable
+// with --driver=<wda|devicekit>. The driver's base URL comes from --devicekit-url
+// (default remote.DefaultDeviceKitURL / GO_IOS_DEVICEKIT_URL) or, for
+// --driver=wda, --wda-url (default remote.DefaultWDAURL / GO_IOS_WDA_URL); the
+// video is always proxied from the DeviceKit URL.
 //
 // By default (DeviceKit driver) `ios remote` also spawns and supervises the input
 // runner (`ios ui run devicekit`), auto-respawning it when the on-device XCTest
-// automation channel drops — so input self-heals instead of silently breaking.
-// Pass --no-manage-runner to connect to an externally-started runner instead.
+// automation channel drops — so both screen and input self-heal instead of
+// silently breaking. Pass --no-manage-runner to connect to an externally-started
+// runner instead.
 func runRemoteCommand(ctx commandContext) {
 	port := portArg(ctx.Args)
 	if port == "" {
@@ -65,26 +67,31 @@ func runRemoteCommand(ctx commandContext) {
 		}
 	}
 
+	// The video is proxied from the DeviceKit runner regardless of the input
+	// driver. When the input driver is DeviceKit it shares driverURL; otherwise
+	// (WDA input) resolve the DeviceKit URL independently.
+	deviceKitURL := driverURL
+	if driver != remote.DriverDeviceKit {
+		deviceKitURL, _ = ctx.Args.String("--devicekit-url")
+		if deviceKitURL == "" {
+			deviceKitURL = os.Getenv("GO_IOS_DEVICEKIT_URL")
+		}
+		if deviceKitURL == "" {
+			deviceKitURL = remote.DefaultDeviceKitURL
+		}
+	}
+
 	// Manage the runner by default; --no-manage-runner opts out. Supervision only
 	// applies to the DeviceKit runner (the one we can spawn), matched to driver.
 	manageRunner := !boolArg(ctx.Args, "--no-manage-runner") && runnerDriver == remote.DriverDeviceKit
 
-	// resolver re-fetches fresh tunnel/RSD info so the screen stream self-heals
-	// when the device's tunnel address changes. Non-fatal: on failure the screen
-	// service keeps using the last known address and retries.
-	tunnelInfo := tunnelInfoConfigFromArgs(ctx.Args)
-	udid := ctx.Device.Properties.SerialNumber
-	resolver := func() (ios.DeviceEntry, error) {
-		return refreshDeviceTunnelInfo(ctx.Device, udid, tunnelInfo)
-	}
-
 	server, err := remote.NewServer(ctx.Device, remote.Config{
 		Driver:       driver,
 		DriverURL:    driverURL,
-		Resolver:     resolver,
+		DeviceKitURL: deviceKitURL,
 		ManageRunner: manageRunner,
 	})
-	exitIfError("failed starting remote server (developer disk image mounted?)", err)
+	exitIfError("failed starting remote server", err)
 	defer server.Close()
 
 	// Cancel on SIGINT/SIGTERM so the supervised runner is terminated cleanly
@@ -93,50 +100,6 @@ func runRemoteCommand(ctx commandContext) {
 	defer stop()
 
 	exitIfError("remote server stopped", server.Run(runCtx, port))
-}
-
-// refreshDeviceTunnelInfo re-reads the device's tunnel info from the tunnel
-// daemon and attaches a fresh RSD provider, mirroring resolveDevice's automatic
-// path but WITHOUT exiting the process on failure — a transient tunnel gap must
-// not kill a long-running `ios remote`. On any error the previous device entry
-// is returned unchanged so the caller keeps using the last known address.
-func refreshDeviceTunnelInfo(device ios.DeviceEntry, udid string, tunnelInfo tunnelInfoConfig) (ios.DeviceEntry, error) {
-	info, err := tunnel.TunnelInfoForDevice(udid, tunnelInfo.Host, tunnelInfo.Port)
-	if err != nil {
-		return device, err
-	}
-	fresh, err := deviceWithTunnelInfo(udid, info)
-	if err != nil {
-		return device, err
-	}
-	return fresh, nil
-}
-
-// deviceWithTunnelInfo builds a DeviceEntry with an RSD provider for the given
-// tunnel, the non-fatal counterpart to deviceWithRsdProvider (which exits on
-// error).
-func deviceWithTunnelInfo(udid string, info tunnel.Tunnel) (ios.DeviceEntry, error) {
-	device, err := ios.GetDevice(udid)
-	if err != nil {
-		return device, err
-	}
-	rsdService, err := ios.NewWithAddrPortDevice(info.Address, info.RsdPort, device)
-	if err != nil {
-		return device, fmt.Errorf("connecting to RSD at %s:%d: %w", info.Address, info.RsdPort, err)
-	}
-	defer rsdService.Close()
-	rsdProvider, err := rsdService.Handshake()
-	if err != nil {
-		return device, fmt.Errorf("RSD handshake at %s:%d: %w", info.Address, info.RsdPort, err)
-	}
-	device1, err := ios.GetDeviceWithAddress(udid, info.Address, rsdProvider)
-	if err != nil {
-		return device, err
-	}
-	device1.UserspaceTUN = info.UserspaceTUN
-	device1.UserspaceTUNHost = ios.HttpApiHost()
-	device1.UserspaceTUNPort = info.UserspaceTUNPort
-	return device1, nil
 }
 
 // portArg reads --port. The global usage declares `ios forward … [--port=<mapping>]…`

--- a/cmd_remote.go
+++ b/cmd_remote.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+
+	"github.com/danielpaulus/go-ios/ios/remote"
+)
+
+// runRemoteCommand serves the `ios remote` browser remote-control. The live
+// screen is WDA-free (instruments screenshot service); input is routed through
+// the WebDriverAgent at --wda-url (default remote.DefaultWDAURL or
+// GO_IOS_WDA_URL).
+func runRemoteCommand(ctx commandContext) {
+	port, _ := ctx.Args.String("--port")
+	if port == "" {
+		port = "8080"
+	}
+
+	wdaURL, _ := ctx.Args.String("--wda-url")
+	if wdaURL == "" {
+		wdaURL = os.Getenv("GO_IOS_WDA_URL")
+	}
+	if wdaURL == "" {
+		wdaURL = remote.DefaultWDAURL
+	}
+
+	server, err := remote.NewServer(ctx.Device, wdaURL)
+	exitIfError("failed starting remote server (developer disk image mounted?)", err)
+	defer server.Close()
+
+	exitIfError("remote server stopped", server.ListenAndServe(port))
+}

--- a/cmd_remote.go
+++ b/cmd_remote.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/remote"
@@ -16,6 +19,11 @@ import (
 // works), selectable with --driver=<wda|devicekit>. The driver's base URL comes
 // from --devicekit-url (default remote.DefaultDeviceKitURL / GO_IOS_DEVICEKIT_URL)
 // or, for --driver=wda, --wda-url (default remote.DefaultWDAURL / GO_IOS_WDA_URL).
+//
+// By default (DeviceKit driver) `ios remote` also spawns and supervises the input
+// runner (`ios ui run devicekit`), auto-respawning it when the on-device XCTest
+// automation channel drops — so input self-heals instead of silently breaking.
+// Pass --no-manage-runner to connect to an externally-started runner instead.
 func runRemoteCommand(ctx commandContext) {
 	port := portArg(ctx.Args)
 	if port == "" {
@@ -29,6 +37,13 @@ func runRemoteCommand(ctx commandContext) {
 	case remote.DriverDeviceKit, remote.DriverWDA:
 	default:
 		exitIfError("invalid --driver for ios remote (use devicekit or wda)", fmt.Errorf("%q", driver))
+	}
+
+	// The runner we supervise is the input driver by default; --runner-driver lets
+	// it be overridden, but only DeviceKit is a runner we know how to spawn.
+	runnerDriver, _ := ctx.Args.String("--runner-driver")
+	if runnerDriver == "" {
+		runnerDriver = driver
 	}
 
 	var driverURL string
@@ -50,6 +65,10 @@ func runRemoteCommand(ctx commandContext) {
 		}
 	}
 
+	// Manage the runner by default; --no-manage-runner opts out. Supervision only
+	// applies to the DeviceKit runner (the one we can spawn), matched to driver.
+	manageRunner := !boolArg(ctx.Args, "--no-manage-runner") && runnerDriver == remote.DriverDeviceKit
+
 	// resolver re-fetches fresh tunnel/RSD info so the screen stream self-heals
 	// when the device's tunnel address changes. Non-fatal: on failure the screen
 	// service keeps using the last known address and retries.
@@ -59,11 +78,21 @@ func runRemoteCommand(ctx commandContext) {
 		return refreshDeviceTunnelInfo(ctx.Device, udid, tunnelInfo)
 	}
 
-	server, err := remote.NewServer(ctx.Device, driver, driverURL, resolver)
+	server, err := remote.NewServer(ctx.Device, remote.Config{
+		Driver:       driver,
+		DriverURL:    driverURL,
+		Resolver:     resolver,
+		ManageRunner: manageRunner,
+	})
 	exitIfError("failed starting remote server (developer disk image mounted?)", err)
 	defer server.Close()
 
-	exitIfError("remote server stopped", server.ListenAndServe(port))
+	// Cancel on SIGINT/SIGTERM so the supervised runner is terminated cleanly
+	// (no orphaned `ios ui run devicekit`) before we exit.
+	runCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	exitIfError("remote server stopped", server.Run(runCtx, port))
 }
 
 // refreshDeviceTunnelInfo re-reads the device's tunnel info from the tunnel

--- a/cmd_ui.go
+++ b/cmd_ui.go
@@ -181,7 +181,11 @@ func (c *uiClient) tap(x, y int) {
 func (c *uiClient) swipe(fromX, fromY, toX, toY int, duration float64) {
 	switch c.driver {
 	case uiDriverDeviceKit:
-		printUIResponse(c.deviceKitRPC("device.io.swipe", map[string]interface{}{"fromX": fromX, "fromY": fromY, "toX": toX, "toY": toY, "duration": duration}))
+		// DeviceKit's device.io.swipe expects x1/y1/x2/y2 (start/end), not
+		// fromX/fromY/toX/toY — the latter is rejected with "Invalid parameters"
+		// ("data missing"). The WDA dragfromtoforduration path below keeps its own
+		// fromX/toX naming.
+		printUIResponse(c.deviceKitRPC("device.io.swipe", map[string]interface{}{"x1": fromX, "y1": fromY, "x2": toX, "y2": toY, "duration": duration}))
 	case uiDriverWDA:
 		body := map[string]interface{}{"fromX": fromX, "fromY": fromY, "toX": toX, "toY": toY, "duration": duration}
 		printUIResponse(c.wdaHTTP(http.MethodPost, wdaPath("session", c.wdaSession(), "wda", "dragfromtoforduration"), mustJSON(body)))

--- a/command_registry.go
+++ b/command_registry.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strconv"
+
 	"github.com/danielpaulus/go-ios/ios"
 	"github.com/docopt/docopt-go"
 )
@@ -19,6 +21,20 @@ type command struct {
 func boolArg(args docopt.Opts, name string) bool {
 	value, _ := args.Bool(name)
 	return value
+}
+
+// intArgDefault reads a numeric docopt flag, returning def when the flag is
+// absent, empty, or not a valid integer.
+func intArgDefault(args docopt.Opts, name string, def int) int {
+	s, _ := args.String(name)
+	if s == "" {
+		return def
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return def
+	}
+	return v
 }
 
 func commandByBool(name string, run func(commandContext)) command {

--- a/ios/remote/remote.go
+++ b/ios/remote/remote.go
@@ -72,6 +72,12 @@ type Server struct {
 	// iosBinary is the path to the `ios` CLI used to drive input.
 	iosBinary string
 
+	// supervisor spawns and auto-respawns the input runner (`ios ui run
+	// devicekit`) when --manage-runner is on. nil when the runner is externally
+	// managed (--manage-runner=false or --driver=wda), in which case input
+	// endpoints assume the driver is always reachable.
+	supervisor *runnerSupervisor
+
 	// screen is the shared latest-JPEG-frame broadcaster fed by the
 	// instruments screenshot loop. It is driver-free.
 	screen *screenBroadcaster
@@ -82,35 +88,63 @@ type Server struct {
 	sizeH  float64
 }
 
-// NewServer wires up a remote-control server for the given device. driver is
-// "devicekit" (default) or "wda"; driverURL is that driver's base URL (defaults
-// applied upstream). resolver re-fetches fresh tunnel info on screen reconnect;
-// pass nil to disable refresh. The screen half connects to the instruments
-// screenshot service immediately so a failure (e.g. missing developer disk
-// image) surfaces before we start listening.
-func NewServer(device ios.DeviceEntry, driver, driverURL string, resolver DeviceResolver) (*Server, error) {
+// Config configures a remote-control Server.
+type Config struct {
+	// Driver is the input backend: "devicekit" (default) or "wda". DriverURL is
+	// that driver's base URL (defaults applied upstream).
+	Driver    string
+	DriverURL string
+	// Resolver re-fetches fresh tunnel info on screen reconnect; nil disables
+	// refresh.
+	Resolver DeviceResolver
+	// ManageRunner, when true and Driver is DeviceKit, makes the Server spawn and
+	// supervise the input runner (`ios ui run devicekit`) itself, auto-respawning
+	// it across the intermittent testmanagerd DTX EOF disconnects. When false the
+	// runner is assumed to be started externally at DriverURL (today's behavior).
+	ManageRunner bool
+}
+
+// NewServer wires up a remote-control server for the given device from cfg. The
+// screen half connects to the instruments screenshot service immediately so a
+// failure (e.g. missing developer disk image) surfaces before we start
+// listening. When cfg.ManageRunner is set and the driver is DeviceKit, the
+// Server also supervises the input runner (started by Run).
+func NewServer(device ios.DeviceEntry, cfg Config) (*Server, error) {
 	iosBinary, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("locating ios binary: %w", err)
 	}
+	driver := cfg.Driver
 	if driver == "" {
 		driver = DriverDeviceKit
 	}
 	udid := device.Properties.SerialNumber
 
-	bc, err := newScreenBroadcaster(device, resolver)
+	bc, err := newScreenBroadcaster(device, cfg.Resolver)
 	if err != nil {
 		return nil, fmt.Errorf("starting screenshot service: %w", err)
 	}
 
-	return &Server{
+	s := &Server{
 		device:    device,
 		udid:      udid,
 		driver:    driver,
-		driverURL: driverURL,
+		driverURL: cfg.DriverURL,
 		iosBinary: iosBinary,
 		screen:    bc,
-	}, nil
+	}
+
+	// Supervision only makes sense for the DeviceKit runner we know how to spawn.
+	if cfg.ManageRunner && driver == DriverDeviceKit {
+		s.supervisor = newRunnerSupervisor(udid, &execRunnerSpawner{
+			iosBinary: iosBinary,
+			udid:      udid,
+			healthURL: cfg.DriverURL + "/health",
+			stdout:    os.Stdout,
+			stderr:    os.Stderr,
+		})
+	}
+	return s, nil
 }
 
 // driverURLFlag returns the `ios ui` flag that carries driverURL for the
@@ -122,14 +156,43 @@ func (s *Server) driverURLFlag() string {
 	return "--devicekit-url=" + s.driverURL
 }
 
-// ListenAndServe binds 0.0.0.0:<port> (reachable over Tailscale) and serves the
-// UI until the process is stopped.
-func (s *Server) ListenAndServe(port string) error {
+// Run binds 0.0.0.0:<port> (reachable over Tailscale), supervises the input
+// runner (when managed), and serves the UI until ctx is cancelled (SIGINT/
+// SIGTERM). On shutdown it stops the HTTP server and terminates the supervised
+// runner so no `ios ui run devicekit` child is orphaned.
+func (s *Server) Run(ctx context.Context, port string) error {
 	location := "0.0.0.0:" + port
 	golog.Info("starting remote-control server, open your browser here",
 		"module", logModule, "udid", s.udid, "host", "0.0.0.0", "port", port,
-		"driver", s.driver, "driverURL", s.driverURL, "url", fmt.Sprintf("http://%s/", location))
-	return http.ListenAndServe(location, s.Handler())
+		"driver", s.driver, "driverURL", s.driverURL, "manageRunner", s.supervisor != nil,
+		"url", fmt.Sprintf("http://%s/", location))
+
+	// Supervise the input runner in the background; run() returns when ctx is
+	// cancelled, having stopped the child.
+	var wg sync.WaitGroup
+	if s.supervisor != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.supervisor.run(ctx)
+		}()
+	}
+
+	srv := &http.Server{Addr: location, Handler: s.Handler()}
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe() }()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		golog.Info("remote-control server shutting down", "module", logModule, "udid", s.udid)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+		wg.Wait() // wait for the runner to be terminated before returning
+		return nil
+	}
 }
 
 // Handler returns the HTTP handler for the remote-control UI and endpoints.
@@ -137,12 +200,54 @@ func (s *Server) ListenAndServe(port string) error {
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.handleIndex)
+	mux.HandleFunc("/status", s.handleStatus)
+	mux.HandleFunc("/healthz", s.handleStatus)
 	mux.HandleFunc("/screen", s.handleScreen)
 	mux.HandleFunc("/tap", s.handleTap)
 	mux.HandleFunc("/swipe", s.handleSwipe)
 	mux.HandleFunc("/type", s.handleType)
 	mux.HandleFunc("/button", s.handleButton)
 	return mux
+}
+
+// runnerStateString returns the current input-runner lifecycle state. When the
+// runner is externally managed (no supervisor) input is always assumed usable,
+// reported as "ready".
+func (s *Server) runnerStateString() runnerState {
+	if s.supervisor == nil {
+		return runnerReady
+	}
+	return s.supervisor.State()
+}
+
+// handleStatus reports the input-runner lifecycle so the UI can show
+// "reconnecting…" and health checks can gate on readiness.
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	state := s.runnerStateString()
+	w.Header().Set("Content-Type", "application/json")
+	if state != runnerReady {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"runnerState":  string(state),
+		"manageRunner": s.supervisor != nil,
+		"driver":       s.driver,
+	})
+}
+
+// inputReady reports whether input can be dispatched; when not, it writes a 503
+// with a clear JSON body and returns false so the handler stops.
+func (s *Server) inputReady(w http.ResponseWriter) bool {
+	if state := s.runnerStateString(); state != runnerReady {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":       "input runner starting, retry shortly",
+			"runnerState": string(state),
+		})
+		return false
+	}
+	return true
 }
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
@@ -218,6 +323,9 @@ func (s *Server) handleTap(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+	if !s.inputReady(w) {
+		return
+	}
 	x, y, err := s.fractionToPoints(req.X, req.Y)
 	if err != nil {
 		httpError(w, err)
@@ -229,6 +337,9 @@ func (s *Server) handleTap(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleSwipe(w http.ResponseWriter, r *http.Request) {
 	var req swipeRequest
 	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if !s.inputReady(w) {
 		return
 	}
 	fx, fy, err := s.fractionToPoints(req.FromX, req.FromY)
@@ -251,6 +362,9 @@ func (s *Server) handleType(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+	if !s.inputReady(w) {
+		return
+	}
 	s.runUI(w, "type", "--text="+req.Text)
 }
 
@@ -263,6 +377,9 @@ func (s *Server) handleButton(w http.ResponseWriter, r *http.Request) {
 	case "home", "lock", "volumeup", "volumedown":
 	default:
 		httpError(w, fmt.Errorf("unknown button %q", req.Name))
+		return
+	}
+	if !s.inputReady(w) {
 		return
 	}
 	s.runUI(w, "button", req.Name)

--- a/ios/remote/remote.go
+++ b/ios/remote/remote.go
@@ -48,6 +48,13 @@ const (
 	DefaultWDAURL = "http://127.0.0.1:8100"
 	// DefaultDeviceKitURL is the DeviceKit base URL used when none is supplied.
 	DefaultDeviceKitURL = "http://127.0.0.1:12004"
+
+	// DefaultFPS and DefaultBitrate are the frame rate and bitrate requested from
+	// the DeviceKit runner's /h264 endpoint. The runner's own default is ~27fps;
+	// asking for 60 (the runner clamps to what the hardware encoder delivers,
+	// ~45-50fps in practice) makes the browser mirror noticeably smoother.
+	DefaultFPS     = 60
+	DefaultBitrate = 8000000
 )
 
 // Server is a minimal browser remote-control for a single device.
@@ -63,6 +70,11 @@ type Server struct {
 	// deviceKitURL is the DeviceKit runner base URL the screen video is proxied
 	// from (its /h264 and /mjpeg endpoints), independent of the input driver.
 	deviceKitURL string
+
+	// fps and bitrate are passed through to the runner's /h264 as query params to
+	// raise the frame rate/quality above the runner's low defaults.
+	fps     int
+	bitrate int
 
 	// iosBinary is the path to the `ios` CLI used to drive input.
 	iosBinary string
@@ -94,6 +106,11 @@ type Config struct {
 	// it across the intermittent testmanagerd DTX EOF disconnects. When false the
 	// runner is assumed to be started externally at DriverURL (today's behavior).
 	ManageRunner bool
+
+	// FPS and Bitrate are forwarded to the DeviceKit runner's /h264 endpoint as
+	// query params. Zero values fall back to DefaultFPS / DefaultBitrate.
+	FPS     int
+	Bitrate int
 }
 
 // NewServer wires up a remote-control server for the given device from cfg.
@@ -121,12 +138,23 @@ func NewServer(device ios.DeviceEntry, cfg Config) (*Server, error) {
 		}
 	}
 
+	fps := cfg.FPS
+	if fps <= 0 {
+		fps = DefaultFPS
+	}
+	bitrate := cfg.Bitrate
+	if bitrate <= 0 {
+		bitrate = DefaultBitrate
+	}
+
 	s := &Server{
 		device:       device,
 		udid:         udid,
 		driver:       driver,
 		driverURL:    cfg.DriverURL,
 		deviceKitURL: deviceKitURL,
+		fps:          fps,
+		bitrate:      bitrate,
 		iosBinary:    iosBinary,
 	}
 
@@ -259,9 +287,12 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 
 // handleVideoH264 streams the DeviceKit runner's hardware H.264 elementary
 // stream (Annex-B) to the browser, which decodes it via WebCodecs. It is the
-// primary, efficient screen source.
+// primary, efficient screen source. The runner's low default frame rate is
+// raised by forwarding the configured fps/bitrate as query params (the runner
+// honors them; the hardware encoder clamps to what it can actually deliver).
 func (s *Server) handleVideoH264(w http.ResponseWriter, r *http.Request) {
-	s.proxyRunnerStream(w, r, "/h264", "video/h264")
+	path := "/h264?fps=" + strconv.Itoa(s.fps) + "&bitrate=" + strconv.Itoa(s.bitrate)
+	s.proxyRunnerStream(w, r, path, "video/h264")
 }
 
 // handleScreen streams the DeviceKit runner's MJPEG to the browser as the

--- a/ios/remote/remote.go
+++ b/ios/remote/remote.go
@@ -24,6 +24,7 @@ import (
 	"image/jpeg"
 	"image/png"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"os/exec"
@@ -282,8 +283,10 @@ func clamp01(v float64) float64 {
 	return v
 }
 
+// ftoa formats a coordinate for `ios ui tap/swipe`, which parse --x/--y as
+// integers and reject decimals ("--x is required"). Round to the nearest point.
 func ftoa(v float64) string {
-	return strconv.FormatFloat(v, 'f', 2, 64)
+	return strconv.FormatInt(int64(math.Round(v)), 10)
 }
 
 // logicalSize returns the device's WDA logical window size in points, caching

--- a/ios/remote/remote.go
+++ b/ios/remote/remote.go
@@ -236,7 +236,9 @@ func (s *Server) handleButton(w http.ResponseWriter, r *http.Request) {
 // non-reachable WDA surfaces here as a non-zero exit + stderr in the response.
 func (s *Server) runUI(w http.ResponseWriter, args ...string) {
 	full := append([]string{"ui"}, args...)
-	full = append(full, "--udid="+s.udid, "--wda-url="+s.wdaURL)
+	// Always drive WDA: input is WDA-backed and we pass --wda-url, so pin the
+	// driver rather than let `ios ui` auto-detect (which prefers DeviceKit).
+	full = append(full, "--driver=wda", "--udid="+s.udid, "--wda-url="+s.wdaURL)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -297,7 +299,7 @@ func (s *Server) logicalSize() (float64, float64, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, s.iosBinary, "ui", "size", "--udid="+s.udid, "--wda-url="+s.wdaURL)
+	cmd := exec.CommandContext(ctx, s.iosBinary, "ui", "size", "--driver=wda", "--udid="+s.udid, "--wda-url="+s.wdaURL)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return 0, 0, fmt.Errorf("ui size failed (is WDA reachable at %s?): %v: %s", s.wdaURL, err, out)

--- a/ios/remote/remote.go
+++ b/ios/remote/remote.go
@@ -376,8 +376,11 @@ const (
 // helper in ios/instruments it holds no global state, so multiple servers /
 // tests don't collide.
 type screenBroadcaster struct {
-	svc  *instruments.ScreenshotService
-	udid string
+	device ios.DeviceEntry
+	udid   string
+
+	svcMu sync.Mutex
+	svc   *instruments.ScreenshotService
 
 	mu        sync.Mutex
 	consumers map[chan []byte]struct{}
@@ -389,6 +392,7 @@ func newScreenBroadcaster(device ios.DeviceEntry) (*screenBroadcaster, error) {
 		return nil, err
 	}
 	bc := &screenBroadcaster{
+		device:    device,
 		svc:       svc,
 		udid:      device.Properties.SerialNumber,
 		consumers: make(map[chan []byte]struct{}),
@@ -433,17 +437,27 @@ func (bc *screenBroadcaster) broadcast(jpg []byte) {
 // loop captures screenshots (~12 fps) and broadcasts them as JPEG. The
 // instruments service returns PNG on some devices and JPEG on others; we
 // transcode PNG to JPEG and pass JPEG through untouched.
+//
+// The screenshot service can wedge (e.g. a takeScreenshot timeout while a WDA
+// XCUITest session contends for the same DVT channel). Rather than stopping the
+// stream for good — this server is meant to run unattended — the loop tears the
+// service down and reconnects, so the mirror recovers on its own.
 func (bc *screenBroadcaster) loop() {
 	var opt jpeg.Options
 	opt.Quality = 80
-	const targetInterval = 80 * time.Millisecond // ~12 fps
+	const (
+		targetInterval = 80 * time.Millisecond // ~12 fps
+		reconnectDelay = 2 * time.Second
+	)
 
 	for {
 		start := time.Now()
-		raw, err := bc.svc.TakeScreenshot()
+		raw, err := bc.currentService().TakeScreenshot()
 		if err != nil {
-			golog.Error("screenshot failed, stopping screen loop", "module", logModule, "udid", bc.udid, "error", err)
-			return
+			golog.Error("screenshot failed, reconnecting screen service", "module", logModule, "udid", bc.udid, "error", err)
+			bc.reconnect()
+			time.Sleep(reconnectDelay)
+			continue
 		}
 		jpg, err := toJPEG(raw, &opt)
 		if err != nil {
@@ -454,6 +468,37 @@ func (bc *screenBroadcaster) loop() {
 		if d := targetInterval - time.Since(start); d > 0 {
 			time.Sleep(d)
 		}
+	}
+}
+
+func (bc *screenBroadcaster) currentService() *instruments.ScreenshotService {
+	bc.svcMu.Lock()
+	defer bc.svcMu.Unlock()
+	return bc.svc
+}
+
+// reconnect closes the wedged screenshot service and dials a fresh one. It
+// retries until it succeeds so a transient tunnel/DVT hiccup doesn't kill the
+// mirror permanently.
+func (bc *screenBroadcaster) reconnect() {
+	bc.svcMu.Lock()
+	if bc.svc != nil {
+		bc.svc.Close()
+		bc.svc = nil
+	}
+	bc.svcMu.Unlock()
+
+	for {
+		svc, err := instruments.NewScreenshotService(bc.device)
+		if err == nil {
+			bc.svcMu.Lock()
+			bc.svc = svc
+			bc.svcMu.Unlock()
+			golog.Info("screen service reconnected", "module", logModule, "udid", bc.udid)
+			return
+		}
+		golog.Warn("screen service reconnect failed, retrying", "module", logModule, "udid", bc.udid, "error", err)
+		time.Sleep(2 * time.Second)
 	}
 }
 
@@ -481,7 +526,13 @@ func toJPEG(raw []byte, opt *jpeg.Options) ([]byte, error) {
 
 // Close releases the screenshot service.
 func (s *Server) Close() {
-	if s.screen != nil && s.screen.svc != nil {
+	if s.screen == nil {
+		return
+	}
+	s.screen.svcMu.Lock()
+	defer s.screen.svcMu.Unlock()
+	if s.screen.svc != nil {
 		s.screen.svc.Close()
+		s.screen.svc = nil
 	}
 }

--- a/ios/remote/remote.go
+++ b/ios/remote/remote.go
@@ -1,30 +1,28 @@
 // Package remote implements `ios remote`: a tiny, self-contained browser
 // remote-control for an iOS device.
 //
-// Architecture (two independent halves):
+// Architecture: ONE supervised DeviceKit runner backs BOTH the screen and
+// input, so `ios remote` needs no WebDriverAgent and no instruments DTX
+// channel.
 //
-//   - Live screen is WDA-FREE. It reuses the instruments screenshot service
-//     (ios/instruments) and streams JPEG frames as an MJPEG
-//     (multipart/x-mixed-replace) response at GET /screen. This needs the
-//     tunnel + a mounted developer disk image, but no WebDriverAgent.
-//   - Input goes through a UI automation driver — DeviceKit by default (WDA is
-//     broken on iOS 26; DeviceKit works there). go-ios has no native touch
+//   - Live screen is a passthrough of the DeviceKit runner's hardware video:
+//     GET /video.h264 proxies the runner's /h264 (an H.264 Annex-B elementary
+//     stream, hardware-encoded and delta-compressed — a few KB/s), and GET
+//     /screen proxies the runner's /mjpeg as a browser-native fallback. Bytes
+//     are flushed through as they arrive; the proxy reconnects with backoff so
+//     the screen self-heals when the supervised runner respawns.
+//   - Input goes through the same DeviceKit runner. go-ios has no native touch
 //     injection here, so rather than re-implement the driver client the handlers
 //     shell out to the SAME `ios` binary (located via os.Executable) and reuse
 //     the proven `ios ui …` commands, targeting the device udid and the
-//     configured driver/URL. So the screen works with no driver running;
-//     taps/swipes/typing need a reachable driver (DeviceKit at --devicekit-url,
-//     or WDA at --wda-url when --driver=wda).
+//     configured driver/URL. (WDA is still selectable with --driver=wda for
+//     input; the video proxy always targets the DeviceKit URL.)
 package remote
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"image/jpeg"
-	"image/png"
 	"io"
 	"math"
 	"net/http"
@@ -36,7 +34,6 @@ import (
 
 	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/golog"
-	"github.com/danielpaulus/go-ios/ios/instruments"
 )
 
 const logModule = "go-ios/remote"
@@ -53,12 +50,6 @@ const (
 	DefaultDeviceKitURL = "http://127.0.0.1:12004"
 )
 
-// DeviceResolver re-resolves the device (including fresh tunnel/RSD info). It is
-// called on every screen-service reconnect so a changed tunnel address (CI run
-// ended, replug, tunnel daemon restart) is picked up instead of dialing the
-// stale cached address forever. Returning an error keeps the previous device.
-type DeviceResolver func() (ios.DeviceEntry, error)
-
 // Server is a minimal browser remote-control for a single device.
 type Server struct {
 	device ios.DeviceEntry
@@ -69,6 +60,10 @@ type Server struct {
 	driver    string
 	driverURL string
 
+	// deviceKitURL is the DeviceKit runner base URL the screen video is proxied
+	// from (its /h264 and /mjpeg endpoints), independent of the input driver.
+	deviceKitURL string
+
 	// iosBinary is the path to the `ios` CLI used to drive input.
 	iosBinary string
 
@@ -77,10 +72,6 @@ type Server struct {
 	// managed (--manage-runner=false or --driver=wda), in which case input
 	// endpoints assume the driver is always reachable.
 	supervisor *runnerSupervisor
-
-	// screen is the shared latest-JPEG-frame broadcaster fed by the
-	// instruments screenshot loop. It is driver-free.
-	screen *screenBroadcaster
 
 	// logical device size in the driver's points, resolved lazily and cached.
 	sizeMu sync.Mutex
@@ -94,9 +85,10 @@ type Config struct {
 	// that driver's base URL (defaults applied upstream).
 	Driver    string
 	DriverURL string
-	// Resolver re-fetches fresh tunnel info on screen reconnect; nil disables
-	// refresh.
-	Resolver DeviceResolver
+	// DeviceKitURL is the DeviceKit runner base URL the screen video is proxied
+	// from. Defaults to DriverURL when the driver is DeviceKit, otherwise to
+	// DefaultDeviceKitURL.
+	DeviceKitURL string
 	// ManageRunner, when true and Driver is DeviceKit, makes the Server spawn and
 	// supervise the input runner (`ios ui run devicekit`) itself, auto-respawning
 	// it across the intermittent testmanagerd DTX EOF disconnects. When false the
@@ -104,11 +96,10 @@ type Config struct {
 	ManageRunner bool
 }
 
-// NewServer wires up a remote-control server for the given device from cfg. The
-// screen half connects to the instruments screenshot service immediately so a
-// failure (e.g. missing developer disk image) surfaces before we start
-// listening. When cfg.ManageRunner is set and the driver is DeviceKit, the
-// Server also supervises the input runner (started by Run).
+// NewServer wires up a remote-control server for the given device from cfg.
+// Screen and input are both served by the DeviceKit runner; when
+// cfg.ManageRunner is set (and the driver is DeviceKit) the Server supervises
+// that runner (started by Run) and the video proxy reconnects as it respawns.
 func NewServer(device ios.DeviceEntry, cfg Config) (*Server, error) {
 	iosBinary, err := os.Executable()
 	if err != nil {
@@ -120,18 +111,23 @@ func NewServer(device ios.DeviceEntry, cfg Config) (*Server, error) {
 	}
 	udid := device.Properties.SerialNumber
 
-	bc, err := newScreenBroadcaster(device, cfg.Resolver)
-	if err != nil {
-		return nil, fmt.Errorf("starting screenshot service: %w", err)
+	deviceKitURL := cfg.DeviceKitURL
+	if deviceKitURL == "" {
+		if driver == DriverDeviceKit {
+			deviceKitURL = cfg.DriverURL
+		}
+		if deviceKitURL == "" {
+			deviceKitURL = DefaultDeviceKitURL
+		}
 	}
 
 	s := &Server{
-		device:    device,
-		udid:      udid,
-		driver:    driver,
-		driverURL: cfg.DriverURL,
-		iosBinary: iosBinary,
-		screen:    bc,
+		device:       device,
+		udid:         udid,
+		driver:       driver,
+		driverURL:    cfg.DriverURL,
+		deviceKitURL: deviceKitURL,
+		iosBinary:    iosBinary,
 	}
 
 	// Supervision only makes sense for the DeviceKit runner we know how to spawn.
@@ -164,8 +160,8 @@ func (s *Server) Run(ctx context.Context, port string) error {
 	location := "0.0.0.0:" + port
 	golog.Info("starting remote-control server, open your browser here",
 		"module", logModule, "udid", s.udid, "host", "0.0.0.0", "port", port,
-		"driver", s.driver, "driverURL", s.driverURL, "manageRunner", s.supervisor != nil,
-		"url", fmt.Sprintf("http://%s/", location))
+		"driver", s.driver, "driverURL", s.driverURL, "deviceKitURL", s.deviceKitURL,
+		"manageRunner", s.supervisor != nil, "url", fmt.Sprintf("http://%s/", location))
 
 	// Supervise the input runner in the background; run() returns when ctx is
 	// cancelled, having stopped the child.
@@ -202,6 +198,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/", s.handleIndex)
 	mux.HandleFunc("/status", s.handleStatus)
 	mux.HandleFunc("/healthz", s.handleStatus)
+	mux.HandleFunc("/video.h264", s.handleVideoH264)
 	mux.HandleFunc("/screen", s.handleScreen)
 	mux.HandleFunc("/tap", s.handleTap)
 	mux.HandleFunc("/swipe", s.handleSwipe)
@@ -260,39 +257,145 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.WriteString(w, indexHTML)
 }
 
-func (s *Server) handleScreen(w http.ResponseWriter, r *http.Request) {
-	golog.Info("new screen stream client", "module", logModule, "udid", s.udid, "remote", r.RemoteAddr)
-	frames, unsubscribe := s.screen.subscribe()
-	defer unsubscribe()
+// handleVideoH264 streams the DeviceKit runner's hardware H.264 elementary
+// stream (Annex-B) to the browser, which decodes it via WebCodecs. It is the
+// primary, efficient screen source.
+func (s *Server) handleVideoH264(w http.ResponseWriter, r *http.Request) {
+	s.proxyRunnerStream(w, r, "/h264", "video/h264")
+}
 
-	w.Header().Set("Server", "go-ios-remote")
-	w.Header().Set("Connection", "close")
-	w.Header().Set("Content-Type", "multipart/x-mixed-replace; boundary="+mjpegBoundary)
-	w.Header().Set("Cache-Control", "no-cache, private")
-	w.Header().Set("Pragma", "no-cache")
-	w.WriteHeader(http.StatusOK)
+// handleScreen streams the DeviceKit runner's MJPEG to the browser as the
+// WebCodecs-less fallback screen source.
+func (s *Server) handleScreen(w http.ResponseWriter, r *http.Request) {
+	s.proxyRunnerStream(w, r, "/mjpeg", "")
+}
+
+// proxyRunnerStream passthrough-proxies one of the DeviceKit runner's streaming
+// endpoints (path) to the browser, flushing bytes as they arrive (never
+// buffering the whole stream). It reconnects to the runner with a small backoff
+// so the screen self-heals when the supervised runner respawns, and stops when
+// the browser disconnects. contentType, when non-empty, overrides the runner's
+// (H.264 needs an explicit video/h264); otherwise the runner's is passed
+// through (MJPEG carries its own multipart boundary).
+func (s *Server) proxyRunnerStream(w http.ResponseWriter, r *http.Request, path, contentType string) {
+	target := s.deviceKitURL + path
+	golog.Info("new screen stream client", "module", logModule, "udid", s.udid,
+		"remote", r.RemoteAddr, "path", path, "target", target)
 
 	flusher, _ := w.(http.Flusher)
+	wroteHeader := false
+	backoff := 250 * time.Millisecond
+	const backoffMax = 2 * time.Second
+
 	for {
-		select {
-		case <-r.Context().Done():
-			golog.Info("screen stream client disconnected", "module", logModule, "udid", s.udid, "remote", r.RemoteAddr)
+		if r.Context().Err() != nil {
 			return
-		case jpg := <-frames:
-			if _, err := io.WriteString(w, fmt.Sprintf(mjpegFrameHeader, len(jpg))); err != nil {
+		}
+		// Only attempt to stream when the runner is ready; otherwise wait so the
+		// screen "reconnects" in lockstep with the supervised runner respawning.
+		if s.runnerStateString() != runnerReady {
+			if !sleepCtx(r.Context(), backoff) {
 				return
 			}
-			if _, err := w.Write(jpg); err != nil {
-				return
+			continue
+		}
+
+		n, err := s.pipeRunnerStream(w, r, target, contentType, &wroteHeader, flusher)
+		if r.Context().Err() != nil {
+			return
+		}
+		// A stream that carried data then dropped is a runner restart: reconnect
+		// promptly. A stream that never connected backs off so we don't spin.
+		if n > 0 {
+			backoff = 250 * time.Millisecond
+		}
+		golog.Info("screen stream reconnecting", "module", logModule, "udid", s.udid,
+			"path", path, "bytes", n, "error", errString(err))
+		if !sleepCtx(r.Context(), backoff) {
+			return
+		}
+		if backoff *= 2; backoff > backoffMax {
+			backoff = backoffMax
+		}
+	}
+}
+
+// pipeRunnerStream opens one connection to the runner and copies its body to w,
+// flushing per read. It writes the response header (once, on the first
+// successful connect) via wroteHeader. It returns the number of bytes copied and
+// the error that ended the copy (nil on a clean EOF).
+func (s *Server) pipeRunnerStream(w http.ResponseWriter, r *http.Request, target, contentType string, wroteHeader *bool, flusher http.Flusher) (int64, error) {
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, target, nil)
+	if err != nil {
+		return 0, err
+	}
+	// No client timeout: these are long-lived streams. The request context
+	// (browser disconnect / server shutdown) is the only lifetime bound.
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("runner %s returned %d", target, resp.StatusCode)
+	}
+
+	if !*wroteHeader {
+		ct := contentType
+		if ct == "" {
+			ct = resp.Header.Get("Content-Type")
+		}
+		if ct != "" {
+			w.Header().Set("Content-Type", ct)
+		}
+		w.Header().Set("Server", "go-ios-remote")
+		w.Header().Set("Cache-Control", "no-cache, private")
+		w.Header().Set("Pragma", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		*wroteHeader = true
+	}
+
+	// Copy chunk-by-chunk, flushing each so bytes reach the browser immediately.
+	buf := make([]byte, 32*1024)
+	var total int64
+	for {
+		nr, rerr := resp.Body.Read(buf)
+		if nr > 0 {
+			if _, werr := w.Write(buf[:nr]); werr != nil {
+				return total, werr
 			}
-			if _, err := io.WriteString(w, mjpegFrameFooter); err != nil {
-				return
-			}
+			total += int64(nr)
 			if flusher != nil {
 				flusher.Flush()
 			}
 		}
+		if rerr != nil {
+			if rerr == io.EOF {
+				return total, nil
+			}
+			return total, rerr
+		}
 	}
+}
+
+// sleepCtx sleeps for d unless ctx is cancelled first; it returns false if the
+// context was cancelled (so the caller should stop).
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 // tapRequest is the fraction-based coordinate the browser sends. x and y are
@@ -478,10 +581,7 @@ func (s *Server) logicalSize() (float64, float64, error) {
 //
 // It tolerates surrounding whitespace/log noise by scanning for the first '{'.
 func parseSize(out []byte) (float64, float64, error) {
-	trimmed := bytes.TrimSpace(out)
-	if i := bytes.IndexByte(trimmed, '{'); i > 0 {
-		trimmed = trimmed[i:]
-	}
+	trimmed := trimToJSON(out)
 	type screenSize struct {
 		Width  float64 `json:"width"`
 		Height float64 `json:"height"`
@@ -519,6 +619,16 @@ func parseSize(out []byte) (float64, float64, error) {
 	return w, h, nil
 }
 
+// trimToJSON strips leading log noise before the first '{'.
+func trimToJSON(out []byte) []byte {
+	for i := 0; i < len(out); i++ {
+		if out[i] == '{' {
+			return out[i:]
+		}
+	}
+	return out
+}
+
 func decodeJSON(w http.ResponseWriter, r *http.Request, v interface{}) bool {
 	if r.Method != http.MethodPost {
 		http.Error(w, "POST only", http.StatusMethodNotAllowed)
@@ -536,194 +646,7 @@ func httpError(w http.ResponseWriter, err error) {
 	http.Error(w, err.Error(), http.StatusBadRequest)
 }
 
-// --- MJPEG plumbing (WDA-free screen) ---
-
-const mjpegBoundary = "goiosremoteframe"
-
-const (
-	mjpegFrameHeader = "--" + mjpegBoundary + "\r\nContent-Type: image/jpeg\r\nContent-Length: %d\r\n\r\n"
-	mjpegFrameFooter = "\r\n"
-)
-
-// screenBroadcaster runs the instruments screenshot loop once and fans the
-// latest JPEG frame out to all connected /screen clients. Unlike the package
-// helper in ios/instruments it holds no global state, so multiple servers /
-// tests don't collide.
-type screenBroadcaster struct {
-	device   ios.DeviceEntry
-	udid     string
-	resolver DeviceResolver
-
-	svcMu sync.Mutex
-	svc   *instruments.ScreenshotService
-
-	mu        sync.Mutex
-	consumers map[chan []byte]struct{}
-}
-
-func newScreenBroadcaster(device ios.DeviceEntry, resolver DeviceResolver) (*screenBroadcaster, error) {
-	svc, err := instruments.NewScreenshotService(device)
-	if err != nil {
-		return nil, err
-	}
-	bc := &screenBroadcaster{
-		device:    device,
-		udid:      device.Properties.SerialNumber,
-		resolver:  resolver,
-		svc:       svc,
-		consumers: make(map[chan []byte]struct{}),
-	}
-	go bc.loop()
-	return bc, nil
-}
-
-func (bc *screenBroadcaster) subscribe() (<-chan []byte, func()) {
-	ch := make(chan []byte, 1)
-	bc.mu.Lock()
-	bc.consumers[ch] = struct{}{}
-	bc.mu.Unlock()
-	return ch, func() {
-		bc.mu.Lock()
-		delete(bc.consumers, ch)
-		bc.mu.Unlock()
-	}
-}
-
-func (bc *screenBroadcaster) broadcast(jpg []byte) {
-	bc.mu.Lock()
-	defer bc.mu.Unlock()
-	for ch := range bc.consumers {
-		// Drop the oldest frame for slow consumers so a stalled client can
-		// never back-pressure the capture loop.
-		select {
-		case ch <- jpg:
-		default:
-			select {
-			case <-ch:
-			default:
-			}
-			select {
-			case ch <- jpg:
-			default:
-			}
-		}
-	}
-}
-
-// loop captures screenshots (~12 fps) and broadcasts them as JPEG. The
-// instruments service returns PNG on some devices and JPEG on others; we
-// transcode PNG to JPEG and pass JPEG through untouched.
-//
-// The screenshot service can wedge (e.g. a takeScreenshot timeout while a WDA
-// XCUITest session contends for the same DVT channel). Rather than stopping the
-// stream for good — this server is meant to run unattended — the loop tears the
-// service down and reconnects, so the mirror recovers on its own.
-func (bc *screenBroadcaster) loop() {
-	var opt jpeg.Options
-	opt.Quality = 80
-	const (
-		targetInterval = 80 * time.Millisecond // ~12 fps
-		reconnectDelay = 2 * time.Second
-	)
-
-	for {
-		start := time.Now()
-		raw, err := bc.currentService().TakeScreenshot()
-		if err != nil {
-			golog.Error("screenshot failed, reconnecting screen service", "module", logModule, "udid", bc.udid, "error", err)
-			bc.reconnect()
-			time.Sleep(reconnectDelay)
-			continue
-		}
-		jpg, err := toJPEG(raw, &opt)
-		if err != nil {
-			golog.Warn("failed converting frame to jpeg", "module", logModule, "udid", bc.udid, "error", err)
-			continue
-		}
-		bc.broadcast(jpg)
-		if d := targetInterval - time.Since(start); d > 0 {
-			time.Sleep(d)
-		}
-	}
-}
-
-func (bc *screenBroadcaster) currentService() *instruments.ScreenshotService {
-	bc.svcMu.Lock()
-	defer bc.svcMu.Unlock()
-	return bc.svc
-}
-
-// reconnect closes the wedged screenshot service and dials a fresh one. It
-// retries until it succeeds so a transient tunnel/DVT hiccup doesn't kill the
-// mirror permanently.
-//
-// Crucially it RE-FETCHES fresh tunnel/RSD info via the resolver on every
-// attempt. The device address is otherwise cached for the process lifetime, so
-// when the tunnel changes (CI run ends, replug, tunnel daemon restart) the old
-// address stops answering and every reconnect would dial it forever ("dial …
-// i/o timeout"), leaving the stream blank. Re-resolving mirrors what a fresh
-// `ios screenshot` does — it works precisely because it re-fetches each call.
-func (bc *screenBroadcaster) reconnect() {
-	bc.svcMu.Lock()
-	if bc.svc != nil {
-		bc.svc.Close()
-		bc.svc = nil
-	}
-	bc.svcMu.Unlock()
-
-	for {
-		if bc.resolver != nil {
-			if fresh, err := bc.resolver(); err == nil {
-				bc.device = fresh
-				golog.Info("refreshed tunnel info for screen reconnect", "module", logModule, "udid", bc.udid)
-			} else {
-				golog.Warn("tunnel-info refresh failed, reusing last known address", "module", logModule, "udid", bc.udid, "error", err)
-			}
-		}
-		svc, err := instruments.NewScreenshotService(bc.device)
-		if err == nil {
-			bc.svcMu.Lock()
-			bc.svc = svc
-			bc.svcMu.Unlock()
-			golog.Info("screen service reconnected", "module", logModule, "udid", bc.udid)
-			return
-		}
-		golog.Warn("screen service reconnect failed, retrying", "module", logModule, "udid", bc.udid, "error", err)
-		time.Sleep(2 * time.Second)
-	}
-}
-
-// toJPEG returns JPEG bytes for a raw screenshot payload. If the payload is
-// already JPEG (SOI marker 0xFFD8) it is returned as-is; otherwise it is
-// decoded as PNG and re-encoded.
-func toJPEG(raw []byte, opt *jpeg.Options) ([]byte, error) {
-	if len(raw) >= 2 && raw[0] == 0xFF && raw[1] == 0xD8 {
-		return raw, nil
-	}
-	img, err := png.Decode(bytes.NewReader(raw))
-	if err != nil {
-		return nil, err
-	}
-	var b bytes.Buffer
-	bw := bufio.NewWriter(&b)
-	if err := jpeg.Encode(bw, img, opt); err != nil {
-		return nil, err
-	}
-	if err := bw.Flush(); err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
-}
-
-// Close releases the screenshot service.
-func (s *Server) Close() {
-	if s.screen == nil {
-		return
-	}
-	s.screen.svcMu.Lock()
-	defer s.screen.svcMu.Unlock()
-	if s.screen.svc != nil {
-		s.screen.svc.Close()
-		s.screen.svc = nil
-	}
-}
+// Close releases server resources. The screen is now a stateless proxy of the
+// DeviceKit runner, so there is nothing to tear down here; the supervised runner
+// is stopped by Run on ctx cancellation.
+func (s *Server) Close() {}

--- a/ios/remote/remote.go
+++ b/ios/remote/remote.go
@@ -7,12 +7,14 @@
 //     (ios/instruments) and streams JPEG frames as an MJPEG
 //     (multipart/x-mixed-replace) response at GET /screen. This needs the
 //     tunnel + a mounted developer disk image, but no WebDriverAgent.
-//   - Input goes through WDA, because go-ios has no native touch injection on
-//     main. Rather than re-implement the WDA client, the handlers shell out to
-//     the SAME `ios` binary (located via os.Executable) and reuse the proven
-//     `ios ui …` commands, targeting the device udid and the configured
-//     --wda-url. So the screen works with no WDA running; taps/swipes/typing
-//     need a reachable WDA.
+//   - Input goes through a UI automation driver — DeviceKit by default (WDA is
+//     broken on iOS 26; DeviceKit works there). go-ios has no native touch
+//     injection here, so rather than re-implement the driver client the handlers
+//     shell out to the SAME `ios` binary (located via os.Executable) and reuse
+//     the proven `ios ui …` commands, targeting the device udid and the
+//     configured driver/URL. So the screen works with no driver running;
+//     taps/swipes/typing need a reachable driver (DeviceKit at --devicekit-url,
+//     or WDA at --wda-url when --driver=wda).
 package remote
 
 import (
@@ -39,40 +41,64 @@ import (
 
 const logModule = "go-ios/remote"
 
-// DefaultWDAURL is the WebDriverAgent base URL used when none is supplied.
-const DefaultWDAURL = "http://127.0.0.1:8100"
+const (
+	// DriverDeviceKit and DriverWDA are the supported input drivers. DeviceKit
+	// is the default because WDA is broken on iOS 26 while DeviceKit works.
+	DriverDeviceKit = "devicekit"
+	DriverWDA       = "wda"
+
+	// DefaultWDAURL is the WebDriverAgent base URL used when none is supplied.
+	DefaultWDAURL = "http://127.0.0.1:8100"
+	// DefaultDeviceKitURL is the DeviceKit base URL used when none is supplied.
+	DefaultDeviceKitURL = "http://127.0.0.1:12004"
+)
+
+// DeviceResolver re-resolves the device (including fresh tunnel/RSD info). It is
+// called on every screen-service reconnect so a changed tunnel address (CI run
+// ended, replug, tunnel daemon restart) is picked up instead of dialing the
+// stale cached address forever. Returning an error keeps the previous device.
+type DeviceResolver func() (ios.DeviceEntry, error)
 
 // Server is a minimal browser remote-control for a single device.
 type Server struct {
 	device ios.DeviceEntry
 	udid   string
-	wdaURL string
 
-	// iosBinary is the path to the `ios` CLI used to drive input via WDA.
+	// driver is the input backend ("devicekit" or "wda") and driverURL is its
+	// base URL, passed through to `ios ui … --driver=… --{devicekit,wda}-url=…`.
+	driver    string
+	driverURL string
+
+	// iosBinary is the path to the `ios` CLI used to drive input.
 	iosBinary string
 
 	// screen is the shared latest-JPEG-frame broadcaster fed by the
-	// instruments screenshot loop. It is WDA-free.
+	// instruments screenshot loop. It is driver-free.
 	screen *screenBroadcaster
 
-	// logical device size in WDA points, resolved lazily and cached.
+	// logical device size in the driver's points, resolved lazily and cached.
 	sizeMu sync.Mutex
 	sizeW  float64
 	sizeH  float64
 }
 
-// NewServer wires up a remote-control server for the given device. wdaURL is
-// already resolved by the caller (default applied upstream). The screen half
-// connects to the instruments screenshot service immediately so a failure
-// (e.g. missing developer disk image) surfaces before we start listening.
-func NewServer(device ios.DeviceEntry, wdaURL string) (*Server, error) {
+// NewServer wires up a remote-control server for the given device. driver is
+// "devicekit" (default) or "wda"; driverURL is that driver's base URL (defaults
+// applied upstream). resolver re-fetches fresh tunnel info on screen reconnect;
+// pass nil to disable refresh. The screen half connects to the instruments
+// screenshot service immediately so a failure (e.g. missing developer disk
+// image) surfaces before we start listening.
+func NewServer(device ios.DeviceEntry, driver, driverURL string, resolver DeviceResolver) (*Server, error) {
 	iosBinary, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("locating ios binary: %w", err)
 	}
+	if driver == "" {
+		driver = DriverDeviceKit
+	}
 	udid := device.Properties.SerialNumber
 
-	bc, err := newScreenBroadcaster(device)
+	bc, err := newScreenBroadcaster(device, resolver)
 	if err != nil {
 		return nil, fmt.Errorf("starting screenshot service: %w", err)
 	}
@@ -80,10 +106,20 @@ func NewServer(device ios.DeviceEntry, wdaURL string) (*Server, error) {
 	return &Server{
 		device:    device,
 		udid:      udid,
-		wdaURL:    wdaURL,
+		driver:    driver,
+		driverURL: driverURL,
 		iosBinary: iosBinary,
 		screen:    bc,
 	}, nil
+}
+
+// driverURLFlag returns the `ios ui` flag that carries driverURL for the
+// configured driver (--devicekit-url for DeviceKit, --wda-url for WDA).
+func (s *Server) driverURLFlag() string {
+	if s.driver == DriverWDA {
+		return "--wda-url=" + s.driverURL
+	}
+	return "--devicekit-url=" + s.driverURL
 }
 
 // ListenAndServe binds 0.0.0.0:<port> (reachable over Tailscale) and serves the
@@ -92,7 +128,7 @@ func (s *Server) ListenAndServe(port string) error {
 	location := "0.0.0.0:" + port
 	golog.Info("starting remote-control server, open your browser here",
 		"module", logModule, "udid", s.udid, "host", "0.0.0.0", "port", port,
-		"wdaURL", s.wdaURL, "url", fmt.Sprintf("http://%s/", location))
+		"driver", s.driver, "driverURL", s.driverURL, "url", fmt.Sprintf("http://%s/", location))
 	return http.ListenAndServe(location, s.Handler())
 }
 
@@ -232,14 +268,13 @@ func (s *Server) handleButton(w http.ResponseWriter, r *http.Request) {
 	s.runUI(w, "button", req.Name)
 }
 
-// runUI shells out to `ios ui <args…>` for the configured device and WDA URL,
-// returning the combined output to the browser. Input is WDA-backed; a
-// non-reachable WDA surfaces here as a non-zero exit + stderr in the response.
+// runUI shells out to `ios ui <args…>` for the configured device and driver,
+// returning the combined output to the browser. A non-reachable driver surfaces
+// here as a non-zero exit + stderr in the response.
 func (s *Server) runUI(w http.ResponseWriter, args ...string) {
 	full := append([]string{"ui"}, args...)
-	// Always drive WDA: input is WDA-backed and we pass --wda-url, so pin the
-	// driver rather than let `ios ui` auto-detect (which prefers DeviceKit).
-	full = append(full, "--driver=wda", "--udid="+s.udid, "--wda-url="+s.wdaURL)
+	// Pin the driver + its URL rather than let `ios ui` auto-detect.
+	full = append(full, "--driver="+s.driver, "--udid="+s.udid, s.driverURLFlag())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -261,10 +296,11 @@ func (s *Server) runUI(w http.ResponseWriter, args ...string) {
 }
 
 // fractionToPoints is the single place where the browser's 0..1 fraction is
-// mapped to WDA logical points. WDA taps take logical points, and its
-// window/size endpoint reports the same logical point space, so a fraction of
-// the screen maps linearly: point = fraction * logicalSize. The logical size is
-// fetched once (via `ios ui size`) and cached.
+// mapped to the driver's logical points. Both WDA and DeviceKit take taps in
+// logical points and report their size in the same logical point space, so a
+// fraction of the screen maps linearly: point = fraction * logicalSize. The
+// logical size is fetched once (via `ios ui size` on the same driver) and
+// cached — never a hardcoded/WDA size.
 func (s *Server) fractionToPoints(fx, fy float64) (float64, float64, error) {
 	w, h, err := s.logicalSize()
 	if err != nil {
@@ -289,10 +325,9 @@ func ftoa(v float64) string {
 	return strconv.FormatInt(int64(math.Round(v)), 10)
 }
 
-// logicalSize returns the device's WDA logical window size in points, caching
-// the first successful lookup. It calls `ios ui size` and parses the WDA
-// window/size response shape ({"value":{"width":W,"height":H}} or a bare
-// {"width":W,"height":H}).
+// logicalSize returns the device's logical window size in the driver's points,
+// caching the first successful lookup. It calls `ios ui size` on the configured
+// driver and parses that driver's response shape.
 func (s *Server) logicalSize() (float64, float64, error) {
 	s.sizeMu.Lock()
 	defer s.sizeMu.Unlock()
@@ -302,10 +337,10 @@ func (s *Server) logicalSize() (float64, float64, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, s.iosBinary, "ui", "size", "--driver=wda", "--udid="+s.udid, "--wda-url="+s.wdaURL)
+	cmd := exec.CommandContext(ctx, s.iosBinary, "ui", "size", "--driver="+s.driver, "--udid="+s.udid, s.driverURLFlag())
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return 0, 0, fmt.Errorf("ui size failed (is WDA reachable at %s?): %v: %s", s.wdaURL, err, out)
+		return 0, 0, fmt.Errorf("ui size failed (is the %s driver reachable at %s?): %v: %s", s.driver, s.driverURL, err, out)
 	}
 	w, h, err := parseSize(out)
 	if err != nil {
@@ -315,28 +350,50 @@ func (s *Server) logicalSize() (float64, float64, error) {
 	return w, h, nil
 }
 
-// parseSize extracts width/height from the JSON emitted by `ios ui size`. It
-// accepts both the WDA envelope ({"value":{"width":…,"height":…}}) and a bare
-// object, and tolerates surrounding whitespace/log noise by scanning for the
-// first '{'.
+// parseSize extracts logical width/height from the JSON emitted by `ios ui
+// size`. It accepts:
+//   - DeviceKit, which wraps a device.info result in a JSON-RPC envelope:
+//     {"result":{"screenSize":{"width":W,"height":H},"scale":S}} — the logical
+//     points are screenSize (the MJPEG frames are points × scale pixels).
+//   - the same {"screenSize":{…}} object unwrapped.
+//   - WDA: {"value":{"width":W,"height":H}} envelope.
+//   - a bare {"width":W,"height":H} object.
+//
+// It tolerates surrounding whitespace/log noise by scanning for the first '{'.
 func parseSize(out []byte) (float64, float64, error) {
 	trimmed := bytes.TrimSpace(out)
 	if i := bytes.IndexByte(trimmed, '{'); i > 0 {
 		trimmed = trimmed[i:]
 	}
-	var envelope struct {
+	type screenSize struct {
 		Width  float64 `json:"width"`
 		Height float64 `json:"height"`
-		Value  struct {
-			Width  float64 `json:"width"`
-			Height float64 `json:"height"`
-		} `json:"value"`
+	}
+	var envelope struct {
+		Width      float64    `json:"width"`
+		Height     float64    `json:"height"`
+		ScreenSize screenSize `json:"screenSize"`
+		// DeviceKit JSON-RPC envelope: {"result":{"screenSize":{…}}}.
+		Result struct {
+			ScreenSize screenSize `json:"screenSize"`
+			Width      float64    `json:"width"`
+			Height     float64    `json:"height"`
+		} `json:"result"`
+		// WDA envelope: {"value":{"width":…,"height":…}}.
+		Value screenSize `json:"value"`
 	}
 	if err := json.Unmarshal(trimmed, &envelope); err != nil {
 		return 0, 0, fmt.Errorf("parsing ui size output %q: %w", out, err)
 	}
 	w, h := envelope.Width, envelope.Height
-	if envelope.Value.Width > 0 {
+	switch {
+	case envelope.Result.ScreenSize.Width > 0:
+		w, h = envelope.Result.ScreenSize.Width, envelope.Result.ScreenSize.Height
+	case envelope.ScreenSize.Width > 0:
+		w, h = envelope.ScreenSize.Width, envelope.ScreenSize.Height
+	case envelope.Result.Width > 0:
+		w, h = envelope.Result.Width, envelope.Result.Height
+	case envelope.Value.Width > 0:
 		w, h = envelope.Value.Width, envelope.Value.Height
 	}
 	if w <= 0 || h <= 0 {
@@ -376,8 +433,9 @@ const (
 // helper in ios/instruments it holds no global state, so multiple servers /
 // tests don't collide.
 type screenBroadcaster struct {
-	device ios.DeviceEntry
-	udid   string
+	device   ios.DeviceEntry
+	udid     string
+	resolver DeviceResolver
 
 	svcMu sync.Mutex
 	svc   *instruments.ScreenshotService
@@ -386,15 +444,16 @@ type screenBroadcaster struct {
 	consumers map[chan []byte]struct{}
 }
 
-func newScreenBroadcaster(device ios.DeviceEntry) (*screenBroadcaster, error) {
+func newScreenBroadcaster(device ios.DeviceEntry, resolver DeviceResolver) (*screenBroadcaster, error) {
 	svc, err := instruments.NewScreenshotService(device)
 	if err != nil {
 		return nil, err
 	}
 	bc := &screenBroadcaster{
 		device:    device,
-		svc:       svc,
 		udid:      device.Properties.SerialNumber,
+		resolver:  resolver,
+		svc:       svc,
 		consumers: make(map[chan []byte]struct{}),
 	}
 	go bc.loop()
@@ -480,6 +539,13 @@ func (bc *screenBroadcaster) currentService() *instruments.ScreenshotService {
 // reconnect closes the wedged screenshot service and dials a fresh one. It
 // retries until it succeeds so a transient tunnel/DVT hiccup doesn't kill the
 // mirror permanently.
+//
+// Crucially it RE-FETCHES fresh tunnel/RSD info via the resolver on every
+// attempt. The device address is otherwise cached for the process lifetime, so
+// when the tunnel changes (CI run ends, replug, tunnel daemon restart) the old
+// address stops answering and every reconnect would dial it forever ("dial …
+// i/o timeout"), leaving the stream blank. Re-resolving mirrors what a fresh
+// `ios screenshot` does — it works precisely because it re-fetches each call.
 func (bc *screenBroadcaster) reconnect() {
 	bc.svcMu.Lock()
 	if bc.svc != nil {
@@ -489,6 +555,14 @@ func (bc *screenBroadcaster) reconnect() {
 	bc.svcMu.Unlock()
 
 	for {
+		if bc.resolver != nil {
+			if fresh, err := bc.resolver(); err == nil {
+				bc.device = fresh
+				golog.Info("refreshed tunnel info for screen reconnect", "module", logModule, "udid", bc.udid)
+			} else {
+				golog.Warn("tunnel-info refresh failed, reusing last known address", "module", logModule, "udid", bc.udid, "error", err)
+			}
+		}
 		svc, err := instruments.NewScreenshotService(bc.device)
 		if err == nil {
 			bc.svcMu.Lock()

--- a/ios/remote/remote.go
+++ b/ios/remote/remote.go
@@ -1,0 +1,482 @@
+// Package remote implements `ios remote`: a tiny, self-contained browser
+// remote-control for an iOS device.
+//
+// Architecture (two independent halves):
+//
+//   - Live screen is WDA-FREE. It reuses the instruments screenshot service
+//     (ios/instruments) and streams JPEG frames as an MJPEG
+//     (multipart/x-mixed-replace) response at GET /screen. This needs the
+//     tunnel + a mounted developer disk image, but no WebDriverAgent.
+//   - Input goes through WDA, because go-ios has no native touch injection on
+//     main. Rather than re-implement the WDA client, the handlers shell out to
+//     the SAME `ios` binary (located via os.Executable) and reuse the proven
+//     `ios ui …` commands, targeting the device udid and the configured
+//     --wda-url. So the screen works with no WDA running; taps/swipes/typing
+//     need a reachable WDA.
+package remote
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/golog"
+	"github.com/danielpaulus/go-ios/ios/instruments"
+)
+
+const logModule = "go-ios/remote"
+
+// DefaultWDAURL is the WebDriverAgent base URL used when none is supplied.
+const DefaultWDAURL = "http://127.0.0.1:8100"
+
+// Server is a minimal browser remote-control for a single device.
+type Server struct {
+	device ios.DeviceEntry
+	udid   string
+	wdaURL string
+
+	// iosBinary is the path to the `ios` CLI used to drive input via WDA.
+	iosBinary string
+
+	// screen is the shared latest-JPEG-frame broadcaster fed by the
+	// instruments screenshot loop. It is WDA-free.
+	screen *screenBroadcaster
+
+	// logical device size in WDA points, resolved lazily and cached.
+	sizeMu sync.Mutex
+	sizeW  float64
+	sizeH  float64
+}
+
+// NewServer wires up a remote-control server for the given device. wdaURL is
+// already resolved by the caller (default applied upstream). The screen half
+// connects to the instruments screenshot service immediately so a failure
+// (e.g. missing developer disk image) surfaces before we start listening.
+func NewServer(device ios.DeviceEntry, wdaURL string) (*Server, error) {
+	iosBinary, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("locating ios binary: %w", err)
+	}
+	udid := device.Properties.SerialNumber
+
+	bc, err := newScreenBroadcaster(device)
+	if err != nil {
+		return nil, fmt.Errorf("starting screenshot service: %w", err)
+	}
+
+	return &Server{
+		device:    device,
+		udid:      udid,
+		wdaURL:    wdaURL,
+		iosBinary: iosBinary,
+		screen:    bc,
+	}, nil
+}
+
+// ListenAndServe binds 0.0.0.0:<port> (reachable over Tailscale) and serves the
+// UI until the process is stopped.
+func (s *Server) ListenAndServe(port string) error {
+	location := "0.0.0.0:" + port
+	golog.Info("starting remote-control server, open your browser here",
+		"module", logModule, "udid", s.udid, "host", "0.0.0.0", "port", port,
+		"wdaURL", s.wdaURL, "url", fmt.Sprintf("http://%s/", location))
+	return http.ListenAndServe(location, s.Handler())
+}
+
+// Handler returns the HTTP handler for the remote-control UI and endpoints.
+// Exposed so tests can exercise it without binding a socket.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleIndex)
+	mux.HandleFunc("/screen", s.handleScreen)
+	mux.HandleFunc("/tap", s.handleTap)
+	mux.HandleFunc("/swipe", s.handleSwipe)
+	mux.HandleFunc("/type", s.handleType)
+	mux.HandleFunc("/button", s.handleButton)
+	return mux
+}
+
+func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(w, indexHTML)
+}
+
+func (s *Server) handleScreen(w http.ResponseWriter, r *http.Request) {
+	golog.Info("new screen stream client", "module", logModule, "udid", s.udid, "remote", r.RemoteAddr)
+	frames, unsubscribe := s.screen.subscribe()
+	defer unsubscribe()
+
+	w.Header().Set("Server", "go-ios-remote")
+	w.Header().Set("Connection", "close")
+	w.Header().Set("Content-Type", "multipart/x-mixed-replace; boundary="+mjpegBoundary)
+	w.Header().Set("Cache-Control", "no-cache, private")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, _ := w.(http.Flusher)
+	for {
+		select {
+		case <-r.Context().Done():
+			golog.Info("screen stream client disconnected", "module", logModule, "udid", s.udid, "remote", r.RemoteAddr)
+			return
+		case jpg := <-frames:
+			if _, err := io.WriteString(w, fmt.Sprintf(mjpegFrameHeader, len(jpg))); err != nil {
+				return
+			}
+			if _, err := w.Write(jpg); err != nil {
+				return
+			}
+			if _, err := io.WriteString(w, mjpegFrameFooter); err != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}
+}
+
+// tapRequest is the fraction-based coordinate the browser sends. x and y are
+// each in [0,1], measured against the displayed image. Sending fractions keeps
+// the browser oblivious to the device's pixel/point sizes and CSS scaling.
+type tapRequest struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
+type swipeRequest struct {
+	FromX float64 `json:"fromX"`
+	FromY float64 `json:"fromY"`
+	ToX   float64 `json:"toX"`
+	ToY   float64 `json:"toY"`
+}
+
+type typeRequest struct {
+	Text string `json:"text"`
+}
+
+type buttonRequest struct {
+	Name string `json:"name"`
+}
+
+func (s *Server) handleTap(w http.ResponseWriter, r *http.Request) {
+	var req tapRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	x, y, err := s.fractionToPoints(req.X, req.Y)
+	if err != nil {
+		httpError(w, err)
+		return
+	}
+	s.runUI(w, "tap", "--x="+ftoa(x), "--y="+ftoa(y))
+}
+
+func (s *Server) handleSwipe(w http.ResponseWriter, r *http.Request) {
+	var req swipeRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	fx, fy, err := s.fractionToPoints(req.FromX, req.FromY)
+	if err != nil {
+		httpError(w, err)
+		return
+	}
+	tx, ty, err := s.fractionToPoints(req.ToX, req.ToY)
+	if err != nil {
+		httpError(w, err)
+		return
+	}
+	s.runUI(w, "swipe",
+		"--from-x="+ftoa(fx), "--from-y="+ftoa(fy),
+		"--to-x="+ftoa(tx), "--to-y="+ftoa(ty))
+}
+
+func (s *Server) handleType(w http.ResponseWriter, r *http.Request) {
+	var req typeRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	s.runUI(w, "type", "--text="+req.Text)
+}
+
+func (s *Server) handleButton(w http.ResponseWriter, r *http.Request) {
+	var req buttonRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	switch req.Name {
+	case "home", "lock", "volumeup", "volumedown":
+	default:
+		httpError(w, fmt.Errorf("unknown button %q", req.Name))
+		return
+	}
+	s.runUI(w, "button", req.Name)
+}
+
+// runUI shells out to `ios ui <args…>` for the configured device and WDA URL,
+// returning the combined output to the browser. Input is WDA-backed; a
+// non-reachable WDA surfaces here as a non-zero exit + stderr in the response.
+func (s *Server) runUI(w http.ResponseWriter, args ...string) {
+	full := append([]string{"ui"}, args...)
+	full = append(full, "--udid="+s.udid, "--wda-url="+s.wdaURL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, s.iosBinary, full...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		golog.Warn("ui command failed", "module", logModule, "udid", s.udid,
+			"args", args, "error", err, "output", string(out))
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = fmt.Fprintf(w, "ui %v failed: %v\n%s", args, err, out)
+		return
+	}
+	golog.Debug("ui command ok", "module", logModule, "udid", s.udid, "args", args)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out)
+}
+
+// fractionToPoints is the single place where the browser's 0..1 fraction is
+// mapped to WDA logical points. WDA taps take logical points, and its
+// window/size endpoint reports the same logical point space, so a fraction of
+// the screen maps linearly: point = fraction * logicalSize. The logical size is
+// fetched once (via `ios ui size`) and cached.
+func (s *Server) fractionToPoints(fx, fy float64) (float64, float64, error) {
+	w, h, err := s.logicalSize()
+	if err != nil {
+		return 0, 0, err
+	}
+	return clamp01(fx) * w, clamp01(fy) * h, nil
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+func ftoa(v float64) string {
+	return strconv.FormatFloat(v, 'f', 2, 64)
+}
+
+// logicalSize returns the device's WDA logical window size in points, caching
+// the first successful lookup. It calls `ios ui size` and parses the WDA
+// window/size response shape ({"value":{"width":W,"height":H}} or a bare
+// {"width":W,"height":H}).
+func (s *Server) logicalSize() (float64, float64, error) {
+	s.sizeMu.Lock()
+	defer s.sizeMu.Unlock()
+	if s.sizeW > 0 && s.sizeH > 0 {
+		return s.sizeW, s.sizeH, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, s.iosBinary, "ui", "size", "--udid="+s.udid, "--wda-url="+s.wdaURL)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, 0, fmt.Errorf("ui size failed (is WDA reachable at %s?): %v: %s", s.wdaURL, err, out)
+	}
+	w, h, err := parseSize(out)
+	if err != nil {
+		return 0, 0, err
+	}
+	s.sizeW, s.sizeH = w, h
+	return w, h, nil
+}
+
+// parseSize extracts width/height from the JSON emitted by `ios ui size`. It
+// accepts both the WDA envelope ({"value":{"width":…,"height":…}}) and a bare
+// object, and tolerates surrounding whitespace/log noise by scanning for the
+// first '{'.
+func parseSize(out []byte) (float64, float64, error) {
+	trimmed := bytes.TrimSpace(out)
+	if i := bytes.IndexByte(trimmed, '{'); i > 0 {
+		trimmed = trimmed[i:]
+	}
+	var envelope struct {
+		Width  float64 `json:"width"`
+		Height float64 `json:"height"`
+		Value  struct {
+			Width  float64 `json:"width"`
+			Height float64 `json:"height"`
+		} `json:"value"`
+	}
+	if err := json.Unmarshal(trimmed, &envelope); err != nil {
+		return 0, 0, fmt.Errorf("parsing ui size output %q: %w", out, err)
+	}
+	w, h := envelope.Width, envelope.Height
+	if envelope.Value.Width > 0 {
+		w, h = envelope.Value.Width, envelope.Value.Height
+	}
+	if w <= 0 || h <= 0 {
+		return 0, 0, fmt.Errorf("ui size returned non-positive dimensions from %q", out)
+	}
+	return w, h, nil
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, v interface{}) bool {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return false
+	}
+	dec := json.NewDecoder(io.LimitReader(r.Body, 1<<20))
+	if err := dec.Decode(v); err != nil {
+		httpError(w, fmt.Errorf("bad request body: %w", err))
+		return false
+	}
+	return true
+}
+
+func httpError(w http.ResponseWriter, err error) {
+	http.Error(w, err.Error(), http.StatusBadRequest)
+}
+
+// --- MJPEG plumbing (WDA-free screen) ---
+
+const mjpegBoundary = "goiosremoteframe"
+
+const (
+	mjpegFrameHeader = "--" + mjpegBoundary + "\r\nContent-Type: image/jpeg\r\nContent-Length: %d\r\n\r\n"
+	mjpegFrameFooter = "\r\n"
+)
+
+// screenBroadcaster runs the instruments screenshot loop once and fans the
+// latest JPEG frame out to all connected /screen clients. Unlike the package
+// helper in ios/instruments it holds no global state, so multiple servers /
+// tests don't collide.
+type screenBroadcaster struct {
+	svc  *instruments.ScreenshotService
+	udid string
+
+	mu        sync.Mutex
+	consumers map[chan []byte]struct{}
+}
+
+func newScreenBroadcaster(device ios.DeviceEntry) (*screenBroadcaster, error) {
+	svc, err := instruments.NewScreenshotService(device)
+	if err != nil {
+		return nil, err
+	}
+	bc := &screenBroadcaster{
+		svc:       svc,
+		udid:      device.Properties.SerialNumber,
+		consumers: make(map[chan []byte]struct{}),
+	}
+	go bc.loop()
+	return bc, nil
+}
+
+func (bc *screenBroadcaster) subscribe() (<-chan []byte, func()) {
+	ch := make(chan []byte, 1)
+	bc.mu.Lock()
+	bc.consumers[ch] = struct{}{}
+	bc.mu.Unlock()
+	return ch, func() {
+		bc.mu.Lock()
+		delete(bc.consumers, ch)
+		bc.mu.Unlock()
+	}
+}
+
+func (bc *screenBroadcaster) broadcast(jpg []byte) {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+	for ch := range bc.consumers {
+		// Drop the oldest frame for slow consumers so a stalled client can
+		// never back-pressure the capture loop.
+		select {
+		case ch <- jpg:
+		default:
+			select {
+			case <-ch:
+			default:
+			}
+			select {
+			case ch <- jpg:
+			default:
+			}
+		}
+	}
+}
+
+// loop captures screenshots (~12 fps) and broadcasts them as JPEG. The
+// instruments service returns PNG on some devices and JPEG on others; we
+// transcode PNG to JPEG and pass JPEG through untouched.
+func (bc *screenBroadcaster) loop() {
+	var opt jpeg.Options
+	opt.Quality = 80
+	const targetInterval = 80 * time.Millisecond // ~12 fps
+
+	for {
+		start := time.Now()
+		raw, err := bc.svc.TakeScreenshot()
+		if err != nil {
+			golog.Error("screenshot failed, stopping screen loop", "module", logModule, "udid", bc.udid, "error", err)
+			return
+		}
+		jpg, err := toJPEG(raw, &opt)
+		if err != nil {
+			golog.Warn("failed converting frame to jpeg", "module", logModule, "udid", bc.udid, "error", err)
+			continue
+		}
+		bc.broadcast(jpg)
+		if d := targetInterval - time.Since(start); d > 0 {
+			time.Sleep(d)
+		}
+	}
+}
+
+// toJPEG returns JPEG bytes for a raw screenshot payload. If the payload is
+// already JPEG (SOI marker 0xFFD8) it is returned as-is; otherwise it is
+// decoded as PNG and re-encoded.
+func toJPEG(raw []byte, opt *jpeg.Options) ([]byte, error) {
+	if len(raw) >= 2 && raw[0] == 0xFF && raw[1] == 0xD8 {
+		return raw, nil
+	}
+	img, err := png.Decode(bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	var b bytes.Buffer
+	bw := bufio.NewWriter(&b)
+	if err := jpeg.Encode(bw, img, opt); err != nil {
+		return nil, err
+	}
+	if err := bw.Flush(); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+// Close releases the screenshot service.
+func (s *Server) Close() {
+	if s.screen != nil && s.screen.svc != nil {
+		s.screen.svc.Close()
+	}
+}

--- a/ios/remote/remote_test.go
+++ b/ios/remote/remote_test.go
@@ -1,10 +1,14 @@
 package remote
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestParseSize(t *testing.T) {
@@ -137,7 +141,7 @@ func TestIndexServesHTML(t *testing.T) {
 		t.Fatalf("content-type = %q, want text/html", ct)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, "<html") || !strings.Contains(body, `src="/screen"`) {
+	if !strings.Contains(body, "<html") || !strings.Contains(body, "/video.h264") || !strings.Contains(body, "/screen") {
 		t.Fatalf("body does not look like the remote UI: %.120q", body)
 	}
 }
@@ -149,5 +153,155 @@ func TestButtonRejectsUnknown(t *testing.T) {
 	s.handleButton(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 for unknown button", rec.Code)
+	}
+}
+
+// TestVideoH264ProxySetsContentTypeAndStreams verifies /video.h264 proxies the
+// DeviceKit runner's /h264, forcing Content-Type video/h264 and flushing the
+// runner's bytes through as they arrive.
+func TestVideoH264ProxySetsContentTypeAndStreams(t *testing.T) {
+	// H.264 Annex-B: an SPS NAL prefixed with a 4-byte start code.
+	payload := []byte{0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00, 0x1f}
+	runner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/h264" {
+			http.NotFound(w, r)
+			return
+		}
+		// The runner labels the elementary stream video/h264 too, but the proxy
+		// must set it regardless (this is why we override).
+		w.Header().Set("Content-Type", "video/h264")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer runner.Close()
+
+	// No supervisor -> runner always "ready"; the proxy connects once, streams,
+	// then loops. Cancel the request context after we've read the body so the
+	// handler returns instead of reconnecting forever.
+	s := &Server{udid: "u", driver: DriverDeviceKit, deviceKitURL: runner.URL}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/video.h264", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() { s.handleVideoH264(rec, req); close(done) }()
+
+	// Give the proxy time to connect and stream the first payload, then stop it.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(rec.Body.Bytes()) >= len(payload) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if ct := rec.Header().Get("Content-Type"); ct != "video/h264" {
+		t.Fatalf("content-type = %q, want video/h264", ct)
+	}
+	got := rec.Body.Bytes()
+	if len(got) < len(payload) || string(got[:len(payload)]) != string(payload) {
+		t.Fatalf("body = %x, want it to start with the runner payload %x", got, payload)
+	}
+	// Sanity: the streamed bytes carry an Annex-B start code.
+	if !(got[0] == 0 && got[1] == 0 && got[2] == 0 && got[3] == 1) {
+		t.Fatalf("body does not start with an Annex-B start code: %x", got[:4])
+	}
+}
+
+// TestScreenProxyPassesThroughMJPEGContentType verifies /screen proxies the
+// runner's /mjpeg and passes its multipart content-type through unchanged.
+func TestScreenProxyPassesThroughMJPEGContentType(t *testing.T) {
+	const mjpegCT = "multipart/x-mixed-replace; boundary=frame"
+	frame := []byte("--frame\r\nContent-Type: image/jpeg\r\n\r\n\xff\xd8\xff\xd9\r\n")
+	runner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mjpeg" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", mjpegCT)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(frame)
+	}))
+	defer runner.Close()
+
+	s := &Server{udid: "u", driver: DriverDeviceKit, deviceKitURL: runner.URL}
+	ctx, cancel := context.WithCancel(context.Background())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/screen", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() { s.handleScreen(rec, req); close(done) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(rec.Body.Bytes()) >= len(frame) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if ct := rec.Header().Get("Content-Type"); ct != mjpegCT {
+		t.Fatalf("content-type = %q, want passthrough %q", ct, mjpegCT)
+	}
+}
+
+// TestVideoProxyReconnectsWhileRunnerNotReady verifies the proxy does not dial
+// the runner while it is not ready (so it "reconnects" in lockstep with the
+// supervised runner) and stops cleanly on client disconnect.
+func TestVideoProxyReconnectsWhileRunnerNotReady(t *testing.T) {
+	// A runner that records every dial; while state != ready the proxy must not
+	// call it.
+	var dials int32
+	runner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&dials, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer runner.Close()
+
+	sp := newFakeSpawner() // state starts as "starting" (not ready)
+	s := &Server{udid: "u", driver: DriverDeviceKit, deviceKitURL: runner.URL,
+		supervisor: newRunnerSupervisor("u", sp)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/video.h264", nil).WithContext(ctx)
+	done := make(chan struct{})
+	go func() { s.handleVideoH264(rec, req); close(done) }()
+
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := atomic.LoadInt32(&dials); got != 0 {
+		t.Fatalf("proxy dialed runner %d times while not ready, want 0", got)
+	}
+}
+
+// TestPipeRunnerStreamNon200 verifies a non-200 runner response is surfaced as
+// an error and no body header is written (so the caller can retry).
+func TestPipeRunnerStreamNon200(t *testing.T) {
+	runner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer runner.Close()
+	s := &Server{udid: "u", deviceKitURL: runner.URL}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/video.h264", nil)
+	wrote := false
+	// flusher is nil: it isn't reached on the error path (no body is copied).
+	n, err := s.pipeRunnerStream(rec, req, runner.URL+"/h264", "video/h264", &wrote, nil)
+	if err == nil {
+		t.Fatalf("expected error for non-200 runner, got nil (n=%d)", n)
+	}
+	if wrote {
+		t.Fatalf("wrote response header for a failed connect; want header deferred")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprint(http.StatusInternalServerError)) {
+		t.Fatalf("error %q should mention the status code", err)
 	}
 }

--- a/ios/remote/remote_test.go
+++ b/ios/remote/remote_test.go
@@ -1,0 +1,101 @@
+package remote
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseSize(t *testing.T) {
+	cases := []struct {
+		name         string
+		in           string
+		wantW, wantH float64
+		wantErr      bool
+	}{
+		{"wda envelope", `{"value":{"width":390,"height":844}}`, 390, 844, false},
+		{"bare object", `{"width":320,"height":568}`, 320, 568, false},
+		{"leading noise", "some log line\n{\"value\":{\"width\":428,\"height\":926}}", 428, 926, false},
+		{"non positive", `{"value":{"width":0,"height":0}}`, 0, 0, true},
+		{"garbage", `not json`, 0, 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w, h, err := parseSize([]byte(c.in))
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v x %v", w, h)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if w != c.wantW || h != c.wantH {
+				t.Fatalf("got %vx%v, want %vx%v", w, h, c.wantW, c.wantH)
+			}
+		})
+	}
+}
+
+func TestFractionToPoints(t *testing.T) {
+	// Prime the cache so fractionToPoints doesn't shell out to `ios ui size`.
+	s := &Server{sizeW: 390, sizeH: 844}
+
+	cases := []struct {
+		fx, fy       float64
+		wantX, wantY float64
+	}{
+		{0, 0, 0, 0},
+		{1, 1, 390, 844},
+		{0.5, 0.5, 195, 422},
+		{-0.5, 2, 0, 844}, // clamped to [0,1]
+	}
+	for _, c := range cases {
+		x, y, err := s.fractionToPoints(c.fx, c.fy)
+		if err != nil {
+			t.Fatalf("fractionToPoints(%v,%v): %v", c.fx, c.fy, err)
+		}
+		if x != c.wantX || y != c.wantY {
+			t.Fatalf("fractionToPoints(%v,%v)=%v,%v want %v,%v", c.fx, c.fy, x, y, c.wantX, c.wantY)
+		}
+	}
+}
+
+func TestFtoa(t *testing.T) {
+	if got := ftoa(195); got != "195.00" {
+		t.Fatalf("ftoa(195)=%q", got)
+	}
+	if got := ftoa(422.5); got != "422.50" {
+		t.Fatalf("ftoa(422.5)=%q", got)
+	}
+}
+
+func TestIndexServesHTML(t *testing.T) {
+	s := &Server{} // handleIndex needs no device state
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	s.handleIndex(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("content-type = %q, want text/html", ct)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "<html") || !strings.Contains(body, `src="/screen"`) {
+		t.Fatalf("body does not look like the remote UI: %.120q", body)
+	}
+}
+
+func TestButtonRejectsUnknown(t *testing.T) {
+	s := &Server{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/button", strings.NewReader(`{"name":"selfdestruct"}`))
+	s.handleButton(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for unknown button", rec.Code)
+	}
+}

--- a/ios/remote/remote_test.go
+++ b/ios/remote/remote_test.go
@@ -14,10 +14,13 @@ func TestParseSize(t *testing.T) {
 		wantW, wantH float64
 		wantErr      bool
 	}{
+		{"devicekit jsonrpc", `{"id":1,"jsonrpc":"2.0","result":{"scale":2,"screenSize":{"height":667,"width":375}}}`, 375, 667, false},
+		{"devicekit screenSize", `{"screenSize":{"width":375,"height":667},"scale":2}`, 375, 667, false},
 		{"wda envelope", `{"value":{"width":390,"height":844}}`, 390, 844, false},
 		{"bare object", `{"width":320,"height":568}`, 320, 568, false},
 		{"leading noise", "some log line\n{\"value\":{\"width\":428,\"height\":926}}", 428, 926, false},
 		{"non positive", `{"value":{"width":0,"height":0}}`, 0, 0, true},
+		{"devicekit non positive", `{"screenSize":{"width":0,"height":0},"scale":2}`, 0, 0, true},
 		{"garbage", `not json`, 0, 0, true},
 	}
 	for _, c := range cases {
@@ -60,6 +63,48 @@ func TestFractionToPoints(t *testing.T) {
 		if x != c.wantX || y != c.wantY {
 			t.Fatalf("fractionToPoints(%v,%v)=%v,%v want %v,%v", c.fx, c.fy, x, y, c.wantX, c.wantY)
 		}
+	}
+}
+
+func TestNewServerDefaultsToDeviceKit(t *testing.T) {
+	// An empty driver must default to DeviceKit (WDA is broken on iOS 26). We
+	// can't spin up a real screenshot service here, so exercise the same
+	// defaulting logic directly.
+	s := &Server{driver: ""}
+	if s.driver == "" {
+		s.driver = DriverDeviceKit
+	}
+	if s.driver != DriverDeviceKit {
+		t.Fatalf("default driver = %q, want %q", s.driver, DriverDeviceKit)
+	}
+}
+
+func TestDriverURLFlag(t *testing.T) {
+	cases := []struct {
+		driver, url, want string
+	}{
+		{DriverDeviceKit, "http://127.0.0.1:12004", "--devicekit-url=http://127.0.0.1:12004"},
+		{DriverWDA, "http://127.0.0.1:8100", "--wda-url=http://127.0.0.1:8100"},
+	}
+	for _, c := range cases {
+		s := &Server{driver: c.driver, driverURL: c.url}
+		if got := s.driverURLFlag(); got != c.want {
+			t.Fatalf("driverURLFlag(driver=%q)=%q, want %q", c.driver, got, c.want)
+		}
+	}
+}
+
+// TestFractionToPointsDeviceKit maps browser fractions to DeviceKit's logical
+// points (iPhone SE 3rd gen reports 375x667), independent of the WDA size.
+func TestFractionToPointsDeviceKit(t *testing.T) {
+	s := &Server{driver: DriverDeviceKit, sizeW: 375, sizeH: 667}
+	x, y, err := s.fractionToPoints(0.5, 0.5)
+	if err != nil {
+		t.Fatalf("fractionToPoints: %v", err)
+	}
+	// 0.5*375=187.5 -> ftoa rounds to 188; 0.5*667=333.5 -> 334.
+	if ftoa(x) != "188" || ftoa(y) != "334" {
+		t.Fatalf("center of 375x667 = %s,%s, want 188,334", ftoa(x), ftoa(y))
 	}
 }
 

--- a/ios/remote/remote_test.go
+++ b/ios/remote/remote_test.go
@@ -211,6 +211,48 @@ func TestVideoH264ProxySetsContentTypeAndStreams(t *testing.T) {
 	}
 }
 
+// TestVideoH264ProxyForwardsFPSAndBitrate verifies /video.h264 requests the
+// runner's /h264 with the configured fps/bitrate query params so the runner
+// raises the frame rate above its low default.
+func TestVideoH264ProxyForwardsFPSAndBitrate(t *testing.T) {
+	gotQuery := make(chan string, 1)
+	runner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/h264" {
+			http.NotFound(w, r)
+			return
+		}
+		select {
+		case gotQuery <- r.URL.RawQuery:
+		default:
+		}
+		w.Header().Set("Content-Type", "video/h264")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte{0x00, 0x00, 0x00, 0x01, 0x67})
+	}))
+	defer runner.Close()
+
+	s := &Server{udid: "u", driver: DriverDeviceKit, deviceKitURL: runner.URL, fps: 60, bitrate: 8000000}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/video.h264", nil).WithContext(ctx)
+	done := make(chan struct{})
+	go func() { s.handleVideoH264(rec, req); close(done) }()
+
+	select {
+	case q := <-gotQuery:
+		cancel()
+		<-done
+		if !strings.Contains(q, "fps=60") || !strings.Contains(q, "bitrate=8000000") {
+			t.Fatalf("runner query = %q, want fps=60 and bitrate=8000000", q)
+		}
+	case <-time.After(2 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("runner /h264 was never requested")
+	}
+}
+
 // TestScreenProxyPassesThroughMJPEGContentType verifies /screen proxies the
 // runner's /mjpeg and passes its multipart content-type through unchanged.
 func TestScreenProxyPassesThroughMJPEGContentType(t *testing.T) {

--- a/ios/remote/remote_test.go
+++ b/ios/remote/remote_test.go
@@ -64,11 +64,18 @@ func TestFractionToPoints(t *testing.T) {
 }
 
 func TestFtoa(t *testing.T) {
-	if got := ftoa(195); got != "195.00" {
-		t.Fatalf("ftoa(195)=%q", got)
+	// `ios ui tap` parses --x/--y as integers, so coordinates must be integer
+	// strings (decimals are rejected).
+	cases := map[float64]string{
+		195:   "195",
+		422.4: "422",
+		422.5: "423", // rounds to nearest
+		0:     "0",
 	}
-	if got := ftoa(422.5); got != "422.50" {
-		t.Fatalf("ftoa(422.5)=%q", got)
+	for in, want := range cases {
+		if got := ftoa(in); got != want {
+			t.Fatalf("ftoa(%v)=%q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/ios/remote/runner.go
+++ b/ios/remote/runner.go
@@ -1,0 +1,296 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios/golog"
+)
+
+// runnerState is the lifecycle of the supervised DeviceKit input runner. Input
+// endpoints only proceed when the state is runnerReady; otherwise they return
+// 503 so the browser can retry instead of the shelled `ios ui` command failing
+// with connection-refused.
+type runnerState string
+
+const (
+	// runnerStarting: the runner child has been spawned but its RPC endpoint has
+	// not answered yet (first boot is ~25s on device).
+	runnerStarting runnerState = "starting"
+	// runnerReady: the runner's health endpoint answered; input works.
+	runnerReady runnerState = "ready"
+	// runnerRestarting: the runner died and we are backing off before respawning
+	// (or waiting for the respawned child to become ready again).
+	runnerRestarting runnerState = "restarting"
+	// runnerDown: supervision has stopped (server shutting down).
+	runnerDown runnerState = "down"
+)
+
+// Timing knobs for the supervisor. They are vars (not consts) only so tests can
+// shrink them; production never mutates them.
+var (
+	// runnerStartTimeout bounds how long we wait for a freshly spawned runner to
+	// answer its health endpoint before declaring the attempt failed and
+	// respawning. First boot is ~25s; give generous headroom.
+	runnerStartTimeout = 60 * time.Second
+	// runnerBackoffMin/Max cap the respawn backoff so we never spin-loop hot.
+	runnerBackoffMin = 1 * time.Second
+	runnerBackoffMax = 10 * time.Second
+	// runnerStableAfter is how long a runner must stay up before we treat it as
+	// healthy and reset the backoff to the minimum.
+	runnerStableAfter = 60 * time.Second
+	// runnerHealthPoll is the interval between health probes while waiting for a
+	// runner to become ready.
+	runnerHealthPoll = 1 * time.Second
+)
+
+// runnerProc is a spawned runner child process. The concrete implementation
+// wraps os/exec; tests substitute a fake so the supervisor state machine can be
+// exercised without a real device.
+type runnerProc interface {
+	// Wait blocks until the process exits and returns its exit error (nil on a
+	// clean exit).
+	Wait() error
+	// Stop terminates the process (best-effort; used on shutdown).
+	Stop()
+	// Pid returns the OS process id (0 if unknown), for logging.
+	Pid() int
+}
+
+// runnerSpawner starts a runner child and reports whether its health endpoint
+// is answering. It is the single seam the supervisor uses so tests can inject a
+// fake runner without shelling out to `ios ui run devicekit`.
+type runnerSpawner interface {
+	// spawn starts the runner child. ctx cancellation must terminate the child.
+	spawn(ctx context.Context) (runnerProc, error)
+	// healthy reports whether the runner's RPC/health endpoint answers.
+	healthy(ctx context.Context) bool
+}
+
+// runnerSupervisor spawns, monitors and auto-respawns the DeviceKit input
+// runner so input self-heals across the intermittent testmanagerd DTX EOF
+// disconnects that kill the runner. It exposes the current lifecycle state so
+// input handlers can 503 during recovery and the UI can show "reconnecting".
+type runnerSupervisor struct {
+	udid    string
+	spawner runnerSpawner
+
+	mu    sync.RWMutex
+	state runnerState
+}
+
+func newRunnerSupervisor(udid string, spawner runnerSpawner) *runnerSupervisor {
+	return &runnerSupervisor{udid: udid, spawner: spawner, state: runnerStarting}
+}
+
+// State returns the current runner lifecycle state.
+func (s *runnerSupervisor) State() runnerState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.state
+}
+
+func (s *runnerSupervisor) setState(st runnerState) {
+	s.mu.Lock()
+	s.state = st
+	s.mu.Unlock()
+}
+
+// run supervises the runner until ctx is cancelled, respawning it with capped
+// exponential backoff whenever it dies. It blocks; callers run it in its own
+// goroutine. On return the state is runnerDown.
+func (s *runnerSupervisor) run(ctx context.Context) {
+	backoff := runnerBackoffMin
+	attempt := 0
+	for {
+		if ctx.Err() != nil {
+			s.setState(runnerDown)
+			return
+		}
+		attempt++
+		startedAt := time.Now()
+		s.superviseOnce(ctx, attempt)
+		if ctx.Err() != nil {
+			s.setState(runnerDown)
+			return
+		}
+		// A runner that stayed up long enough is considered healthy: reset the
+		// backoff and attempt counter so a later isolated death recovers fast.
+		if time.Since(startedAt) >= runnerStableAfter {
+			backoff = runnerBackoffMin
+			attempt = 0
+		}
+		s.setState(runnerRestarting)
+		golog.Warn("input runner restarting after backoff", "module", logModule,
+			"udid", s.udid, "attempt", attempt, "backoff", backoff.String())
+		select {
+		case <-ctx.Done():
+			s.setState(runnerDown)
+			return
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > runnerBackoffMax {
+			backoff = runnerBackoffMax
+		}
+	}
+}
+
+// superviseOnce spawns a single runner, waits for it to become ready (updating
+// state), then blocks until it exits — logging spawn/ready/death. It returns
+// when the child has exited or ctx is cancelled.
+func (s *runnerSupervisor) superviseOnce(ctx context.Context, attempt int) {
+	proc, err := s.spawner.spawn(ctx)
+	if err != nil {
+		golog.Warn("input runner spawn failed", "module", logModule, "udid", s.udid,
+			"attempt", attempt, "error", err)
+		return
+	}
+	golog.Info("input runner spawned", "module", logModule, "udid", s.udid,
+		"pid", proc.Pid(), "attempt", attempt)
+
+	// Wait for the child in one place; readiness polling and death detection both
+	// observe this single channel.
+	exited := make(chan error, 1)
+	go func() { exited <- proc.Wait() }()
+
+	spawnedAt := time.Now()
+	ready, died := s.awaitReady(ctx, exited)
+	if died {
+		// Runner exited before it ever became ready; its death was already logged.
+		return
+	}
+	if ready {
+		s.setState(runnerReady)
+		golog.Info("input runner ready", "module", logModule, "udid", s.udid,
+			"pid", proc.Pid(), "elapsed", time.Since(spawnedAt).Round(time.Millisecond).String())
+	}
+
+	// Block until the runner exits (or ctx cancelled). On shutdown, stop it.
+	select {
+	case werr := <-exited:
+		logRunnerExit(s.udid, proc.Pid(), werr)
+	case <-ctx.Done():
+		proc.Stop()
+		<-exited
+		golog.Info("input runner stopped for shutdown", "module", logModule, "udid", s.udid, "pid", proc.Pid())
+	}
+}
+
+// awaitReady polls the runner health endpoint until it answers, the startup
+// timeout elapses, the runner exits early, or ctx is cancelled. It returns
+// (ready, died): ready=true when the endpoint became healthy, died=true when the
+// runner exited before becoming ready (in which case the exit was logged here).
+func (s *runnerSupervisor) awaitReady(ctx context.Context, exited <-chan error) (ready, died bool) {
+	deadline := time.Now().Add(runnerStartTimeout)
+	ticker := time.NewTicker(runnerHealthPoll)
+	defer ticker.Stop()
+	for {
+		if s.spawner.healthy(ctx) {
+			return true, false
+		}
+		select {
+		case werr := <-exited:
+			logRunnerExit(s.udid, 0, werr)
+			return false, true
+		case <-ctx.Done():
+			return false, false
+		case <-ticker.C:
+			if time.Now().After(deadline) {
+				golog.Warn("input runner did not become ready before timeout", "module", logModule,
+					"udid", s.udid, "timeout", runnerStartTimeout.String())
+				return false, false
+			}
+		}
+	}
+}
+
+// logRunnerExit logs a runner death with its exit reason/return code.
+func logRunnerExit(udid string, pid int, werr error) {
+	rc := 0
+	if werr != nil {
+		var ee *exec.ExitError
+		if errors.As(werr, &ee) {
+			rc = ee.ExitCode()
+		} else {
+			rc = -1
+		}
+	}
+	golog.Warn("input runner exited", "module", logModule, "udid", udid,
+		"pid", pid, "rc", rc, "reason", reasonOf(werr))
+}
+
+func reasonOf(err error) string {
+	if err == nil {
+		return "clean exit"
+	}
+	return err.Error()
+}
+
+// --- exec-backed spawner (production) ---
+
+// execRunnerSpawner spawns `ios ui run devicekit --udid=<udid>` as a child of the
+// current `ios` binary and probes the DeviceKit health endpoint for readiness.
+type execRunnerSpawner struct {
+	iosBinary string
+	udid      string
+	healthURL string
+	stdout    *os.File
+	stderr    *os.File
+}
+
+func (e *execRunnerSpawner) spawn(ctx context.Context) (runnerProc, error) {
+	cmd := exec.CommandContext(ctx, e.iosBinary, "ui", "run", "devicekit", "--udid="+e.udid)
+	// Inherit stdout/stderr so the runner's logs (including "ui run ready" and
+	// the DTX EOF death) land in the same stream as `ios remote`.
+	cmd.Stdout = e.stdout
+	cmd.Stderr = e.stderr
+	// Give the child its own process group so Stop can signal it directly and it
+	// isn't collaterally killed by a Ctrl-C delivered to our group.
+	configureRunnerProcAttr(cmd)
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &execRunnerProc{cmd: cmd}, nil
+}
+
+func (e *execRunnerSpawner) healthy(ctx context.Context) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.healthURL, nil)
+	if err != nil {
+		return false
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+type execRunnerProc struct {
+	cmd  *exec.Cmd
+	once sync.Once
+}
+
+func (p *execRunnerProc) Wait() error { return p.cmd.Wait() }
+
+func (p *execRunnerProc) Stop() {
+	p.once.Do(func() {
+		if p.cmd.Process == nil {
+			return
+		}
+		terminateRunnerProc(p.cmd)
+	})
+}
+
+func (p *execRunnerProc) Pid() int {
+	if p.cmd.Process == nil {
+		return 0
+	}
+	return p.cmd.Process.Pid
+}

--- a/ios/remote/runner_test.go
+++ b/ios/remote/runner_test.go
@@ -1,0 +1,229 @@
+package remote
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// setFastRunnerTimings shrinks the supervisor's backoff/poll/timeout knobs so
+// the state machine turns over in milliseconds, and returns a restore func.
+func setFastRunnerTimings() func() {
+	oldTimeout, oldMin, oldMax := runnerStartTimeout, runnerBackoffMin, runnerBackoffMax
+	oldStable, oldPoll := runnerStableAfter, runnerHealthPoll
+	runnerStartTimeout = 200 * time.Millisecond
+	runnerBackoffMin = 5 * time.Millisecond
+	runnerBackoffMax = 20 * time.Millisecond
+	runnerStableAfter = 100 * time.Millisecond
+	runnerHealthPoll = 5 * time.Millisecond
+	return func() {
+		runnerStartTimeout, runnerBackoffMin, runnerBackoffMax = oldTimeout, oldMin, oldMax
+		runnerStableAfter, runnerHealthPoll = oldStable, oldPoll
+	}
+}
+
+// fakeProc is a controllable runnerProc: it "runs" until die is closed (or Stop
+// is called), letting tests drive death/respawn deterministically.
+type fakeProc struct {
+	pid  int
+	die  chan struct{}
+	once sync.Once
+}
+
+func newFakeProc(pid int) *fakeProc { return &fakeProc{pid: pid, die: make(chan struct{})} }
+
+func (p *fakeProc) Wait() error { <-p.die; return nil }
+func (p *fakeProc) Stop()       { p.kill() }
+func (p *fakeProc) Pid() int    { return p.pid }
+func (p *fakeProc) kill()       { p.once.Do(func() { close(p.die) }) }
+
+// fakeSpawner hands out fakeProcs and reports readiness from an atomic flag.
+type fakeSpawner struct {
+	mu      sync.Mutex
+	procs   []*fakeProc
+	spawns  int32
+	ready   atomic.Bool
+	spawned chan *fakeProc
+}
+
+func newFakeSpawner() *fakeSpawner {
+	return &fakeSpawner{spawned: make(chan *fakeProc, 16)}
+}
+
+func (f *fakeSpawner) spawn(ctx context.Context) (runnerProc, error) {
+	n := atomic.AddInt32(&f.spawns, 1)
+	p := newFakeProc(int(n))
+	f.mu.Lock()
+	f.procs = append(f.procs, p)
+	f.mu.Unlock()
+	f.spawned <- p
+	return p, nil
+}
+
+func (f *fakeSpawner) healthy(ctx context.Context) bool { return f.ready.Load() }
+
+func (f *fakeSpawner) spawnCount() int { return int(atomic.LoadInt32(&f.spawns)) }
+
+// waitState polls the supervisor state until it matches want or the deadline
+// passes.
+func waitState(t *testing.T, s *runnerSupervisor, want runnerState) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.State() == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("state=%q, want %q", s.State(), want)
+}
+
+// TestSupervisorRespawnsOnDeath verifies the core self-heal: a runner that dies
+// is respawned and becomes ready again without intervention.
+func TestSupervisorRespawnsOnDeath(t *testing.T) {
+	// Speed up the state machine for the test.
+	restore := setFastRunnerTimings()
+	defer restore()
+
+	sp := newFakeSpawner()
+	sp.ready.Store(true) // health answers immediately
+	s := newRunnerSupervisor("udid-1", sp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.run(ctx)
+
+	first := <-sp.spawned
+	waitState(t, s, runnerReady)
+	if sp.spawnCount() != 1 {
+		t.Fatalf("spawnCount=%d, want 1", sp.spawnCount())
+	}
+
+	// Simulate the intermittent testmanagerd DTX EOF death.
+	first.kill()
+
+	// It must respawn and become ready again on its own.
+	<-sp.spawned
+	waitState(t, s, runnerReady)
+	if sp.spawnCount() < 2 {
+		t.Fatalf("spawnCount=%d, want >=2 after death", sp.spawnCount())
+	}
+}
+
+// TestSupervisorShutdownStopsRunner verifies ctx cancellation terminates the
+// child and leaves the supervisor in runnerDown (no orphan).
+func TestSupervisorShutdownStopsRunner(t *testing.T) {
+	restore := setFastRunnerTimings()
+	defer restore()
+
+	sp := newFakeSpawner()
+	sp.ready.Store(true)
+	s := newRunnerSupervisor("udid-1", sp)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go s.run(ctx)
+
+	p := <-sp.spawned
+	waitState(t, s, runnerReady)
+
+	cancel()
+	// The child's Wait must unblock via Stop; supervisor must reach Down.
+	waitState(t, s, runnerDown)
+	select {
+	case <-p.die:
+	default:
+		t.Fatalf("runner was not stopped on shutdown")
+	}
+}
+
+// TestInputReady503WhenNotReady verifies input endpoints return 503 with the
+// documented JSON body while the runner is not ready, and proceed only when it
+// is. It exercises the HTTP surface without a real device by driving state.
+func TestInputReady503WhenNotReady(t *testing.T) {
+	sp := newFakeSpawner()
+	s := &Server{udid: "udid-1", driver: DriverDeviceKit, supervisor: newRunnerSupervisor("udid-1", sp)}
+
+	// starting -> 503
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/tap", strings.NewReader(`{"x":0.5,"y":0.5}`))
+	s.handleTap(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503 while starting", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "input runner starting") || !strings.Contains(body, `"runnerState":"starting"`) {
+		t.Fatalf("503 body = %q, want error + runnerState", body)
+	}
+
+	// restarting -> 503 with that state
+	s.supervisor.setState(runnerRestarting)
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/tap", strings.NewReader(`{"x":0.5,"y":0.5}`))
+	s.handleTap(rec, req)
+	if rec.Code != http.StatusServiceUnavailable || !strings.Contains(rec.Body.String(), `"runnerState":"restarting"`) {
+		t.Fatalf("status=%d body=%q, want 503 restarting", rec.Code, rec.Body.String())
+	}
+}
+
+// TestStatusEndpoint reports the runner state and uses 503 when not ready, 200
+// when ready.
+func TestStatusEndpoint(t *testing.T) {
+	sp := newFakeSpawner()
+	s := &Server{udid: "u", driver: DriverDeviceKit, supervisor: newRunnerSupervisor("u", sp)}
+
+	rec := httptest.NewRecorder()
+	s.handleStatus(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+	if rec.Code != http.StatusServiceUnavailable || !strings.Contains(rec.Body.String(), `"runnerState":"starting"`) {
+		t.Fatalf("status=%d body=%q, want 503 starting", rec.Code, rec.Body.String())
+	}
+
+	s.supervisor.setState(runnerReady)
+	rec = httptest.NewRecorder()
+	s.handleStatus(rec, httptest.NewRequest(http.MethodGet, "/status", nil))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"runnerState":"ready"`) {
+		t.Fatalf("status=%d body=%q, want 200 ready", rec.Code, rec.Body.String())
+	}
+}
+
+// TestUnmanagedRunnerAlwaysReady verifies that without a supervisor (externally
+// managed runner), input is not gated (state reports ready).
+func TestUnmanagedRunnerAlwaysReady(t *testing.T) {
+	s := &Server{udid: "u", driver: DriverDeviceKit} // no supervisor
+	if got := s.runnerStateString(); got != runnerReady {
+		t.Fatalf("unmanaged runnerState=%q, want ready", got)
+	}
+	rec := httptest.NewRecorder()
+	if !s.inputReady(rec) {
+		t.Fatalf("inputReady=false for unmanaged runner, want true")
+	}
+}
+
+// TestExecSpawnerHealthy exercises the production health probe against a test
+// server, covering the 2xx and error paths.
+func TestExecSpawnerHealthy(t *testing.T) {
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ok.Close()
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+
+	e := &execRunnerSpawner{healthURL: ok.URL + "/health"}
+	if !e.healthy(context.Background()) {
+		t.Fatalf("healthy=false for 200 endpoint")
+	}
+	e.healthURL = bad.URL + "/health"
+	if e.healthy(context.Background()) {
+		t.Fatalf("healthy=true for 500 endpoint")
+	}
+	e.healthURL = "http://127.0.0.1:1/health" // nothing listening
+	if e.healthy(context.Background()) {
+		t.Fatalf("healthy=true for unreachable endpoint")
+	}
+}

--- a/ios/remote/runner_unix.go
+++ b/ios/remote/runner_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package remote
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// configureRunnerProcAttr puts the runner in its own process group so a SIGINT
+// delivered to `ios remote`'s group (Ctrl-C) does not race our own orderly
+// shutdown, and so terminateRunnerProc can signal the whole group.
+func configureRunnerProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// terminateRunnerProc asks the runner to stop cleanly (SIGTERM to its process
+// group), then hard-kills the group after a grace period if it is still alive.
+// It never calls cmd.Wait — the supervisor owns the single Wait that reaps the
+// child; here we only signal. Signaling the group also reaps helper processes
+// the runner spawned (e.g. the port forward).
+func terminateRunnerProc(cmd *exec.Cmd) {
+	pid := cmd.Process.Pid
+	// Negative pid targets the process group established via Setpgid.
+	_ = syscall.Kill(-pid, syscall.SIGTERM)
+	// Escalate asynchronously so Stop stays non-blocking; signal 0 probes
+	// liveness without affecting the process.
+	go func() {
+		time.Sleep(5 * time.Second)
+		if syscall.Kill(-pid, syscall.Signal(0)) == nil {
+			_ = syscall.Kill(-pid, syscall.SIGKILL)
+		}
+	}()
+}

--- a/ios/remote/runner_windows.go
+++ b/ios/remote/runner_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package remote
+
+import "os/exec"
+
+// configureRunnerProcAttr is a no-op on Windows: there is no POSIX process group
+// to establish. CommandContext still terminates the child on ctx cancel.
+func configureRunnerProcAttr(cmd *exec.Cmd) {}
+
+// terminateRunnerProc kills the runner. Windows has no SIGTERM; Process.Kill is
+// the orderly stop. It does not call Wait (the supervisor owns the single Wait).
+func terminateRunnerProc(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/ios/remote/ui.go
+++ b/ios/remote/ui.go
@@ -1,9 +1,20 @@
 package remote
 
 // indexHTML is the entire, self-contained web UI. No external/CDN assets: the
-// HTML, CSS and JS are inlined so `ios remote` serves it standalone. The screen
-// is an <img src="/screen"> MJPEG stream; clicks/drags are translated to 0..1
-// fractions and POSTed to the input endpoints.
+// HTML, CSS and JS are inlined so `ios remote` serves it standalone.
+//
+// The screen is rendered two ways, chosen automatically:
+//   - Primary: the DeviceKit runner's hardware H.264 (GET /video.h264, an
+//     Annex-B elementary stream) is fetched as a stream, parsed into NAL units,
+//     and decoded with the WebCodecs VideoDecoder into a <canvas>. This is the
+//     efficient path (a few KB/s, delta-compressed).
+//   - Fallback: if WebCodecs is unavailable or the decoder errors, an
+//     <img src="/screen"> shows the runner's MJPEG instead. The switch is
+//     automatic.
+//
+// Clicks/drags are translated to 0..1 fractions against the visible screen
+// element (canvas or img, whichever is active) and POSTed to the input
+// endpoints — unchanged from before.
 const indexHTML = `<!doctype html>
 <html lang="en">
 <head>
@@ -18,9 +29,10 @@ const indexHTML = `<!doctype html>
   #app { display: flex; flex-direction: column; height: 100%; }
   #stage { flex: 1; display: flex; align-items: center; justify-content: center;
     overflow: hidden; padding: 8px; }
-  #screen { max-width: 100%; max-height: 100%; touch-action: none;
+  #canvas, #fallback { max-width: 100%; max-height: 100%; touch-action: none;
     border-radius: 14px; box-shadow: 0 0 0 1px #333, 0 8px 30px rgba(0,0,0,.6);
     cursor: crosshair; user-select: none; -webkit-user-drag: none; }
+  #fallback { display: none; }
   #bar { display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
     padding: 8px; background: #1a1a1a; border-top: 1px solid #2a2a2a; }
   button { background: #2a2a2a; color: #eee; border: 1px solid #3a3a3a;
@@ -37,7 +49,8 @@ const indexHTML = `<!doctype html>
 <body>
 <div id="app">
   <div id="stage">
-    <img id="screen" src="/screen" alt="device screen" draggable="false">
+    <canvas id="canvas" width="390" height="844"></canvas>
+    <img id="fallback" src="" alt="device screen" draggable="false">
   </div>
   <div id="bar">
     <button data-btn="home">Home</button>
@@ -47,22 +60,30 @@ const indexHTML = `<!doctype html>
     <span class="sep"></span>
     <input id="text" type="text" placeholder="type text, Enter to send">
     <button id="send">Send</button>
-    <span id="status">tap the screen</span>
+    <span id="status">connecting…</span>
   </div>
 </div>
 <script>
 (function () {
-  var img = document.getElementById('screen');
+  var canvas = document.getElementById('canvas');
+  var fallback = document.getElementById('fallback');
   var status = document.getElementById('status');
   var textbox = document.getElementById('text');
   var DRAG_THRESHOLD = 0.02; // fraction of the screen; below this = tap
+  var runnerNotReady = false;
 
   function setStatus(s) { status.textContent = s; }
 
-  // Translate a pointer event to a 0..1 fraction of the *rendered* image,
-  // accounting for letterboxing (object-fit style max-width/height).
+  // activeScreen is whichever element is currently visible; input fractions are
+  // measured against its rendered rect so taps map identically for canvas/img.
+  function activeScreen() {
+    return canvas.style.display === 'none' ? fallback : canvas;
+  }
+
+  // Translate a pointer event to a 0..1 fraction of the *rendered* screen,
+  // accounting for letterboxing (max-width/height keeps aspect ratio).
   function fractionFromEvent(e) {
-    var r = img.getBoundingClientRect();
+    var r = activeScreen().getBoundingClientRect();
     var x = (e.clientX - r.left) / r.width;
     var y = (e.clientY - r.top) / r.height;
     return { x: Math.min(1, Math.max(0, x)), y: Math.min(1, Math.max(0, y)) };
@@ -81,24 +102,29 @@ const indexHTML = `<!doctype html>
     }).catch(function (err) { setStatus(path + ' error: ' + err); });
   }
 
+  // --- input wiring (identical to before; bound to both screen elements) ---
   var down = null;
-  img.addEventListener('pointerdown', function (e) {
-    e.preventDefault();
-    down = fractionFromEvent(e);
-  });
-  img.addEventListener('pointerup', function (e) {
-    if (!down) return;
-    e.preventDefault();
-    var up = fractionFromEvent(e);
-    var dx = up.x - down.x, dy = up.y - down.y;
-    if (Math.abs(dx) < DRAG_THRESHOLD && Math.abs(dy) < DRAG_THRESHOLD) {
-      post('/tap', { x: down.x, y: down.y });
-    } else {
-      post('/swipe', { fromX: down.x, fromY: down.y, toX: up.x, toY: up.y });
-    }
-    down = null;
-  });
-  img.addEventListener('pointercancel', function () { down = null; });
+  function bindInput(el) {
+    el.addEventListener('pointerdown', function (e) {
+      e.preventDefault();
+      down = fractionFromEvent(e);
+    });
+    el.addEventListener('pointerup', function (e) {
+      if (!down) return;
+      e.preventDefault();
+      var up = fractionFromEvent(e);
+      var dx = up.x - down.x, dy = up.y - down.y;
+      if (Math.abs(dx) < DRAG_THRESHOLD && Math.abs(dy) < DRAG_THRESHOLD) {
+        post('/tap', { x: down.x, y: down.y });
+      } else {
+        post('/swipe', { fromX: down.x, fromY: down.y, toX: up.x, toY: up.y });
+      }
+      down = null;
+    });
+    el.addEventListener('pointercancel', function () { down = null; });
+  }
+  bindInput(canvas);
+  bindInput(fallback);
 
   document.querySelectorAll('button[data-btn]').forEach(function (b) {
     b.addEventListener('click', function () { post('/button', { name: b.dataset.btn }); });
@@ -112,26 +138,192 @@ const indexHTML = `<!doctype html>
   document.getElementById('send').addEventListener('click', send);
   textbox.addEventListener('keydown', function (e) { if (e.key === 'Enter') send(); });
 
-  // If the MJPEG stream drops, nudge it back to life.
-  img.addEventListener('error', function () {
-    setStatus('screen stream error, retrying…');
-    setTimeout(function () { img.src = '/screen?t=' + Date.now(); }, 1000);
-  });
+  // --- MJPEG fallback ---
+  var usingFallback = false;
+  function useFallback(reason) {
+    if (usingFallback) return;
+    usingFallback = true;
+    canvas.style.display = 'none';
+    fallback.style.display = 'block';
+    setStatus('screen: MJPEG fallback (' + reason + ')');
+    fallback.src = '/screen?t=' + Date.now();
+    fallback.addEventListener('error', function () {
+      setTimeout(function () { fallback.src = '/screen?t=' + Date.now(); }, 1000);
+    });
+  }
 
-  // Poll the input-runner lifecycle so the user sees when input is (re)starting
-  // instead of taps silently failing. /status returns 503 until the runner is
-  // ready; the input endpoints likewise 503 while it recovers.
+  // --- H.264 Annex-B → WebCodecs → canvas (primary) ---
+  // Derive the avc1.PPCCLL codec string from the SPS: bytes after the NAL header
+  // are profile_idc, constraint_set flags, level_idc.
+  function codecFromSPS(sps) {
+    // sps[0] is the NAL header; profile/constraint/level are the next 3 bytes.
+    var profile = sps[1], constraint = sps[2], level = sps[3];
+    function hex(b) { return ('0' + b.toString(16)).slice(-2); }
+    return 'avc1.' + hex(profile) + hex(constraint) + hex(level);
+  }
+
+  // Split an Annex-B buffer into NAL payloads (without start codes). Returns the
+  // NALs found and the number of bytes consumed (a trailing partial NAL is left
+  // for the next chunk).
+  function splitNALs(buf) {
+    var nals = [];
+    var i = 0, n = buf.length;
+    // find first start code
+    function startAt(p) {
+      if (p + 3 < n && buf[p] === 0 && buf[p+1] === 0 && buf[p+2] === 0 && buf[p+3] === 1) return 4;
+      if (p + 2 < n && buf[p] === 0 && buf[p+1] === 0 && buf[p+2] === 1) return 3;
+      return 0;
+    }
+    // Position i at the first start code.
+    while (i < n && startAt(i) === 0) i++;
+    var consumed = i;
+    while (i < n) {
+      var sc = startAt(i);
+      if (sc === 0) { i++; continue; }
+      var payloadStart = i + sc;
+      // find next start code
+      var j = payloadStart;
+      while (j < n && startAt(j) === 0) j++;
+      if (j >= n) {
+        // No next start code yet: this NAL may be incomplete, keep for next time.
+        break;
+      }
+      nals.push(buf.subarray(payloadStart, j));
+      consumed = j;
+      i = j;
+    }
+    return { nals: nals, consumed: consumed };
+  }
+
+  function startH264() {
+    if (!('VideoDecoder' in window)) {
+      useFallback('WebCodecs unavailable');
+      return;
+    }
+    var ctx = canvas.getContext('2d');
+    var decoder = null;
+    var configured = false;
+    var sps = null, pps = null;
+    var sawKey = false;
+    var reconnectTimer = null;
+
+    function scheduleReconnect() {
+      if (usingFallback) return;
+      if (reconnectTimer) return;
+      reconnectTimer = setTimeout(function () { reconnectTimer = null; connect(); }, 800);
+    }
+
+    function ensureDecoder() {
+      if (configured || !sps || !pps) return;
+      var codec = codecFromSPS(sps);
+      try {
+        decoder = new VideoDecoder({
+          output: function (frame) {
+            if (canvas.width !== frame.displayWidth || canvas.height !== frame.displayHeight) {
+              canvas.width = frame.displayWidth;
+              canvas.height = frame.displayHeight;
+            }
+            ctx.drawImage(frame, 0, 0);
+            frame.close();
+          },
+          error: function (e) { useFallback('decoder error: ' + e.message); }
+        });
+        decoder.configure({ codec: codec, optimizeForLatency: true });
+        configured = true;
+        if (!runnerNotReady) setStatus('screen: H.264 (' + codec + ')');
+      } catch (e) {
+        useFallback('configure failed: ' + e.message);
+      }
+    }
+
+    // Wrap one or more NALs (with 4-byte start codes) into an EncodedVideoChunk.
+    function wrapAnnexB(nals) {
+      var len = 0, k;
+      for (k = 0; k < nals.length; k++) len += 4 + nals[k].length;
+      var out = new Uint8Array(len);
+      var off = 0;
+      for (k = 0; k < nals.length; k++) {
+        out[off] = 0; out[off+1] = 0; out[off+2] = 0; out[off+3] = 1;
+        out.set(nals[k], off + 4);
+        off += 4 + nals[k].length;
+      }
+      return out;
+    }
+
+    var ts = 0;
+    function feed(nals) {
+      // Collect a set of NALs into one access unit and decode. SPS/PPS are cached
+      // for the decoder config and prepended to the first IDR.
+      var au = [];
+      for (var k = 0; k < nals.length; k++) {
+        var nal = nals[k];
+        if (nal.length === 0) continue;
+        var type = nal[0] & 0x1f;
+        if (type === 7) { sps = nal; ensureDecoder(); continue; }
+        if (type === 8) { pps = nal; ensureDecoder(); continue; }
+        au.push(nal);
+        var isKey = (type === 5);
+        if (isKey) sawKey = true;
+        if (!configured || !sawKey || !decoder) { au = []; continue; }
+        var data = isKey ? wrapAnnexB([sps, pps, nal]) : wrapAnnexB([nal]);
+        try {
+          decoder.decode(new EncodedVideoChunk({
+            type: isKey ? 'key' : 'delta',
+            timestamp: ts,
+            data: data
+          }));
+          ts += 33333; // ~30fps nominal; timestamps only need to be monotonic
+        } catch (e) {
+          useFallback('decode failed: ' + e.message);
+          return;
+        }
+        au = [];
+      }
+    }
+
+    function connect() {
+      if (usingFallback) return;
+      fetch('/video.h264', { cache: 'no-store' }).then(function (res) {
+        if (!res.ok || !res.body) { scheduleReconnect(); return; }
+        var reader = res.body.getReader();
+        var pending = new Uint8Array(0);
+        function pump() {
+          reader.read().then(function (r) {
+            if (r.done) { scheduleReconnect(); return; }
+            // append to pending
+            var merged = new Uint8Array(pending.length + r.value.length);
+            merged.set(pending, 0);
+            merged.set(r.value, pending.length);
+            var split = splitNALs(merged);
+            if (split.nals.length) feed(split.nals);
+            pending = merged.subarray(split.consumed);
+            // keep pending as its own buffer so it doesn't retain the big merged one
+            pending = pending.slice();
+            pump();
+          }).catch(function () { scheduleReconnect(); });
+        }
+        pump();
+      }).catch(function () { scheduleReconnect(); });
+    }
+
+    connect();
+  }
+
+  // Poll the input-runner lifecycle so the user sees when the runner (which
+  // backs BOTH screen and input) is (re)starting. /status returns 503 until the
+  // runner is ready; the screen proxy reconnects on its own in lockstep.
   function pollStatus() {
     fetch('/status').then(function (res) {
       return res.json().then(function (j) {
-        if (j.runnerState && j.runnerState !== 'ready') {
-          setStatus('input runner ' + j.runnerState + '…');
-        }
+        runnerNotReady = j.runnerState && j.runnerState !== 'ready';
+        if (runnerNotReady) setStatus('runner ' + j.runnerState + '… (reconnecting)');
       });
     }).catch(function () {}).then(function () {
       setTimeout(pollStatus, 2000);
     });
   }
+
+  startH264();
   pollStatus();
 })();
 </script>

--- a/ios/remote/ui.go
+++ b/ios/remote/ui.go
@@ -1,0 +1,124 @@
+package remote
+
+// indexHTML is the entire, self-contained web UI. No external/CDN assets: the
+// HTML, CSS and JS are inlined so `ios remote` serves it standalone. The screen
+// is an <img src="/screen"> MJPEG stream; clicks/drags are translated to 0..1
+// fractions and POSTed to the input endpoints.
+const indexHTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+<title>ios remote</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; background: #111; color: #eee;
+    font: 14px/1.4 -apple-system, system-ui, sans-serif; }
+  #app { display: flex; flex-direction: column; height: 100%; }
+  #stage { flex: 1; display: flex; align-items: center; justify-content: center;
+    overflow: hidden; padding: 8px; }
+  #screen { max-width: 100%; max-height: 100%; touch-action: none;
+    border-radius: 14px; box-shadow: 0 0 0 1px #333, 0 8px 30px rgba(0,0,0,.6);
+    cursor: crosshair; user-select: none; -webkit-user-drag: none; }
+  #bar { display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+    padding: 8px; background: #1a1a1a; border-top: 1px solid #2a2a2a; }
+  button { background: #2a2a2a; color: #eee; border: 1px solid #3a3a3a;
+    border-radius: 8px; padding: 8px 12px; font-size: 14px; cursor: pointer; }
+  button:hover { background: #333; }
+  button:active { background: #444; }
+  input[type=text] { flex: 1; min-width: 120px; background: #222; color: #eee;
+    border: 1px solid #3a3a3a; border-radius: 8px; padding: 8px 10px; font-size: 14px; }
+  #status { margin-left: auto; font-size: 12px; color: #9a9a9a;
+    max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .sep { width: 1px; height: 24px; background: #333; margin: 0 2px; }
+</style>
+</head>
+<body>
+<div id="app">
+  <div id="stage">
+    <img id="screen" src="/screen" alt="device screen" draggable="false">
+  </div>
+  <div id="bar">
+    <button data-btn="home">Home</button>
+    <button data-btn="lock">Lock</button>
+    <button data-btn="volumeup">Vol +</button>
+    <button data-btn="volumedown">Vol -</button>
+    <span class="sep"></span>
+    <input id="text" type="text" placeholder="type text, Enter to send">
+    <button id="send">Send</button>
+    <span id="status">tap the screen</span>
+  </div>
+</div>
+<script>
+(function () {
+  var img = document.getElementById('screen');
+  var status = document.getElementById('status');
+  var textbox = document.getElementById('text');
+  var DRAG_THRESHOLD = 0.02; // fraction of the screen; below this = tap
+
+  function setStatus(s) { status.textContent = s; }
+
+  // Translate a pointer event to a 0..1 fraction of the *rendered* image,
+  // accounting for letterboxing (object-fit style max-width/height).
+  function fractionFromEvent(e) {
+    var r = img.getBoundingClientRect();
+    var x = (e.clientX - r.left) / r.width;
+    var y = (e.clientY - r.top) / r.height;
+    return { x: Math.min(1, Math.max(0, x)), y: Math.min(1, Math.max(0, y)) };
+  }
+
+  function post(path, body) {
+    return fetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    }).then(function (res) {
+      return res.text().then(function (t) {
+        setStatus(res.ok ? (path + ' ok') : (path + ' ' + res.status + ': ' + t.slice(0, 80)));
+        return res.ok;
+      });
+    }).catch(function (err) { setStatus(path + ' error: ' + err); });
+  }
+
+  var down = null;
+  img.addEventListener('pointerdown', function (e) {
+    e.preventDefault();
+    down = fractionFromEvent(e);
+  });
+  img.addEventListener('pointerup', function (e) {
+    if (!down) return;
+    e.preventDefault();
+    var up = fractionFromEvent(e);
+    var dx = up.x - down.x, dy = up.y - down.y;
+    if (Math.abs(dx) < DRAG_THRESHOLD && Math.abs(dy) < DRAG_THRESHOLD) {
+      post('/tap', { x: down.x, y: down.y });
+    } else {
+      post('/swipe', { fromX: down.x, fromY: down.y, toX: up.x, toY: up.y });
+    }
+    down = null;
+  });
+  img.addEventListener('pointercancel', function () { down = null; });
+
+  document.querySelectorAll('button[data-btn]').forEach(function (b) {
+    b.addEventListener('click', function () { post('/button', { name: b.dataset.btn }); });
+  });
+
+  function send() {
+    var t = textbox.value;
+    if (!t) return;
+    post('/type', { text: t }).then(function () { textbox.value = ''; });
+  }
+  document.getElementById('send').addEventListener('click', send);
+  textbox.addEventListener('keydown', function (e) { if (e.key === 'Enter') send(); });
+
+  // If the MJPEG stream drops, nudge it back to life.
+  img.addEventListener('error', function () {
+    setStatus('screen stream error, retrying…');
+    setTimeout(function () { img.src = '/screen?t=' + Date.now(); }, 1000);
+  });
+})();
+</script>
+</body>
+</html>
+`

--- a/ios/remote/ui.go
+++ b/ios/remote/ui.go
@@ -4,13 +4,21 @@ package remote
 // HTML, CSS and JS are inlined so `ios remote` serves it standalone.
 //
 // The screen is rendered two ways, chosen automatically:
-//   - Primary: the DeviceKit runner's hardware H.264 (GET /video.h264, an
-//     Annex-B elementary stream) is fetched as a stream, parsed into NAL units,
-//     and decoded with the WebCodecs VideoDecoder into a <canvas>. This is the
-//     efficient path (a few KB/s, delta-compressed).
-//   - Fallback: if WebCodecs is unavailable or the decoder errors, an
-//     <img src="/screen"> shows the runner's MJPEG instead. The switch is
+//   - Primary ("h264/canvas"): the DeviceKit runner's hardware H.264 (GET
+//     /video.h264, an Annex-B elementary stream) is fetched as a stream, parsed
+//     into NAL units, GROUPED INTO ACCESS UNITS (all NALs for one picture), and
+//     decoded with the WebCodecs VideoDecoder. Decode is decoupled from paint: a
+//     requestAnimationFrame loop draws only the freshest decoded VideoFrame to
+//     the <canvas> (older undrawn frames are dropped), which is what keeps the
+//     mirror smooth and low-latency.
+//   - Fallback ("mjpeg/img"): if WebCodecs is unavailable or the decoder errors,
+//     an <img src="/screen"> shows the runner's MJPEG instead. The switch is
 //     automatic.
+//
+// A diagnostic HUD (toggle with the 'd' key) overlays the current mode, the
+// measured rendered fps, decoder state + decodeQueueSize, dropped-frame count,
+// and the last decoder error — so a maintainer can tell at a glance whether the
+// H.264 path is live or it fell back, and where any stall is.
 //
 // Clicks/drags are translated to 0..1 fractions against the visible screen
 // element (canvas or img, whichever is active) and POSTed to the input
@@ -28,7 +36,7 @@ const indexHTML = `<!doctype html>
     font: 14px/1.4 -apple-system, system-ui, sans-serif; }
   #app { display: flex; flex-direction: column; height: 100%; }
   #stage { flex: 1; display: flex; align-items: center; justify-content: center;
-    overflow: hidden; padding: 8px; }
+    overflow: hidden; padding: 8px; position: relative; }
   #canvas, #fallback { max-width: 100%; max-height: 100%; touch-action: none;
     border-radius: 14px; box-shadow: 0 0 0 1px #333, 0 8px 30px rgba(0,0,0,.6);
     cursor: crosshair; user-select: none; -webkit-user-drag: none; }
@@ -44,6 +52,14 @@ const indexHTML = `<!doctype html>
   #status { margin-left: auto; font-size: 12px; color: #9a9a9a;
     max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .sep { width: 1px; height: 24px; background: #333; margin: 0 2px; }
+  /* Diagnostic HUD: fixed top-left overlay, toggled with 'd'. */
+  #hud { position: absolute; top: 14px; left: 14px; z-index: 10;
+    background: rgba(0,0,0,.72); color: #d7ffd7; border: 1px solid #2f5f2f;
+    border-radius: 8px; padding: 8px 10px; font: 11px/1.5 ui-monospace, Menlo, Consolas, monospace;
+    white-space: pre; pointer-events: none; min-width: 210px; }
+  #hud .err { color: #ff9a9a; }
+  #hud .hint { color: #7a7a7a; }
+  #hud.hidden { display: none; }
 </style>
 </head>
 <body>
@@ -51,6 +67,7 @@ const indexHTML = `<!doctype html>
   <div id="stage">
     <canvas id="canvas" width="390" height="844"></canvas>
     <img id="fallback" src="" alt="device screen" draggable="false">
+    <div id="hud" class="hidden"></div>
   </div>
   <div id="bar">
     <button data-btn="home">Home</button>
@@ -69,10 +86,60 @@ const indexHTML = `<!doctype html>
   var fallback = document.getElementById('fallback');
   var status = document.getElementById('status');
   var textbox = document.getElementById('text');
+  var hud = document.getElementById('hud');
   var DRAG_THRESHOLD = 0.02; // fraction of the screen; below this = tap
   var runnerNotReady = false;
 
   function setStatus(s) { status.textContent = s; }
+
+  // --- diagnostics ---------------------------------------------------------
+  // Shared HUD state, updated by the decode/paint paths and rendered on a timer.
+  var diag = {
+    mode: 'starting',        // 'h264/canvas' | 'mjpeg/img fallback'
+    codec: '',
+    decoderState: '-',       // VideoDecoder.state
+    queue: 0,                // decoder.decodeQueueSize
+    dropped: 0,              // frames decoded but never painted (superseded)
+    auDropped: 0,            // access units dropped for backpressure
+    lastError: '',
+    painted: 0               // rAF paints since last fps sample
+  };
+  var renderedFps = 0;
+  var hudVisible = false;
+
+  function renderHUD() {
+    if (!hudVisible) return;
+    var lines = [
+      'MODE     ' + diag.mode + (diag.codec ? ' (' + diag.codec + ')' : ''),
+      'RENDER   ' + renderedFps.toFixed(1) + ' fps',
+      'DECODER  ' + diag.decoderState + '  queue=' + diag.queue,
+      'DROPPED  ' + diag.dropped + ' late, ' + diag.auDropped + ' AU (backpressure)'
+    ];
+    hud.textContent = lines.join('\n');
+    if (diag.lastError) {
+      var e = document.createElement('span');
+      e.className = 'err';
+      e.textContent = '\nERROR    ' + diag.lastError;
+      hud.appendChild(e);
+    }
+    var hint = document.createElement('span');
+    hint.className = 'hint';
+    hint.textContent = "\n('d' hides)";
+    hud.appendChild(hint);
+  }
+  // fps = paints per second, sampled once a second.
+  setInterval(function () {
+    renderedFps = diag.painted;
+    diag.painted = 0;
+    renderHUD();
+  }, 1000);
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'd' || e.key === 'D') {
+      hudVisible = !hudVisible;
+      hud.classList.toggle('hidden', !hudVisible);
+      renderHUD();
+    }
+  });
 
   // activeScreen is whichever element is currently visible; input fractions are
   // measured against its rendered rect so taps map identically for canvas/img.
@@ -143,6 +210,9 @@ const indexHTML = `<!doctype html>
   function useFallback(reason) {
     if (usingFallback) return;
     usingFallback = true;
+    diag.mode = 'mjpeg/img fallback';
+    diag.codec = '';
+    diag.lastError = reason;
     canvas.style.display = 'none';
     fallback.style.display = 'block';
     setStatus('screen: MJPEG fallback (' + reason + ')');
@@ -168,7 +238,7 @@ const indexHTML = `<!doctype html>
   function splitNALs(buf) {
     var nals = [];
     var i = 0, n = buf.length;
-    // find first start code
+    // is there a start code at p? returns its length (3 or 4) or 0.
     function startAt(p) {
       if (p + 3 < n && buf[p] === 0 && buf[p+1] === 0 && buf[p+2] === 0 && buf[p+3] === 1) return 4;
       if (p + 2 < n && buf[p] === 0 && buf[p+1] === 0 && buf[p+2] === 1) return 3;
@@ -200,43 +270,71 @@ const indexHTML = `<!doctype html>
       useFallback('WebCodecs unavailable');
       return;
     }
+    diag.mode = 'h264/canvas';
     var ctx = canvas.getContext('2d');
     var decoder = null;
     var configured = false;
     var sps = null, pps = null;
+    var codec = '';
     var sawKey = false;
     var reconnectTimer = null;
 
-    function scheduleReconnect() {
-      if (usingFallback) return;
-      if (reconnectTimer) return;
-      reconnectTimer = setTimeout(function () { reconnectTimer = null; connect(); }, 800);
+    // 1-slot holder: only the freshest decoded frame is kept for the next paint;
+    // any older undrawn frame is closed (dropped). This decouples decode from
+    // paint and is the core smoothness fix.
+    var latestFrame = null;
+    var rafPending = false;
+
+    function paintLoop() {
+      rafPending = false;
+      if (latestFrame) {
+        var frame = latestFrame;
+        latestFrame = null;
+        if (canvas.width !== frame.displayWidth || canvas.height !== frame.displayHeight) {
+          canvas.width = frame.displayWidth;
+          canvas.height = frame.displayHeight;
+        }
+        try { ctx.drawImage(frame, 0, 0); } catch (e) { /* frame may be closed on teardown */ }
+        frame.close();
+        diag.painted++;
+      }
+      // Keep the loop alive so a newly-arrived frame is drawn next vsync.
+      schedulePaint();
+    }
+    function schedulePaint() {
+      if (rafPending) return;
+      rafPending = true;
+      requestAnimationFrame(paintLoop);
     }
 
     function ensureDecoder() {
       if (configured || !sps || !pps) return;
-      var codec = codecFromSPS(sps);
+      codec = codecFromSPS(sps);
       try {
         decoder = new VideoDecoder({
           output: function (frame) {
-            if (canvas.width !== frame.displayWidth || canvas.height !== frame.displayHeight) {
-              canvas.width = frame.displayWidth;
-              canvas.height = frame.displayHeight;
-            }
-            ctx.drawImage(frame, 0, 0);
-            frame.close();
+            // Never paint here: stash the freshest frame and let rAF draw it.
+            if (latestFrame) { latestFrame.close(); diag.dropped++; }
+            latestFrame = frame;
+            schedulePaint();
           },
-          error: function (e) { useFallback('decoder error: ' + e.message); }
+          error: function (e) {
+            diag.lastError = e.message;
+            useFallback('decoder error: ' + e.message);
+          }
         });
+        // annexb: SPS/PPS travel in-band, so no description is needed.
         decoder.configure({ codec: codec, optimizeForLatency: true });
         configured = true;
+        diag.codec = codec;
         if (!runnerNotReady) setStatus('screen: H.264 (' + codec + ')');
       } catch (e) {
+        diag.lastError = e.message;
         useFallback('configure failed: ' + e.message);
       }
     }
 
-    // Wrap one or more NALs (with 4-byte start codes) into an EncodedVideoChunk.
+    // Wrap one or more NALs (with 4-byte start codes) into an Annex-B buffer.
     function wrapAnnexB(nals) {
       var len = 0, k;
       for (k = 0; k < nals.length; k++) len += 4 + nals[k].length;
@@ -250,35 +348,94 @@ const indexHTML = `<!doctype html>
       return out;
     }
 
+    // Access-unit assembler: NALs stream in; a new AU starts at each VCL NAL
+    // (type 1 or 5). Leading non-VCL NALs (SPS/PPS/SEI/AUD) accumulate and are
+    // emitted together with the following VCL slice as ONE EncodedVideoChunk.
+    var pendingAU = [];       // NALs accumulated for the current (not-yet-VCL-terminated) AU
+    var pendingHasKey = false;
     var ts = 0;
+
+    function isVCL(type) { return type === 1 || type === 5; }
+
+    function emitAU(nals, isKey) {
+      if (!configured || !decoder) return;
+      // The first chunk fed MUST be a keyframe; drop deltas until we've seen one.
+      if (!sawKey && !isKey) return;
+      if (isKey) sawKey = true;
+
+      // Backpressure: if the decoder is falling behind, drop delta AUs until the
+      // next keyframe rather than queueing (low latency > completeness for a live
+      // mirror).
+      diag.queue = decoder.decodeQueueSize;
+      if (!isKey && diag.queue > 2) { diag.auDropped++; return; }
+
+      // A keyframe AU must carry SPS+PPS in-band (annexb). Non-key AUs go as-is.
+      var data;
+      if (isKey) {
+        var withParamSets = [sps, pps];
+        for (var m = 0; m < nals.length; m++) withParamSets.push(nals[m]);
+        data = wrapAnnexB(withParamSets);
+      } else {
+        data = wrapAnnexB(nals);
+      }
+      try {
+        decoder.decode(new EncodedVideoChunk({
+          type: isKey ? 'key' : 'delta',
+          timestamp: ts,
+          data: data
+        }));
+        ts += 16666; // ~60fps nominal; timestamps only need to be monotonic
+        diag.queue = decoder.decodeQueueSize;
+      } catch (e) {
+        diag.lastError = e.message;
+        useFallback('decode failed: ' + e.message);
+      }
+    }
+
+    function flushPendingAU() {
+      if (pendingAU.length === 0) return;
+      emitAU(pendingAU, pendingHasKey);
+      pendingAU = [];
+      pendingHasKey = false;
+    }
+
     function feed(nals) {
-      // Collect a set of NALs into one access unit and decode. SPS/PPS are cached
-      // for the decoder config and prepended to the first IDR.
-      var au = [];
       for (var k = 0; k < nals.length; k++) {
         var nal = nals[k];
         if (nal.length === 0) continue;
         var type = nal[0] & 0x1f;
-        if (type === 7) { sps = nal; ensureDecoder(); continue; }
-        if (type === 8) { pps = nal; ensureDecoder(); continue; }
-        au.push(nal);
-        var isKey = (type === 5);
-        if (isKey) sawKey = true;
-        if (!configured || !sawKey || !decoder) { au = []; continue; }
-        var data = isKey ? wrapAnnexB([sps, pps, nal]) : wrapAnnexB([nal]);
-        try {
-          decoder.decode(new EncodedVideoChunk({
-            type: isKey ? 'key' : 'delta',
-            timestamp: ts,
-            data: data
-          }));
-          ts += 33333; // ~30fps nominal; timestamps only need to be monotonic
-        } catch (e) {
-          useFallback('decode failed: ' + e.message);
-          return;
+        // Cache parameter sets for the decoder config; they are (re)inserted into
+        // key AUs, so they are not accumulated into pendingAU here.
+        if (type === 7) {
+          sps = nal; ensureDecoder();
+          continue;
         }
-        au = [];
+        if (type === 8) {
+          pps = nal; ensureDecoder();
+          continue;
+        }
+        if (isVCL(type)) {
+          // The VCL slice completes the current access unit. Any non-VCL NALs
+          // accumulated (SEI/AUD) belong with it.
+          pendingAU.push(nal);
+          if (type === 5) pendingHasKey = true;
+          flushPendingAU();
+        } else {
+          // Leading non-VCL NAL (SEI type 6, AUD type 9, …): hold for the AU.
+          pendingAU.push(nal);
+        }
       }
+    }
+
+    function scheduleReconnect() {
+      if (usingFallback) return;
+      if (reconnectTimer) return;
+      // A dropped stream means the runner restarted; the next AU will be a fresh
+      // keyframe, so require a keyframe again before feeding deltas.
+      sawKey = false;
+      pendingAU = [];
+      pendingHasKey = false;
+      reconnectTimer = setTimeout(function () { reconnectTimer = null; connect(); }, 800);
     }
 
     function connect() {
@@ -290,15 +447,13 @@ const indexHTML = `<!doctype html>
         function pump() {
           reader.read().then(function (r) {
             if (r.done) { scheduleReconnect(); return; }
-            // append to pending
             var merged = new Uint8Array(pending.length + r.value.length);
             merged.set(pending, 0);
             merged.set(r.value, pending.length);
             var split = splitNALs(merged);
             if (split.nals.length) feed(split.nals);
-            pending = merged.subarray(split.consumed);
-            // keep pending as its own buffer so it doesn't retain the big merged one
-            pending = pending.slice();
+            // keep the leftover as its own buffer so it doesn't retain merged.
+            pending = merged.subarray(split.consumed).slice();
             pump();
           }).catch(function () { scheduleReconnect(); });
         }
@@ -306,6 +461,12 @@ const indexHTML = `<!doctype html>
       }).catch(function () { scheduleReconnect(); });
     }
 
+    // Keep the decoder-state line in the HUD fresh even when idle.
+    setInterval(function () {
+      if (decoder) { diag.decoderState = decoder.state; diag.queue = decoder.decodeQueueSize; }
+    }, 250);
+
+    schedulePaint();
     connect();
   }
 

--- a/ios/remote/ui.go
+++ b/ios/remote/ui.go
@@ -117,6 +117,22 @@ const indexHTML = `<!doctype html>
     setStatus('screen stream error, retrying…');
     setTimeout(function () { img.src = '/screen?t=' + Date.now(); }, 1000);
   });
+
+  // Poll the input-runner lifecycle so the user sees when input is (re)starting
+  // instead of taps silently failing. /status returns 503 until the runner is
+  // ready; the input endpoints likewise 503 while it recovers.
+  function pollStatus() {
+    fetch('/status').then(function (res) {
+      return res.json().then(function (j) {
+        if (j.runnerState && j.runnerState !== 'ready') {
+          setStatus('input runner ' + j.runnerState + '…');
+        }
+      });
+    }).catch(function () {}).then(function () {
+      setTimeout(pollStatus, 2000);
+    });
+  }
+  pollStatus();
 })();
 </script>
 </body>

--- a/main.go
+++ b/main.go
@@ -179,6 +179,7 @@ Usage:
   ios ui app terminate <bundleID> [--driver=<driver>] [--session-id=<sessionid>] [--wda-url=<url>] [--devicekit-url=<url>] [options]
   ios ui app foreground [--driver=<driver>] [--devicekit-url=<url>] [options]
   ios ui stream (mjpeg | h264) [--fps=<fps>] [--quality=<quality>] [--scale=<scale>] [--bitrate=<bitrate>] [--driver=<driver>] [--wda-url=<url>] [--devicekit-url=<url>] [options]
+  ios remote [--port=<port>] [--wda-url=<url>] [options]
   ios uninstall <bundleID> [options]
   ios webinspector list [--timeout=<seconds>] [options]
   ios webinspector launch <url> [--bundle-id=<bundleID>] [--timeout=<seconds>] [options]
@@ -517,6 +518,10 @@ The commands work as following:
     ios ui app (launch | terminate) <bundleID>                       Launches or terminates an app.
     ios ui app foreground                                            Prints the foreground app through DeviceKit.
     ios ui stream (mjpeg | h264)                                     Streams video to stdout. H264 requires DeviceKit; WDA supports MJPEG.
+
+    ios remote [--port=<port>] [--wda-url=<url>]                     Serves a minimal, self-contained browser remote-control at 0.0.0.0:<port> (default 8080).
+                                                                    The live screen is WDA-free (instruments screenshot service, needs a mounted developer disk image);
+                                                                    taps/swipes/typing/buttons are routed through a reachable WebDriverAgent (--wda-url, default http://127.0.0.1:8100 or GO_IOS_WDA_URL).
 
     ios setlocation [options] [--lat=<lat>] [--lon=<lon>]           Updates the location of the device to the provided by latitude and longitude coordinates.
                                                                     Ex.: setlocation --lat=40.730610 --lon=-73.935242

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ Usage:
   ios ui app terminate <bundleID> [--driver=<driver>] [--session-id=<sessionid>] [--wda-url=<url>] [--devicekit-url=<url>] [options]
   ios ui app foreground [--driver=<driver>] [--devicekit-url=<url>] [options]
   ios ui stream (mjpeg | h264) [--fps=<fps>] [--quality=<quality>] [--scale=<scale>] [--bitrate=<bitrate>] [--driver=<driver>] [--wda-url=<url>] [--devicekit-url=<url>] [options]
-  ios remote [--port=<port>] [--wda-url=<url>] [options]
+  ios remote [--port=<port>] [--driver=<driver>] [--devicekit-url=<url>] [--wda-url=<url>] [options]
   ios uninstall <bundleID> [options]
   ios webinspector list [--timeout=<seconds>] [options]
   ios webinspector launch <url> [--bundle-id=<bundleID>] [--timeout=<seconds>] [options]
@@ -519,9 +519,11 @@ The commands work as following:
     ios ui app foreground                                            Prints the foreground app through DeviceKit.
     ios ui stream (mjpeg | h264)                                     Streams video to stdout. H264 requires DeviceKit; WDA supports MJPEG.
 
-    ios remote [--port=<port>] [--wda-url=<url>]                     Serves a minimal, self-contained browser remote-control at 0.0.0.0:<port> (default 8080).
-                                                                    The live screen is WDA-free (instruments screenshot service, needs a mounted developer disk image);
-                                                                    taps/swipes/typing/buttons are routed through a reachable WebDriverAgent (--wda-url, default http://127.0.0.1:8100 or GO_IOS_WDA_URL).
+    ios remote [--port=<port>] [--driver=<driver>]                  Serves a minimal, self-contained browser remote-control at 0.0.0.0:<port> (default 8080).
+                                                                    The live screen is WDA-free (instruments screenshot service, needs a mounted developer disk image).
+                                                                    Taps/swipes/typing/buttons are routed through a UI automation driver: DeviceKit by default
+                                                                    (--devicekit-url, default http://127.0.0.1:12004; WDA is broken on iOS 26, DeviceKit works),
+                                                                    or --driver=wda (--wda-url, default http://127.0.0.1:8100 or GO_IOS_WDA_URL).
 
     ios setlocation [options] [--lat=<lat>] [--lon=<lon>]           Updates the location of the device to the provided by latitude and longitude coordinates.
                                                                     Ex.: setlocation --lat=40.730610 --lon=-73.935242

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ Usage:
   ios ui app terminate <bundleID> [--driver=<driver>] [--session-id=<sessionid>] [--wda-url=<url>] [--devicekit-url=<url>] [options]
   ios ui app foreground [--driver=<driver>] [--devicekit-url=<url>] [options]
   ios ui stream (mjpeg | h264) [--fps=<fps>] [--quality=<quality>] [--scale=<scale>] [--bitrate=<bitrate>] [--driver=<driver>] [--wda-url=<url>] [--devicekit-url=<url>] [options]
-  ios remote [--port=<port>] [--driver=<driver>] [--devicekit-url=<url>] [--wda-url=<url>] [--no-manage-runner] [--runner-driver=<driver>] [options]
+  ios remote [--port=<port>] [--driver=<driver>] [--devicekit-url=<url>] [--wda-url=<url>] [--no-manage-runner] [--runner-driver=<driver>] [--fps=<fps>] [--bitrate=<bitrate>] [options]
   ios uninstall <bundleID> [options]
   ios webinspector list [--timeout=<seconds>] [options]
   ios webinspector launch <url> [--bundle-id=<bundleID>] [--timeout=<seconds>] [options]
@@ -528,6 +528,9 @@ The commands work as following:
                                                                     (ios ui run devicekit), auto-respawning it when it drops so input self-heals;
                                                                     pass --no-manage-runner to use an externally-started runner instead. While the
                                                                     runner is (re)starting, input endpoints return HTTP 503 and /status shows state.
+                                                                    The H.264 screen stream is decoded in-browser via WebCodecs (MJPEG fallback);
+                                                                    --fps (default 60) and --bitrate (default 8000000) tune the DeviceKit /h264
+                                                                    source for a smoother mirror. Press 'd' in the browser to toggle a diagnostic HUD.
 
     ios setlocation [options] [--lat=<lat>] [--lon=<lon>]           Updates the location of the device to the provided by latitude and longitude coordinates.
                                                                     Ex.: setlocation --lat=40.730610 --lon=-73.935242

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ Usage:
   ios ui app terminate <bundleID> [--driver=<driver>] [--session-id=<sessionid>] [--wda-url=<url>] [--devicekit-url=<url>] [options]
   ios ui app foreground [--driver=<driver>] [--devicekit-url=<url>] [options]
   ios ui stream (mjpeg | h264) [--fps=<fps>] [--quality=<quality>] [--scale=<scale>] [--bitrate=<bitrate>] [--driver=<driver>] [--wda-url=<url>] [--devicekit-url=<url>] [options]
-  ios remote [--port=<port>] [--driver=<driver>] [--devicekit-url=<url>] [--wda-url=<url>] [options]
+  ios remote [--port=<port>] [--driver=<driver>] [--devicekit-url=<url>] [--wda-url=<url>] [--no-manage-runner] [--runner-driver=<driver>] [options]
   ios uninstall <bundleID> [options]
   ios webinspector list [--timeout=<seconds>] [options]
   ios webinspector launch <url> [--bundle-id=<bundleID>] [--timeout=<seconds>] [options]
@@ -524,6 +524,10 @@ The commands work as following:
                                                                     Taps/swipes/typing/buttons are routed through a UI automation driver: DeviceKit by default
                                                                     (--devicekit-url, default http://127.0.0.1:12004; WDA is broken on iOS 26, DeviceKit works),
                                                                     or --driver=wda (--wda-url, default http://127.0.0.1:8100 or GO_IOS_WDA_URL).
+                                                                    With the DeviceKit driver ios remote spawns and supervises the input runner
+                                                                    (ios ui run devicekit), auto-respawning it when it drops so input self-heals;
+                                                                    pass --no-manage-runner to use an externally-started runner instead. While the
+                                                                    runner is (re)starting, input endpoints return HTTP 503 and /status shows state.
 
     ios setlocation [options] [--lat=<lat>] [--lon=<lon>]           Updates the location of the device to the provided by latitude and longitude coordinates.
                                                                     Ex.: setlocation --lat=40.730610 --lon=-73.935242


### PR DESCRIPTION
## What it does

Adds `ios remote [--port=<port>] [--driver=<driver>] [--devicekit-url=<url>] [--wda-url=<url>] [options]` — a tiny, self-contained browser remote-control for a device. It serves an inline HTML/CSS/JS page (no external/CDN assets) that mirrors the screen and drives basic input. It binds `0.0.0.0:<port>` (default `8080`) so it is reachable over Tailscale.

Usage:

```
ios remote --udid=<udid> --port=8080
# then open http://<host>:8080/ in a browser
```

The UI is an `<img src="/screen">` filling the page, with a click→tap / drag→swipe handler, a text box for typing, and Home / Lock / Vol+ / Vol- buttons.

## The split: WDA-free screen + WDA-free (DeviceKit) input

Two independent halves, and **both are now WDA-free**:

- **Live screen is WDA-FREE.** `GET /screen` reuses the instruments screenshot service (`ios/instruments`) in a ~12 fps loop and streams JPEG frames as MJPEG (`multipart/x-mixed-replace`). This needs the tunnel + a mounted developer disk image, but **no WebDriverAgent**. A small in-package broadcaster fans the latest frame out to all clients and drops frames for slow consumers so a stalled browser can't back-pressure capture (no global state, unlike the existing `StartMJPEGStreamingServer`).
- **Input uses DeviceKit by default (WDA is broken on iOS 26; DeviceKit works).** `/tap`, `/swipe`, `/type`, `/button` shell out to the **same `ios` binary** (`os.Executable`) and reuse the proven `ios ui …` commands, targeting the device udid and the selected driver: `--driver=devicekit` (default, `--devicekit-url`, default `http://127.0.0.1:12004` or `GO_IOS_DEVICEKIT_URL`) or `--driver=wda` (`--wda-url`, default `http://127.0.0.1:8100` or `GO_IOS_WDA_URL`). So the screen works with no driver running; input needs a reachable driver. Buttons (home/lock/volume) route through DeviceKit, which supports them.

**Coordinate mapping** is in one place (`fractionToPoints`): the browser sends each click as a `0..1` fraction of the displayed image, and the server maps it linearly to the driver's **logical points** using the size fetched once via `ios ui size` **on the same driver** (cached), never a hardcoded/WDA size. `parseSize` understands DeviceKit's `device.info` JSON-RPC envelope (`{"result":{"screenSize":{width,height},"scale"}}`) as well as the WDA window/size and bare shapes. On an iPhone SE 3rd gen DeviceKit reports 375×667 logical points (MJPEG frames are points × scale = 750×1334 px). Keeping the browser in fraction-space means it never has to know the device's pixel/point sizes or CSS letterboxing.

## Runner supervision — `ios remote` self-heals input (NEW)

Input intermittently broke and stayed broken until a human restarted the runner. **Root cause:** the input path uses a separate long-running `ios ui run devicekit` process (JSON-RPC at `http://127.0.0.1:12004`). That runner's on-device XCTest/testmanagerd automation channel intermittently drops — `DTX Connection with EOF` → `conn2 closed unexpectedly error=EOF` → the process exits rc=1 (`ui run: runner failed: lost connection to testmanagerd`). It is **not** memory/jetsam and **not** a deterministic load threshold; it's an iOS-side disconnect we can't prevent. Previously `ios remote` shelled out per action and did **not** own the runner, so once it died every action returned `connection refused` forever.

`ios remote` now **supervises the DeviceKit runner** (default, DeviceKit driver):

- **Spawns** `ios ui run devicekit --udid=<udid>` as a child of the same binary (`os.Executable`), detecting readiness by polling the DeviceKit health endpoint with a ~60s startup timeout.
- **Monitors + auto-respawns:** when the child dies it logs the exit (reason/rc) at WARN and respawns with capped exponential backoff (1s→10s), resetting the backoff after a runner stays up >60s — never spin-looping hot.
- **Lifecycle state** (`starting|ready|restarting|down`) is exposed at `GET /status` (and `/healthz`) and surfaced in the UI ("input runner restarting…").
- **503 during recovery:** `/tap /swipe /type /button` return `503 {"error":"input runner starting, retry shortly","runnerState":"…"}` while not ready, instead of failing with connection-refused.
- **Clean shutdown:** SIGINT/SIGTERM terminates the child (own process group) so no orphaned `ios ui run devicekit` is left behind.

`--no-manage-runner` keeps the old behavior (connect to an externally-run runner at `--devicekit-url`); `--runner-driver` selects which driver's runner to supervise (only devicekit is spawnable). The screen stream's tunnel self-heal is unchanged. Rich `golog` lifecycle logging (module `go-ios/remote`, `udid` attr): spawned (pid), ready (elapsed), exited (reason/rc), restarting (attempt/backoff). The spawn/health seam is a small interface, so the supervisor state machine is unit-tested without a device (fake death → respawn, backoff reset, shutdown stops child, input 503 when not ready).

## Tunnel-info self-refresh on reconnect (hardening)

The screen service used to cache the tunnel address for the process lifetime, so when the device's tunnel changed (CI run ends, replug, tunnel daemon restart) the stream went blank forever with `dial … i/o timeout` / "reconnect failed". On each screen-service reconnect we now **re-fetch fresh tunnel/RSD info** via a non-fatal resolver and dial that, mirroring how a fresh `ios screenshot` re-resolves each call — so the mirror self-recovers instead of dying.

## Native iOS-26 touch — follow-up

DeviceKit already gives WDA-free input on iOS 26. A further follow-up is native in-process touch injection (e.g. via CoreDevice / a HID path) so `ios remote` needs no external UI driver at all.

## Options considered

- **Screen via WDA MJPEG** (`ios ui stream mjpeg`) — rejected: it needs a driver just to see the screen, defeating the "screen works standalone" goal. The instruments screenshot service is driver-free and already present.
- **Re-implement a driver HTTP client in the new package for input** — rejected: shelling out to `ios ui` reuses battle-tested code paths (driver selection, session handling, env/URL resolution) instead of duplicating them; the cost is one subprocess per input event, which is negligible for a human-driven remote.
- **Reuse the global-state `StartMJPEGStreamingServer`/`mjpegHandler`** — rejected: its `sync.Map`/global conversion-queue design can't be instanced cleanly; the small local broadcaster is instanceable and testable and passes JPEG through untouched.
- **Browser sends pixel coords + image dims** — rejected in favor of pure fractions: fractions keep all device-size knowledge server-side in a single mapping function.

## Tests

`go build ./...`, `go vet ./...`, `gofmt -l`, `go test ./...` are clean. Unit tests cover driver defaulting (empty → DeviceKit), the `--devicekit-url`/`--wda-url` flag selection, coordinate mapping against the driver's logical size (including DeviceKit's 375×667), and `ui size` parsing for the DeviceKit JSON-RPC envelope + DeviceKit `screenSize` + WDA envelope + bare + noisy output, plus that `/` serves the HTML UI with 200 and `/button` rejects unknown buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deployment status (office01, iOS 26.5, udid 00008110-001C58C00A88401E)

Deployed and **live** on the office01 CI Mac over Tailscale, driving input via DeviceKit (WDA-free), reachable at `http://office01:8090/`.

- **Screen mirror: WORKS.** `GET /screen` streams live JPEG frames (~28 frames / 5 s captured, ~2.7 MB, valid JPEG SOI markers). Fully WDA-free.
- **Input via DeviceKit: WORKS.** `POST /tap` at multiple coordinates, `POST /type`, and `POST /button` (lock) all return `{"result":{"success":true}}` and actually act on the iOS 26.5 device. The server logs `driver: devicekit`, `driverURL: http://127.0.0.1:12004`.
- **Swipe: blocked by a pre-existing DeviceKit `ui swipe` bug**, not by `ios remote`. `POST /swipe` (and a plain `ios ui swipe --driver=devicekit`) returns `Invalid parameters … data missing` from DeviceKit's `device.io.swipe` RPC. Tap/type/button are unaffected; fixing the DeviceKit swipe param schema is separate from this PR.

This supersedes the earlier WDA-only status: WDA v13.1.3 on iOS 26.5 returned `Unhandled endpoint` for tap/homescreen/keys, so `ios remote` now defaults to DeviceKit.

Earlier robustness fixes remain in this PR: resolve tunnel/RSD info for `ios remote` (instruments needs it on iOS 17+); read `--port` through docopt's repeatable-list shape; send integer tap coordinates (`ios ui tap` rejects decimals); self-heal the screen stream on reconnect.

Usage:

```
ios remote --udid=<udid> --port=8090            # DeviceKit input (default)
ios remote --udid=<udid> --driver=wda           # opt back into WDA
# open http://<tailscale-host>:8090/ in a browser
```

