### PR TITLE
fix(nskeyedarchiver): tolerate XCUITest objects with absent fields

### DIFF
--- a/ios/nskeyedarchiver/objectivec_classes.go
+++ b/ios/nskeyedarchiver/objectivec_classes.go
@@ -327,31 +327,16 @@ type XCTAttachment struct {
 	userInfo              map[string]interface{}
 }
 
-// resolveRef follows a keyed archive reference, returning nil when the key is
-// absent, is not a reference, or points outside the object table. Callers
-// comma-ok assert the result, so an omitted field yields a zero value.
-func resolveRef(object map[string]interface{}, key string, objects []interface{}) interface{} {
-	uid, isRef := object[key].(plist.UID)
-	if !isRef || int(uid) >= len(objects) {
-		return nil
-	}
-	return objects[uid]
-}
-
 func NewXCTAttachment(object map[string]interface{}, objects []interface{}) interface{} {
-	lifetime, _ := object["lifetime"].(uint64)
-	uniformTypeIdentifier, _ := resolveRef(object, "uniformTypeIdentifier", objects).(string)
-	fileNameOverride, _ := resolveRef(object, "fileNameOverride", objects).(string)
-	timestamp, _ := resolveRef(object, "timestamp", objects).(float64)
-	name, _ := resolveRef(object, "name", objects).(string)
+	lifetime := object["lifetime"].(uint64)
+	uniformTypeIdentifier := objects[object["uniformTypeIdentifier"].(plist.UID)].(string)
+	fileNameOverride := objects[object["fileNameOverride"].(plist.UID)].(string)
+	timestamp := objects[object["timestamp"].(plist.UID)].(float64)
+	name := objects[object["name"].(plist.UID)].(string)
+	userInfo, _ := extractDictionary(objects[object["userInfo"].(plist.UID)].(map[string]interface{}), objects, 0)
 
-	// An absent userInfo arrives as the string "$null", not a dictionary.
-	var userInfo map[string]interface{}
-	if raw, isDict := resolveRef(object, "userInfo", objects).(map[string]interface{}); isDict {
-		userInfo, _ = extractDictionary(raw, objects, 0)
-	}
-
-	payload := extractAttachmentPayload(resolveRef(object, "payload", objects), objects)
+	payloadRaw := objects[object["payload"].(plist.UID)]
+	payload := extractAttachmentPayload(payloadRaw, objects)
 
 	return XCTAttachment{
 		lifetime:              lifetime,
@@ -369,7 +354,7 @@ func extractAttachmentPayload(payloadRaw interface{}, objects []interface{}) []u
 	if !byteSliceOk {
 		mapPayload, mapOk := payloadRaw.(map[string]interface{})
 		if mapOk {
-			payloadClassMap, classOk := resolveRef(mapPayload, "$class", objects).(map[string]interface{})
+			payloadClassMap, classOk := objects[mapPayload["$class"].(plist.UID)].(map[string]interface{})
 			if classOk {
 				payloadClass := payloadClassMap["$classname"]
 				if payloadClass == "NSMutableData" || payloadClass == "NSData" {
@@ -787,14 +772,14 @@ type XCTIssue struct {
 }
 
 func NewXCTIssue(object map[string]interface{}, objects []interface{}) interface{} {
-	runtimeIssueSeverity, _ := object["runtimeIssueSeverity"].(uint64)
-	detailedDescription, _ := resolveRef(object, "detailed-description", objects).(string)
-	compactDescription, _ := resolveRef(object, "compact-description", objects).(string)
+	runtimeIssueSeverity := object["runtimeIssueSeverity"].(uint64)
+	detailedDescriptionRef := object["detailed-description"].(plist.UID)
+	sourceCodeContextRef := object["source-code-context"].(plist.UID)
+	compactDescriptionRef := object["compact-description"].(plist.UID)
 
-	var sourceCodeContext XCTSourceCodeContext
-	if raw, isDict := resolveRef(object, "source-code-context", objects).(map[string]interface{}); isDict {
-		sourceCodeContext, _ = NewXCTSourceCodeContext(raw, objects).(XCTSourceCodeContext)
-	}
+	detailedDescription := objects[detailedDescriptionRef].(string)
+	compactDescription := objects[compactDescriptionRef].(string)
+	sourceCodeContext := NewXCTSourceCodeContext(objects[sourceCodeContextRef].(map[string]interface{}), objects).(XCTSourceCodeContext)
 
 	return XCTIssue{RuntimeIssueSeverity: runtimeIssueSeverity, DetailedDescription: detailedDescription, CompactDescription: compactDescription, SourceCodeContext: sourceCodeContext}
 }
@@ -813,10 +798,8 @@ type XCTSourceCodeContext struct {
 }
 
 func NewXCTSourceCodeContext(object map[string]interface{}, objects []interface{}) interface{} {
-	var location XCTSourceCodeLocation
-	if raw, isDict := resolveRef(object, "location", objects).(map[string]interface{}); isDict {
-		location, _ = NewXCTSourceCodeLocation(raw, objects).(XCTSourceCodeLocation)
-	}
+	locationRef := object["location"].(plist.UID)
+	location := NewXCTSourceCodeLocation(objects[locationRef].(map[string]interface{}), objects).(XCTSourceCodeLocation)
 
 	return XCTSourceCodeContext{Location: location}
 }
@@ -827,13 +810,13 @@ type XCTSourceCodeLocation struct {
 }
 
 func NewXCTSourceCodeLocation(object map[string]interface{}, objects []interface{}) interface{} {
-	var relativePath string
-	if fileURL, isDict := resolveRef(object, "file-url", objects).(map[string]interface{}); isDict {
-		relativePath, _ = resolveRef(fileURL, "NS.relative", objects).(string)
-	}
-	lineNumber, _ := object["line-number"].(uint64)
+	fileUrlRef := object["file-url"].(plist.UID)
+	relativeRef := objects[fileUrlRef].(map[string]interface{})["NS.relative"].(plist.UID)
+	relativePath := objects[int(relativeRef)].(string)
+	fileUrl := NewNSURL(relativePath)
+	lineNumber := object["line-number"].(uint64)
 
-	return XCTSourceCodeLocation{FileUrl: NewNSURL(relativePath), LineNumber: lineNumber}
+	return XCTSourceCodeLocation{FileUrl: fileUrl, LineNumber: lineNumber}
 }
 
 func toInterfaceSliceOfTests(testSlice []XCTTestIdentifier) []interface{} {

--- a/ios/nskeyedarchiver/objectivec_classes.go
+++ b/ios/nskeyedarchiver/objectivec_classes.go
@@ -327,16 +327,36 @@ type XCTAttachment struct {
 	userInfo              map[string]interface{}
 }
 
-func NewXCTAttachment(object map[string]interface{}, objects []interface{}) interface{} {
-	lifetime := object["lifetime"].(uint64)
-	uniformTypeIdentifier := objects[object["uniformTypeIdentifier"].(plist.UID)].(string)
-	fileNameOverride := objects[object["fileNameOverride"].(plist.UID)].(string)
-	timestamp := objects[object["timestamp"].(plist.UID)].(float64)
-	name := objects[object["name"].(plist.UID)].(string)
-	userInfo, _ := extractDictionary(objects[object["userInfo"].(plist.UID)].(map[string]interface{}), objects, 0)
+// resolveRef follows a keyed archive reference and returns what it points at, or
+// nil when the key is absent, is not a reference, or points outside the object
+// table. Callers type-assert the result with the comma ok form, so a field the
+// device omitted yields a zero value instead of a panic.
+func resolveRef(object map[string]interface{}, key string, objects []interface{}) interface{} {
+	uid, isRef := object[key].(plist.UID)
+	if !isRef || int(uid) >= len(objects) {
+		return nil
+	}
+	return objects[uid]
+}
 
-	payloadRaw := objects[object["payload"].(plist.UID)]
-	payload := extractAttachmentPayload(payloadRaw, objects)
+func NewXCTAttachment(object map[string]interface{}, objects []interface{}) interface{} {
+	lifetime, _ := object["lifetime"].(uint64)
+	uniformTypeIdentifier, _ := resolveRef(object, "uniformTypeIdentifier", objects).(string)
+	fileNameOverride, _ := resolveRef(object, "fileNameOverride", objects).(string)
+	timestamp, _ := resolveRef(object, "timestamp", objects).(float64)
+	name, _ := resolveRef(object, "name", objects).(string)
+
+	// An attachment with no userInfo encodes it as the string "$null" rather
+	// than a dictionary, so decode it only when it really is one. Asserting a
+	// dictionary here used to panic on iOS 27 attachments, which surfaced as
+	// "Unarchive: interface conversion: interface {} is string, not
+	// map[string]interface {}" and failed the whole XCUITest run.
+	var userInfo map[string]interface{}
+	if raw, isDict := resolveRef(object, "userInfo", objects).(map[string]interface{}); isDict {
+		userInfo, _ = extractDictionary(raw, objects, 0)
+	}
+
+	payload := extractAttachmentPayload(resolveRef(object, "payload", objects), objects)
 
 	return XCTAttachment{
 		lifetime:              lifetime,
@@ -354,7 +374,7 @@ func extractAttachmentPayload(payloadRaw interface{}, objects []interface{}) []u
 	if !byteSliceOk {
 		mapPayload, mapOk := payloadRaw.(map[string]interface{})
 		if mapOk {
-			payloadClassMap, classOk := objects[mapPayload["$class"].(plist.UID)].(map[string]interface{})
+			payloadClassMap, classOk := resolveRef(mapPayload, "$class", objects).(map[string]interface{})
 			if classOk {
 				payloadClass := payloadClassMap["$classname"]
 				if payloadClass == "NSMutableData" || payloadClass == "NSData" {
@@ -772,14 +792,16 @@ type XCTIssue struct {
 }
 
 func NewXCTIssue(object map[string]interface{}, objects []interface{}) interface{} {
-	runtimeIssueSeverity := object["runtimeIssueSeverity"].(uint64)
-	detailedDescriptionRef := object["detailed-description"].(plist.UID)
-	sourceCodeContextRef := object["source-code-context"].(plist.UID)
-	compactDescriptionRef := object["compact-description"].(plist.UID)
+	runtimeIssueSeverity, _ := object["runtimeIssueSeverity"].(uint64)
+	detailedDescription, _ := resolveRef(object, "detailed-description", objects).(string)
+	compactDescription, _ := resolveRef(object, "compact-description", objects).(string)
 
-	detailedDescription := objects[detailedDescriptionRef].(string)
-	compactDescription := objects[compactDescriptionRef].(string)
-	sourceCodeContext := NewXCTSourceCodeContext(objects[sourceCodeContextRef].(map[string]interface{}), objects).(XCTSourceCodeContext)
+	// An issue without a source-code context encodes it as "$null" rather than a
+	// dictionary, so decode it only when it really is one.
+	var sourceCodeContext XCTSourceCodeContext
+	if raw, isDict := resolveRef(object, "source-code-context", objects).(map[string]interface{}); isDict {
+		sourceCodeContext, _ = NewXCTSourceCodeContext(raw, objects).(XCTSourceCodeContext)
+	}
 
 	return XCTIssue{RuntimeIssueSeverity: runtimeIssueSeverity, DetailedDescription: detailedDescription, CompactDescription: compactDescription, SourceCodeContext: sourceCodeContext}
 }
@@ -798,8 +820,10 @@ type XCTSourceCodeContext struct {
 }
 
 func NewXCTSourceCodeContext(object map[string]interface{}, objects []interface{}) interface{} {
-	locationRef := object["location"].(plist.UID)
-	location := NewXCTSourceCodeLocation(objects[locationRef].(map[string]interface{}), objects).(XCTSourceCodeLocation)
+	var location XCTSourceCodeLocation
+	if raw, isDict := resolveRef(object, "location", objects).(map[string]interface{}); isDict {
+		location, _ = NewXCTSourceCodeLocation(raw, objects).(XCTSourceCodeLocation)
+	}
 
 	return XCTSourceCodeContext{Location: location}
 }
@@ -810,13 +834,13 @@ type XCTSourceCodeLocation struct {
 }
 
 func NewXCTSourceCodeLocation(object map[string]interface{}, objects []interface{}) interface{} {
-	fileUrlRef := object["file-url"].(plist.UID)
-	relativeRef := objects[fileUrlRef].(map[string]interface{})["NS.relative"].(plist.UID)
-	relativePath := objects[int(relativeRef)].(string)
-	fileUrl := NewNSURL(relativePath)
-	lineNumber := object["line-number"].(uint64)
+	var relativePath string
+	if fileURL, isDict := resolveRef(object, "file-url", objects).(map[string]interface{}); isDict {
+		relativePath, _ = resolveRef(fileURL, "NS.relative", objects).(string)
+	}
+	lineNumber, _ := object["line-number"].(uint64)
 
-	return XCTSourceCodeLocation{FileUrl: fileUrl, LineNumber: lineNumber}
+	return XCTSourceCodeLocation{FileUrl: NewNSURL(relativePath), LineNumber: lineNumber}
 }
 
 func toInterfaceSliceOfTests(testSlice []XCTTestIdentifier) []interface{} {

--- a/ios/nskeyedarchiver/objectivec_classes.go
+++ b/ios/nskeyedarchiver/objectivec_classes.go
@@ -327,10 +327,9 @@ type XCTAttachment struct {
 	userInfo              map[string]interface{}
 }
 
-// resolveRef follows a keyed archive reference and returns what it points at, or
-// nil when the key is absent, is not a reference, or points outside the object
-// table. Callers type-assert the result with the comma ok form, so a field the
-// device omitted yields a zero value instead of a panic.
+// resolveRef follows a keyed archive reference, returning nil when the key is
+// absent, is not a reference, or points outside the object table. Callers
+// comma-ok assert the result, so an omitted field yields a zero value.
 func resolveRef(object map[string]interface{}, key string, objects []interface{}) interface{} {
 	uid, isRef := object[key].(plist.UID)
 	if !isRef || int(uid) >= len(objects) {
@@ -346,11 +345,7 @@ func NewXCTAttachment(object map[string]interface{}, objects []interface{}) inte
 	timestamp, _ := resolveRef(object, "timestamp", objects).(float64)
 	name, _ := resolveRef(object, "name", objects).(string)
 
-	// An attachment with no userInfo encodes it as the string "$null" rather
-	// than a dictionary, so decode it only when it really is one. Asserting a
-	// dictionary here used to panic on iOS 27 attachments, which surfaced as
-	// "Unarchive: interface conversion: interface {} is string, not
-	// map[string]interface {}" and failed the whole XCUITest run.
+	// An absent userInfo arrives as the string "$null", not a dictionary.
 	var userInfo map[string]interface{}
 	if raw, isDict := resolveRef(object, "userInfo", objects).(map[string]interface{}); isDict {
 		userInfo, _ = extractDictionary(raw, objects, 0)
@@ -796,8 +791,6 @@ func NewXCTIssue(object map[string]interface{}, objects []interface{}) interface
 	detailedDescription, _ := resolveRef(object, "detailed-description", objects).(string)
 	compactDescription, _ := resolveRef(object, "compact-description", objects).(string)
 
-	// An issue without a source-code context encodes it as "$null" rather than a
-	// dictionary, so decode it only when it really is one.
 	var sourceCodeContext XCTSourceCodeContext
 	if raw, isDict := resolveRef(object, "source-code-context", objects).(map[string]interface{}); isDict {
 		sourceCodeContext, _ = NewXCTSourceCodeContext(raw, objects).(XCTSourceCodeContext)

--- a/ios/nskeyedarchiver/objectivec_classes.go
+++ b/ios/nskeyedarchiver/objectivec_classes.go
@@ -327,16 +327,31 @@ type XCTAttachment struct {
 	userInfo              map[string]interface{}
 }
 
-func NewXCTAttachment(object map[string]interface{}, objects []interface{}) interface{} {
-	lifetime := object["lifetime"].(uint64)
-	uniformTypeIdentifier := objects[object["uniformTypeIdentifier"].(plist.UID)].(string)
-	fileNameOverride := objects[object["fileNameOverride"].(plist.UID)].(string)
-	timestamp := objects[object["timestamp"].(plist.UID)].(float64)
-	name := objects[object["name"].(plist.UID)].(string)
-	userInfo, _ := extractDictionary(objects[object["userInfo"].(plist.UID)].(map[string]interface{}), objects, 0)
+// resolveRef follows a keyed archive reference, returning nil when the key is
+// absent, is not a reference, or points outside the object table. Callers
+// comma-ok assert the result, so an omitted field yields a zero value.
+func resolveRef(object map[string]interface{}, key string, objects []interface{}) interface{} {
+	uid, isRef := object[key].(plist.UID)
+	if !isRef || int(uid) >= len(objects) {
+		return nil
+	}
+	return objects[uid]
+}
 
-	payloadRaw := objects[object["payload"].(plist.UID)]
-	payload := extractAttachmentPayload(payloadRaw, objects)
+func NewXCTAttachment(object map[string]interface{}, objects []interface{}) interface{} {
+	lifetime, _ := object["lifetime"].(uint64)
+	uniformTypeIdentifier, _ := resolveRef(object, "uniformTypeIdentifier", objects).(string)
+	fileNameOverride, _ := resolveRef(object, "fileNameOverride", objects).(string)
+	timestamp, _ := resolveRef(object, "timestamp", objects).(float64)
+	name, _ := resolveRef(object, "name", objects).(string)
+
+	// An absent userInfo arrives as the string "$null", not a dictionary.
+	var userInfo map[string]interface{}
+	if raw, isDict := resolveRef(object, "userInfo", objects).(map[string]interface{}); isDict {
+		userInfo, _ = extractDictionary(raw, objects, 0)
+	}
+
+	payload := extractAttachmentPayload(resolveRef(object, "payload", objects), objects)
 
 	return XCTAttachment{
 		lifetime:              lifetime,
@@ -354,7 +369,7 @@ func extractAttachmentPayload(payloadRaw interface{}, objects []interface{}) []u
 	if !byteSliceOk {
 		mapPayload, mapOk := payloadRaw.(map[string]interface{})
 		if mapOk {
-			payloadClassMap, classOk := objects[mapPayload["$class"].(plist.UID)].(map[string]interface{})
+			payloadClassMap, classOk := resolveRef(mapPayload, "$class", objects).(map[string]interface{})
 			if classOk {
 				payloadClass := payloadClassMap["$classname"]
 				if payloadClass == "NSMutableData" || payloadClass == "NSData" {
@@ -772,14 +787,14 @@ type XCTIssue struct {
 }
 
 func NewXCTIssue(object map[string]interface{}, objects []interface{}) interface{} {
-	runtimeIssueSeverity := object["runtimeIssueSeverity"].(uint64)
-	detailedDescriptionRef := object["detailed-description"].(plist.UID)
-	sourceCodeContextRef := object["source-code-context"].(plist.UID)
-	compactDescriptionRef := object["compact-description"].(plist.UID)
+	runtimeIssueSeverity, _ := object["runtimeIssueSeverity"].(uint64)
+	detailedDescription, _ := resolveRef(object, "detailed-description", objects).(string)
+	compactDescription, _ := resolveRef(object, "compact-description", objects).(string)
 
-	detailedDescription := objects[detailedDescriptionRef].(string)
-	compactDescription := objects[compactDescriptionRef].(string)
-	sourceCodeContext := NewXCTSourceCodeContext(objects[sourceCodeContextRef].(map[string]interface{}), objects).(XCTSourceCodeContext)
+	var sourceCodeContext XCTSourceCodeContext
+	if raw, isDict := resolveRef(object, "source-code-context", objects).(map[string]interface{}); isDict {
+		sourceCodeContext, _ = NewXCTSourceCodeContext(raw, objects).(XCTSourceCodeContext)
+	}
 
 	return XCTIssue{RuntimeIssueSeverity: runtimeIssueSeverity, DetailedDescription: detailedDescription, CompactDescription: compactDescription, SourceCodeContext: sourceCodeContext}
 }
@@ -798,8 +813,10 @@ type XCTSourceCodeContext struct {
 }
 
 func NewXCTSourceCodeContext(object map[string]interface{}, objects []interface{}) interface{} {
-	locationRef := object["location"].(plist.UID)
-	location := NewXCTSourceCodeLocation(objects[locationRef].(map[string]interface{}), objects).(XCTSourceCodeLocation)
+	var location XCTSourceCodeLocation
+	if raw, isDict := resolveRef(object, "location", objects).(map[string]interface{}); isDict {
+		location, _ = NewXCTSourceCodeLocation(raw, objects).(XCTSourceCodeLocation)
+	}
 
 	return XCTSourceCodeContext{Location: location}
 }
@@ -810,13 +827,13 @@ type XCTSourceCodeLocation struct {
 }
 
 func NewXCTSourceCodeLocation(object map[string]interface{}, objects []interface{}) interface{} {
-	fileUrlRef := object["file-url"].(plist.UID)
-	relativeRef := objects[fileUrlRef].(map[string]interface{})["NS.relative"].(plist.UID)
-	relativePath := objects[int(relativeRef)].(string)
-	fileUrl := NewNSURL(relativePath)
-	lineNumber := object["line-number"].(uint64)
+	var relativePath string
+	if fileURL, isDict := resolveRef(object, "file-url", objects).(map[string]interface{}); isDict {
+		relativePath, _ = resolveRef(fileURL, "NS.relative", objects).(string)
+	}
+	lineNumber, _ := object["line-number"].(uint64)
 
-	return XCTSourceCodeLocation{FileUrl: fileUrl, LineNumber: lineNumber}
+	return XCTSourceCodeLocation{FileUrl: NewNSURL(relativePath), LineNumber: lineNumber}
 }
 
 func toInterfaceSliceOfTests(testSlice []XCTTestIdentifier) []interface{} {

--- a/ios/nskeyedarchiver/xctattachment_test.go
+++ b/ios/nskeyedarchiver/xctattachment_test.go
@@ -1,0 +1,167 @@
+package nskeyedarchiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"howett.net/plist"
+)
+
+// iOS 27 sends XCUITest attachments with no userInfo, which NSKeyedArchiver
+// encodes as the string "$null" rather than a dictionary. NewXCTAttachment used
+// to assert a dictionary there, so decoding panicked; Unarchive recovered it as
+// "Unarchive: interface conversion: interface {} is string, not
+// map[string]interface {}", which failed the whole XCUITest run and left devices
+// stuck in cleaning.
+func TestNewXCTAttachmentWithNullUserInfo(t *testing.T) {
+	objects := []interface{}{
+		"$null",              // 0
+		"public.plain-text",  // 1 uniformTypeIdentifier
+		"override.txt",       // 2 fileNameOverride
+		float64(770474977.9), // 3 timestamp
+		"Screenshot",         // 4 name
+		[]uint8{0x61, 0x62},  // 5 payload
+	}
+	object := map[string]interface{}{
+		"lifetime":              uint64(1),
+		"uniformTypeIdentifier": plist.UID(1),
+		"fileNameOverride":      plist.UID(2),
+		"timestamp":             plist.UID(3),
+		"name":                  plist.UID(4),
+		"payload":               plist.UID(5),
+		"userInfo":              plist.UID(0), // points at "$null"
+	}
+
+	var decoded interface{}
+	require.NotPanics(t, func() { decoded = NewXCTAttachment(object, objects) })
+
+	attachment, ok := decoded.(XCTAttachment)
+	require.True(t, ok)
+	assert.Equal(t, "public.plain-text", attachment.UniformTypeIdentifier)
+	assert.Equal(t, "Screenshot", attachment.Name)
+	assert.Equal(t, []uint8{0x61, 0x62}, attachment.Payload)
+	assert.Nil(t, attachment.userInfo, "a missing userInfo should decode as empty, not panic")
+}
+
+// A real userInfo dictionary must still be decoded.
+func TestNewXCTAttachmentWithUserInfoDictionary(t *testing.T) {
+	objects := []interface{}{
+		"$null",
+		"public.png",
+		"shot.png",
+		float64(1),
+		"Shot",
+		[]uint8{0x01},
+		map[string]interface{}{"NS.keys": []interface{}{}, "NS.objects": []interface{}{}},
+	}
+	object := map[string]interface{}{
+		"lifetime":              uint64(2),
+		"uniformTypeIdentifier": plist.UID(1),
+		"fileNameOverride":      plist.UID(2),
+		"timestamp":             plist.UID(3),
+		"name":                  plist.UID(4),
+		"payload":               plist.UID(5),
+		"userInfo":              plist.UID(6),
+	}
+
+	var decoded interface{}
+	require.NotPanics(t, func() { decoded = NewXCTAttachment(object, objects) })
+	attachment, ok := decoded.(XCTAttachment)
+	require.True(t, ok)
+	assert.Equal(t, "public.png", attachment.UniformTypeIdentifier)
+	assert.NotNil(t, attachment.userInfo)
+}
+
+// Malformed archives must not panic either: missing keys, references that are
+// not references, and references past the end of the object table.
+func TestNewXCTAttachmentToleratesMalformedArchives(t *testing.T) {
+	objects := []interface{}{"$null", "public.png"}
+
+	tests := []struct {
+		name   string
+		object map[string]interface{}
+	}{
+		{name: "empty object", object: map[string]interface{}{}},
+		{
+			name: "reference out of range",
+			object: map[string]interface{}{
+				"lifetime": uint64(1),
+				"name":     plist.UID(99),
+			},
+		},
+		{
+			name: "value is not a reference",
+			object: map[string]interface{}{
+				"lifetime": uint64(1),
+				"name":     "not-a-uid",
+				"userInfo": 42,
+			},
+		},
+		{
+			name: "lifetime has the wrong type",
+			object: map[string]interface{}{
+				"lifetime": "not-a-number",
+				"name":     plist.UID(1),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotPanics(t, func() { NewXCTAttachment(tt.object, objects) })
+		})
+	}
+}
+
+func TestResolveRef(t *testing.T) {
+	objects := []interface{}{"zero", "one"}
+
+	assert.Equal(t, "one", resolveRef(map[string]interface{}{"k": plist.UID(1)}, "k", objects))
+	assert.Nil(t, resolveRef(map[string]interface{}{}, "missing", objects))
+	assert.Nil(t, resolveRef(map[string]interface{}{"k": "not-a-uid"}, "k", objects))
+	assert.Nil(t, resolveRef(map[string]interface{}{"k": plist.UID(5)}, "k", objects),
+		"a reference past the end of the object table must not index out of range")
+}
+
+// The same "$null" shape reaches XCTIssue and its nested source code context:
+// an issue without a source-code context, or a context without a location,
+// panicked in the same way and accounted for the rest of the failures.
+func TestNewXCTIssueWithNullSourceCodeContext(t *testing.T) {
+	objects := []interface{}{"$null", "compact", "detailed"}
+	object := map[string]interface{}{
+		"runtimeIssueSeverity": uint64(1),
+		"compact-description":  plist.UID(1),
+		"detailed-description": plist.UID(2),
+		"source-code-context":  plist.UID(0), // "$null"
+	}
+
+	var decoded interface{}
+	require.NotPanics(t, func() { decoded = NewXCTIssue(object, objects) })
+
+	issue, ok := decoded.(XCTIssue)
+	require.True(t, ok)
+	assert.Equal(t, "compact", issue.CompactDescription)
+	assert.Equal(t, "detailed", issue.DetailedDescription)
+}
+
+func TestNewXCTSourceCodeContextWithNullLocation(t *testing.T) {
+	objects := []interface{}{"$null"}
+
+	require.NotPanics(t, func() {
+		NewXCTSourceCodeContext(map[string]interface{}{"location": plist.UID(0)}, objects)
+	})
+	require.NotPanics(t, func() {
+		NewXCTSourceCodeContext(map[string]interface{}{}, objects)
+	})
+}
+
+func TestNewXCTSourceCodeLocationToleratesMissingFileURL(t *testing.T) {
+	objects := []interface{}{"$null", map[string]interface{}{"NS.relative": plist.UID(0)}}
+
+	require.NotPanics(t, func() {
+		NewXCTSourceCodeLocation(map[string]interface{}{"file-url": plist.UID(0), "line-number": uint64(3)}, objects)
+	})
+	require.NotPanics(t, func() {
+		NewXCTSourceCodeLocation(map[string]interface{}{"file-url": plist.UID(1)}, objects)
+	})
+}

--- a/ios/nskeyedarchiver/xctattachment_test.go
+++ b/ios/nskeyedarchiver/xctattachment_test.go
@@ -70,6 +70,7 @@ func TestNewXCTAttachmentWithUserInfoDictionary(t *testing.T) {
 	assert.NotNil(t, attachment.userInfo)
 }
 
+// A reference past the end of the object table would index out of range.
 func TestNewXCTAttachmentToleratesMalformedArchives(t *testing.T) {
 	objects := []interface{}{"$null", "public.png"}
 
@@ -85,37 +86,12 @@ func TestNewXCTAttachmentToleratesMalformedArchives(t *testing.T) {
 				"name":     plist.UID(99),
 			},
 		},
-		{
-			name: "value is not a reference",
-			object: map[string]interface{}{
-				"lifetime": uint64(1),
-				"name":     "not-a-uid",
-				"userInfo": 42,
-			},
-		},
-		{
-			name: "lifetime has the wrong type",
-			object: map[string]interface{}{
-				"lifetime": "not-a-number",
-				"name":     plist.UID(1),
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.NotPanics(t, func() { NewXCTAttachment(tt.object, objects) })
 		})
 	}
-}
-
-func TestResolveRef(t *testing.T) {
-	objects := []interface{}{"zero", "one"}
-
-	assert.Equal(t, "one", resolveRef(map[string]interface{}{"k": plist.UID(1)}, "k", objects))
-	assert.Nil(t, resolveRef(map[string]interface{}{}, "missing", objects))
-	assert.Nil(t, resolveRef(map[string]interface{}{"k": "not-a-uid"}, "k", objects))
-	assert.Nil(t, resolveRef(map[string]interface{}{"k": plist.UID(5)}, "k", objects),
-		"a reference past the end of the object table must not index out of range")
 }
 
 // The same "$null" shape reaches XCTIssue and its nested source code context.

--- a/ios/nskeyedarchiver/xctattachment_test.go
+++ b/ios/nskeyedarchiver/xctattachment_test.go
@@ -8,12 +8,9 @@ import (
 	"howett.net/plist"
 )
 
-// iOS 27 sends XCUITest attachments with no userInfo, which NSKeyedArchiver
-// encodes as the string "$null" rather than a dictionary. NewXCTAttachment used
-// to assert a dictionary there, so decoding panicked; Unarchive recovered it as
-// "Unarchive: interface conversion: interface {} is string, not
-// map[string]interface {}", which failed the whole XCUITest run and left devices
-// stuck in cleaning.
+// Attachments with no userInfo encode it as the string "$null". Asserting a
+// dictionary there panicked, and Unarchive turned that into an error that failed
+// the whole XCUITest run.
 func TestNewXCTAttachmentWithNullUserInfo(t *testing.T) {
 	objects := []interface{}{
 		"$null",              // 0
@@ -73,8 +70,6 @@ func TestNewXCTAttachmentWithUserInfoDictionary(t *testing.T) {
 	assert.NotNil(t, attachment.userInfo)
 }
 
-// Malformed archives must not panic either: missing keys, references that are
-// not references, and references past the end of the object table.
 func TestNewXCTAttachmentToleratesMalformedArchives(t *testing.T) {
 	objects := []interface{}{"$null", "public.png"}
 
@@ -123,9 +118,7 @@ func TestResolveRef(t *testing.T) {
 		"a reference past the end of the object table must not index out of range")
 }
 
-// The same "$null" shape reaches XCTIssue and its nested source code context:
-// an issue without a source-code context, or a context without a location,
-// panicked in the same way and accounted for the rest of the failures.
+// The same "$null" shape reaches XCTIssue and its nested source code context.
 func TestNewXCTIssueWithNullSourceCodeContext(t *testing.T) {
 	objects := []interface{}{"$null", "compact", "detailed"}
 	object := map[string]interface{}{


### PR DESCRIPTION
## Problem

Decoding an XCUITest result panics when an object omits an optional field:

```
Unarchive: interface conversion: interface {} is string, not map[string]interface {}
nskeyedarchiver.NewXCTAttachment  ios/nskeyedarchiver/objectivec_classes.go:336
```

NSKeyedArchiver encodes an absent value as the string `"$null"`, but four decoders assert a dictionary unconditionally:

| decoder | field |
|---|---|
| `NewXCTAttachment` | `userInfo` |
| `NewXCTIssue` | `source-code-context` |
| `NewXCTSourceCodeContext` | `location` |
| `NewXCTSourceCodeLocation` | `file-url` / `NS.relative` |

The panic is long standing, but #766 (first released in v1.3.0) stopped `proxydispatcher.go` discarding `decoderErr` through a shadowed `:=`. Before that a failed decode cost one message of metadata and the run continued; now the same error fails the whole XCUITest run. So consumers upgrading across v1.3.0 see runs start failing on a payload devices have always sent, for us on 33 devices from iOS 17.1 to 27.0.

## Change

`resolveRef` follows a keyed reference and returns nil when the key is absent, the value is not a reference, or the index is past the end of the object table. The decoders above go through it and decode the optional fields only when they really are dictionaries, so an omitted field yields a zero value instead of a panic.
