### PR TITLE
Allow for Silent Install of Wifi Profile

### DIFF
--- a/cmd_device_management.go
+++ b/cmd_device_management.go
@@ -50,6 +50,8 @@ func runWifiCommand(ctx commandContext) {
 	psw, _ := ctx.Args.String("--password")
 	encType, _ := ctx.Args.String("--enc-type")
 	remove, _ := ctx.Args.Bool("--remove")
+	p12file, _ := ctx.Args.String("--p12file")
+	p12password, _ := ctx.Args.String("--p12password")
 
 	if encType == "" {
 		encType = "WPA"
@@ -58,7 +60,8 @@ func runWifiCommand(ctx commandContext) {
 	if remove {
 		exitIfError("failed removing wifi", mcinstall.RemoveWifi(ctx.Device, ssid))
 	} else {
-		exitIfError("failed preparing wifi", mcinstall.PrepareWifi(ctx.Device, ssid, psw, encType))
+		exitIfError("failed preparing wifi", mcinstall.PrepareWifi(ctx.Device, ssid, psw, encType,
+			p12file, p12password))
 	}
 	fmt.Print(convertToJSONString("ok"))
 }

--- a/ios/mcinstall/wifi.go
+++ b/ios/mcinstall/wifi.go
@@ -126,7 +126,11 @@ func isSupervised(conn *Connection) bool {
 	if err != nil {
 		return false
 	}
-	s, _ := cfg["IsSupervised"].(bool)
+	cloudCfg, ok := cfg["CloudConfiguration"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	s, _ := cloudCfg["IsSupervised"].(bool)
 	return s
 }
 

--- a/ios/mcinstall/wifi.go
+++ b/ios/mcinstall/wifi.go
@@ -39,7 +39,7 @@ func PrepareWifi(device ios.DeviceEntry, ssid string, psw string, encType string
 	golog.Debug("flush response", "module", logModule, "udid", device.Properties.SerialNumber, "response", re)
 
 	supervised := isSupervised(conn)
-	golog.Info("PrepareWifi: device supervised: ", supervised)
+	golog.Info("PrepareWifi: device supervised: ", "module", logModule, "udid", device.Properties.SerialNumber, "IsSupervised", supervised)
 
 	err = conn.EscalateUnsupervised()
 	if err != nil {
@@ -72,14 +72,14 @@ func PrepareWifi(device ios.DeviceEntry, ssid string, psw string, encType string
 		if err != nil {
 			return fmt.Errorf("PrepareWifi: %w", err)
 		}
-		golog.Info("Successfully installed wifi profile")
+		golog.Info("Successfully installed wifi profile", "module", logModule, "udid", device.Properties.SerialNumber, "ssid", ssid)
 	} else {
 		if err := conn.AddProfile([]byte(profile)); err != nil {
 			return fmt.Errorf("PrepareWifi: %w", err)
 		}
 		if supervised {
-			golog.Warn("device is supervised, but supervision credentials were not given.",
-						   "The Wi-Fi profile must be approved manually on the device (Settings > General > VPN & Device Management) before it takes effect.")
+			golog.Warn("device is supervised, but supervision credentials were not given. The Wi-Fi profile must be approved manually on the device (Settings > General > VPN & Device Management) before it takes effect.",
+			"module", logModule, "udid", device.Properties.SerialNumber, "ssid", ssid)
 		} else {
 			golog.Warn("device is not supervised: the Wi-Fi profile was installed but must be approved manually on the device(Settings > General > VPN & Device Management) before it takes effect. Supervise the device for a silent install.",
 				"module", logModule, "udid", device.Properties.SerialNumber, "ssid", ssid)

--- a/ios/mcinstall/wifi.go
+++ b/ios/mcinstall/wifi.go
@@ -3,6 +3,7 @@ package mcinstall
 import (
 	"crypto/sha1"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -11,7 +12,8 @@ import (
 	"github.com/danielpaulus/go-ios/ios/mobileactivation"
 )
 
-func PrepareWifi(device ios.DeviceEntry, ssid string, psw string, encType string) error {
+func PrepareWifi(device ios.DeviceEntry, ssid string, psw string, encType string,
+					  p12file string, p12password string) error {
 	if ssid == "" || psw == "" {
 		return fmt.Errorf("PrepareWifi: both ssid and password must be specified")
 	}
@@ -37,6 +39,7 @@ func PrepareWifi(device ios.DeviceEntry, ssid string, psw string, encType string
 	golog.Debug("flush response", "module", logModule, "udid", device.Properties.SerialNumber, "response", re)
 
 	supervised := isSupervised(conn)
+	golog.Info("PrepareWifi: device supervised: ", supervised)
 
 	err = conn.EscalateUnsupervised()
 	if err != nil {
@@ -60,14 +63,29 @@ func PrepareWifi(device ios.DeviceEntry, ssid string, psw string, encType string
 		profileUUID(ssid),
 	)
 
-	if err := conn.AddProfile([]byte(profile)); err != nil {
-		return fmt.Errorf("PrepareWifi: %w", err)
+	if supervised && p12file != "" && p12password != "" {
+		p12bytes, err := os.ReadFile(p12file)
+		if err != nil {
+			return fmt.Errorf("PrepareWifi: could not read p12 file: %w", err)
+		}
+		err = conn.AddProfileSupervised([]byte(profile), p12bytes, p12password)
+		if err != nil {
+			return fmt.Errorf("PrepareWifi: %w", err)
+		}
+		golog.Info("Successfully installed wifi profile")
+	} else {
+		if err := conn.AddProfile([]byte(profile)); err != nil {
+			return fmt.Errorf("PrepareWifi: %w", err)
+		}
+		if supervised {
+			golog.Warn("device is supervised, but supervision credentials were not given.",
+						   "The Wi-Fi profile must be approved manually on the device (Settings > General > VPN & Device Management) before it takes effect.")
+		} else {
+			golog.Warn("device is not supervised: the Wi-Fi profile was installed but must be approved manually on the device(Settings > General > VPN & Device Management) before it takes effect. Supervise the device for a silent install.",
+				"module", logModule, "udid", device.Properties.SerialNumber, "ssid", ssid)
+		}
 	}
 
-	if !supervised {
-		golog.Warn("device is not supervised: the Wi-Fi profile was installed but must be approved manually on the device (Settings > General > VPN & Device Management) before it takes effect. Supervise the device for a silent install.",
-			"module", logModule, "udid", device.Properties.SerialNumber, "ssid", ssid)
-	}
 	return nil
 }
 

--- a/ios/mcinstall/wifi.go
+++ b/ios/mcinstall/wifi.go
@@ -144,12 +144,15 @@ func isSupervised(conn *Connection) bool {
 	if err != nil {
 		return false
 	}
-	cloudCfg, ok := cfg["CloudConfiguration"].(map[string]interface{})
-	if !ok {
-		return false
+	if cc, ok := cfg["CloudConfiguration"].(map[string]interface{}); ok {
+		if s, ok := cc["IsSupervised"].(bool); ok {
+			return s
+		}
 	}
-	s, _ := cloudCfg["IsSupervised"].(bool)
-	return s
+	if s, ok := cfg["IsSupervised"].(bool); ok {
+		return s
+	}
+	return false
 }
 
 // sanitizeIdentifier converts a string into an Apple-compatible PayloadIdentifier fragment.

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ Usage:
   ios prepare cloudconfig [options]
   ios prepare create-cert
   ios prepare printskip
-  ios wifi [--ssid=<ssid>] [--password=<password>] [--enc-type=<encType>] [--remove] [options]
+  ios wifi [--ssid=<ssid>] [--password=<password>] [--enc-type=<encType>] [--p12file=<p12file>] [--p12password=<p12password>] [--remove] [options]
   ios profile add <profileFile> [--p12file=<orgid>] [--password=<p12password>] [options]
   ios profile list [options]
   ios profile remove <profileName> [options]
@@ -426,7 +426,7 @@ The commands work as following:
 
     ios prepare printskip                                              Print all options you can skip.
 
-	ios wifi [--ssid=<ssid>] [--password=<password>] [--enc-type=<encType>] [--remove]
+	ios wifi [--ssid=<ssid>] [--password=<password>] [--enc-type=<encType>] [--p12file=<p12file>] [--p12password=<p12password>] [--remove]
 																		Installs a wifi profile on the device forcing a connection to the provided WiFi network
 																		If --remove is specified, the wifi profile of the provided ssid will be removed.
 


### PR DESCRIPTION
The `ios wifi` command would previously only install the generated profile as if the device were unsupervised. Additionally, even if this was used with a supervised device, the check for supervision would always fail. 

Updates wifi command to take a `--p12file` and a `--p12password` similar to the `ios profile add` command. This allows for supervised devices to silently accept the profile.

Proposed wifi command structure:
```ios wifi --ssid=my_ssid --password=my_password --enc-type=my_encryption_type --p12file=certificate.p12 --p12password=a```

Tested with an iPhone 16 running iOS 26.2.1 on Fedora 39. Supervision was setup using ```ios prepare```