### PR TITLE
feat(hid): touch, button and keyboard input over CoreDevice HID (builds on #845)

### DIFF
--- a/cli_device_resolution.go
+++ b/cli_device_resolution.go
@@ -91,6 +91,7 @@ func needsAutomaticTunnelInfo(args docopt.Opts) bool {
 
 	for _, commandName := range []string{
 		"debug",
+		"hid",
 		"devicestate",
 		"instruments",
 		"kill",

--- a/cmd_device_hid.go
+++ b/cmd_device_hid.go
@@ -1,0 +1,362 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios/hid"
+	log "github.com/sirupsen/logrus"
+)
+
+// Default pacing for drag gestures. Eight samples over 100ms reads as a flick to
+// the device's gesture recogniser, which is what VoiceOver navigation needs; pass
+// a longer duration for a slow drag.
+const (
+	defaultDragSteps    = 8
+	defaultDragDuration = 100 * time.Millisecond
+)
+
+// runHIDCommand dispatches the `ios hid` subcommands, which inject touch, button
+// and keyboard events through the CoreDevice HID services.
+//
+// Touch input needs a media stream to hold dtuhidd's auth gate open, which
+// hid.Session starts on demand. Every single-gesture command below opens its own
+// session and therefore negotiates its own stream: convenient, but a stream costs
+// about a second to set up, and the device's mediastream daemon has been seen to
+// wedge when many are started in quick succession. Use `ios hid session` to run a
+// batch of gestures through one stream.
+func runHIDCommand(ctx commandContext) {
+	switch {
+	case boolArg(ctx.Args, "services"):
+		runHIDListServices(ctx)
+	case boolArg(ctx.Args, "tap"):
+		runHIDTap(ctx)
+	case boolArg(ctx.Args, "drag"):
+		runHIDDrag(ctx)
+	case boolArg(ctx.Args, "button"):
+		runHIDButton(ctx)
+	case boolArg(ctx.Args, "type"):
+		runHIDType(ctx)
+	case boolArg(ctx.Args, "session"):
+		runHIDSession(ctx)
+	}
+}
+
+func runHIDListServices(ctx commandContext) {
+	withHIDSession(ctx, func(session *hid.Session) error {
+		services, err := session.ListServices()
+		if err != nil {
+			return err
+		}
+		fmt.Println(convertToJSONString(services))
+		return nil
+	})
+}
+
+func runHIDTap(ctx commandContext) {
+	p := hidPoint(ctx, "<x>", "<y>")
+	withHIDSession(ctx, func(session *hid.Session) error {
+		if err := session.Tap(context.Background(), p); err != nil {
+			return err
+		}
+		log.WithFields(log.Fields{"x": p.X, "y": p.Y}).Info("tap sent")
+		return nil
+	})
+}
+
+func runHIDDrag(ctx commandContext) {
+	from := hidPoint(ctx, "<x>", "<y>")
+	to := hidPoint(ctx, "<tox>", "<toy>")
+	steps := hidOptionalInt(ctx, "--steps", defaultDragSteps)
+	duration := hidOptionalDuration(ctx, "--duration", defaultDragDuration)
+
+	withHIDSession(ctx, func(session *hid.Session) error {
+		if err := session.Drag(context.Background(), from, to, steps, duration); err != nil {
+			return err
+		}
+		log.WithFields(log.Fields{
+			"fromX": from.X, "fromY": from.Y, "toX": to.X, "toY": to.Y,
+			"steps": steps, "duration": duration,
+		}).Info("drag sent")
+		return nil
+	})
+}
+
+func runHIDButton(ctx commandContext) {
+	usagePage, err := ctx.Args.Int("<usagepage>")
+	exitIfError("failed parsing <usagepage>", err)
+	usageCode, err := ctx.Args.Int("<usagecode>")
+	exitIfError("failed parsing <usagecode>", err)
+
+	withHIDSession(ctx, func(session *hid.Session) error {
+		if err := session.PressButton(context.Background(), uint64(usagePage), uint64(usageCode)); err != nil {
+			return err
+		}
+		log.WithFields(log.Fields{"usagePage": usagePage, "usageCode": usageCode}).Info("button pressed")
+		return nil
+	})
+}
+
+func runHIDType(ctx commandContext) {
+	text, err := ctx.Args.String("<text>")
+	exitIfError("failed parsing <text>", err)
+
+	withHIDSession(ctx, func(session *hid.Session) error {
+		if err := session.Type(context.Background(), text); err != nil {
+			return err
+		}
+		log.WithFields(log.Fields{"length": len(text)}).Info("text typed")
+		return nil
+	})
+}
+
+// runHIDSession runs a batch of gestures inside a single session, so one media
+// stream serves all of them.
+func runHIDSession(ctx commandContext) {
+	source := os.Stdin
+	if path, err := ctx.Args.String("--script"); err == nil && path != "" {
+		file, err := os.Open(path)
+		exitIfError("failed opening the gesture script", err)
+		defer file.Close()
+		source = file
+	}
+
+	gestures, err := parseHIDGestures(source)
+	exitIfError("failed parsing gestures", err)
+	if len(gestures) == 0 {
+		exitIfError("no gestures to run", fmt.Errorf("the script is empty"))
+	}
+
+	withHIDSession(ctx, func(session *hid.Session) error {
+		for _, g := range gestures {
+			if err := g.run(context.Background(), session); err != nil {
+				return fmt.Errorf("line %d (%s): %w", g.line, g.op, err)
+			}
+		}
+		log.WithFields(log.Fields{"gestures": len(gestures)}).Info("gesture batch finished")
+		return nil
+	})
+}
+
+// withHIDSession opens a session, runs fn and always closes the session, so the
+// media stream is stopped even when the gesture fails.
+func withHIDSession(ctx commandContext, fn func(*hid.Session) error) {
+	session, err := hid.NewSession(ctx.Device)
+	exitIfError("failed connecting to the HID service", err)
+
+	runErr := fn(session)
+	closeErr := session.Close()
+
+	exitIfError("HID command failed", runErr)
+	if closeErr != nil {
+		log.WithFields(log.Fields{"error": closeErr}).Debug("closing the HID session reported an error")
+	}
+}
+
+// hidGesture is one parsed line of a gesture script.
+type hidGesture struct {
+	line int
+	op   string
+	run  func(context.Context, *hid.Session) error
+}
+
+// parseHIDGestures reads whitespace-separated gesture lines. Blank lines and
+// everything after a '#' are ignored.
+//
+//	tap   X Y
+//	drag  X Y TOX TOY [STEPS [DURATION_SECONDS]]
+//	move  X Y
+//	type  TEXT...
+//	button USAGEPAGE USAGECODE
+//	sleep SECONDS
+func parseHIDGestures(r io.Reader) ([]hidGesture, error) {
+	var gestures []hidGesture
+
+	scanner := bufio.NewScanner(r)
+	for lineNo := 1; scanner.Scan(); lineNo++ {
+		line := scanner.Text()
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = line[:idx]
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+
+		gesture, err := parseHIDGesture(lineNo, fields)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+		gestures = append(gestures, gesture)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed reading gestures: %w", err)
+	}
+	return gestures, nil
+}
+
+func parseHIDGesture(lineNo int, fields []string) (hidGesture, error) {
+	op := fields[0]
+	args := fields[1:]
+	g := hidGesture{line: lineNo, op: op}
+
+	switch op {
+	case "tap":
+		p, err := parsePoint(args, 2)
+		if err != nil {
+			return g, fmt.Errorf("tap wants X Y: %w", err)
+		}
+		g.run = func(ctx context.Context, s *hid.Session) error { return s.Tap(ctx, p) }
+	case "drag":
+		if len(args) < 4 {
+			return g, fmt.Errorf("drag wants X Y TOX TOY [STEPS [DURATION_SECONDS]]")
+		}
+		from, err := parsePoint(args[:2], 2)
+		if err != nil {
+			return g, err
+		}
+		to, err := parsePoint(args[2:4], 2)
+		if err != nil {
+			return g, err
+		}
+		steps := defaultDragSteps
+		if len(args) > 4 {
+			if steps, err = strconv.Atoi(args[4]); err != nil {
+				return g, fmt.Errorf("invalid STEPS %q: %w", args[4], err)
+			}
+		}
+		duration := defaultDragDuration
+		if len(args) > 5 {
+			seconds, err := strconv.ParseFloat(args[5], 64)
+			if err != nil {
+				return g, fmt.Errorf("invalid DURATION %q: %w", args[5], err)
+			}
+			duration = time.Duration(seconds * float64(time.Second))
+		}
+		g.run = func(ctx context.Context, s *hid.Session) error {
+			return s.Drag(ctx, from, to, steps, duration)
+		}
+	case "move":
+		if len(args) != 2 {
+			return g, fmt.Errorf("move wants X Y")
+		}
+		x, err := strconv.ParseInt(args[0], 10, 32)
+		if err != nil {
+			return g, fmt.Errorf("invalid X %q: %w", args[0], err)
+		}
+		y, err := strconv.ParseInt(args[1], 10, 32)
+		if err != nil {
+			return g, fmt.Errorf("invalid Y %q: %w", args[1], err)
+		}
+		g.run = func(ctx context.Context, s *hid.Session) error {
+			return s.Move(ctx, int32(x), int32(y))
+		}
+	case "type":
+		if len(args) == 0 {
+			return g, fmt.Errorf("type wants TEXT")
+		}
+		text := strings.Join(args, " ")
+		g.run = func(ctx context.Context, s *hid.Session) error { return s.Type(ctx, text) }
+	case "button":
+		if len(args) != 2 {
+			return g, fmt.Errorf("button wants USAGEPAGE USAGECODE")
+		}
+		page, err := strconv.ParseUint(args[0], 0, 64)
+		if err != nil {
+			return g, fmt.Errorf("invalid USAGEPAGE %q: %w", args[0], err)
+		}
+		code, err := strconv.ParseUint(args[1], 0, 64)
+		if err != nil {
+			return g, fmt.Errorf("invalid USAGECODE %q: %w", args[1], err)
+		}
+		g.run = func(ctx context.Context, s *hid.Session) error {
+			return s.PressButton(ctx, page, code)
+		}
+	case "sleep":
+		if len(args) != 1 {
+			return g, fmt.Errorf("sleep wants SECONDS")
+		}
+		seconds, err := strconv.ParseFloat(args[0], 64)
+		if err != nil {
+			return g, fmt.Errorf("invalid SECONDS %q: %w", args[0], err)
+		}
+		delay := time.Duration(seconds * float64(time.Second))
+		g.run = func(ctx context.Context, _ *hid.Session) error {
+			select {
+			case <-time.After(delay):
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	default:
+		return g, fmt.Errorf("unknown gesture %q", op)
+	}
+	return g, nil
+}
+
+func parsePoint(args []string, want int) (hid.Point, error) {
+	if len(args) != want {
+		return hid.Point{}, fmt.Errorf("expected %d coordinates, got %d", want, len(args))
+	}
+	x, err := parseNormalisedCoordinate(args[0])
+	if err != nil {
+		return hid.Point{}, err
+	}
+	y, err := parseNormalisedCoordinate(args[1])
+	if err != nil {
+		return hid.Point{}, err
+	}
+	return hid.Point{X: x, Y: y}, nil
+}
+
+func parseNormalisedCoordinate(s string) (uint16, error) {
+	v, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid coordinate %q: %w", s, err)
+	}
+	if v > 0xFFFF {
+		return 0, fmt.Errorf("coordinate %d is out of the 0..65535 range", v)
+	}
+	return uint16(v), nil
+}
+
+// hidPoint reads a pair of docopt positional coordinates. Coordinates are
+// normalised across the display: 0 is the left/top edge, 65535 the right/bottom.
+func hidPoint(ctx commandContext, xArg, yArg string) hid.Point {
+	x, err := ctx.Args.Int(xArg)
+	exitIfError("failed parsing "+xArg, err)
+	y, err := ctx.Args.Int(yArg)
+	exitIfError("failed parsing "+yArg, err)
+	if x < 0 || x > 0xFFFF || y < 0 || y > 0xFFFF {
+		exitIfError("coordinates must be within 0..65535",
+			fmt.Errorf("got %s=%d %s=%d", xArg, x, yArg, y))
+	}
+	return hid.Point{X: uint16(x), Y: uint16(y)}
+}
+
+func hidOptionalInt(ctx commandContext, name string, fallback int) int {
+	raw, err := ctx.Args.String(name)
+	if err != nil || raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	exitIfError("failed parsing "+name, err)
+	return value
+}
+
+func hidOptionalDuration(ctx commandContext, name string, fallback time.Duration) time.Duration {
+	raw, err := ctx.Args.String(name)
+	if err != nil || raw == "" {
+		return fallback
+	}
+	seconds, err := strconv.ParseFloat(raw, 64)
+	exitIfError("failed parsing "+name, err)
+	return time.Duration(seconds * float64(time.Second))
+}

--- a/cmd_device_hid.go
+++ b/cmd_device_hid.go
@@ -171,7 +171,8 @@ type hidGesture struct {
 // everything after a '#' are ignored.
 //
 //	tap   X Y
-//	drag  X Y TOX TOY [STEPS [DURATION_SECONDS]]
+//	drag   X Y TOX TOY [STEPS [DURATION_SECONDS]]
+//	stroke SECONDS X1 Y1 X2 Y2 ...   (one contact through every point)
 //	move  X Y
 //	type  TEXT...   (whitespace is collapsed and '#' cannot appear in the text)
 //	button USAGEPAGE USAGECODE
@@ -245,6 +246,29 @@ func parseHIDGesture(lineNo int, fields []string) (hidGesture, error) {
 		}
 		g.run = func(ctx context.Context, s *hid.Session) error {
 			return s.Drag(ctx, from, to, steps, duration)
+		}
+	case "stroke":
+		// stroke SECONDS X1 Y1 X2 Y2 ... - the duration comes first so the
+		// point list can be any length.
+		if len(args) < 3 || len(args)%2 == 0 {
+			return g, fmt.Errorf("stroke wants SECONDS then at least one X Y pair")
+		}
+		seconds, err := strconv.ParseFloat(args[0], 64)
+		if err != nil {
+			return g, fmt.Errorf("invalid SECONDS %q: %w", args[0], err)
+		}
+		coords := args[1:]
+		points := make([]hid.Point, 0, len(coords)/2)
+		for i := 0; i < len(coords); i += 2 {
+			p, err := parsePoint(coords[i:i+2], 2)
+			if err != nil {
+				return g, err
+			}
+			points = append(points, p)
+		}
+		duration := time.Duration(seconds * float64(time.Second))
+		g.run = func(ctx context.Context, s *hid.Session) error {
+			return s.Stroke(ctx, points, duration)
 		}
 	case "move":
 		if len(args) != 2 {

--- a/cmd_device_hid.go
+++ b/cmd_device_hid.go
@@ -74,6 +74,7 @@ func runHIDDrag(ctx commandContext) {
 	from := hidPoint(ctx, "<x>", "<y>")
 	to := hidPoint(ctx, "<tox>", "<toy>")
 	steps := hidOptionalInt(ctx, "--steps", defaultDragSteps)
+	exitIfError("invalid --steps", validateDragSteps(steps))
 	duration := hidOptionalDuration(ctx, "--duration", defaultDragDuration)
 
 	withHIDSession(ctx, func(session *hid.Session) error {
@@ -172,7 +173,7 @@ type hidGesture struct {
 //	tap   X Y
 //	drag  X Y TOX TOY [STEPS [DURATION_SECONDS]]
 //	move  X Y
-//	type  TEXT...
+//	type  TEXT...   (whitespace is collapsed and '#' cannot appear in the text)
 //	button USAGEPAGE USAGECODE
 //	sleep SECONDS
 func parseHIDGestures(r io.Reader) ([]hidGesture, error) {
@@ -230,6 +231,9 @@ func parseHIDGesture(lineNo int, fields []string) (hidGesture, error) {
 			if steps, err = strconv.Atoi(args[4]); err != nil {
 				return g, fmt.Errorf("invalid STEPS %q: %w", args[4], err)
 			}
+			if err := validateDragSteps(steps); err != nil {
+				return g, err
+			}
 		}
 		duration := defaultDragDuration
 		if len(args) > 5 {
@@ -255,7 +259,7 @@ func parseHIDGesture(lineNo int, fields []string) (hidGesture, error) {
 			return g, fmt.Errorf("invalid Y %q: %w", args[1], err)
 		}
 		g.run = func(ctx context.Context, s *hid.Session) error {
-			return s.Move(ctx, int32(x), int32(y))
+			return s.MoveDigitizer(ctx, int32(x), int32(y))
 		}
 	case "type":
 		if len(args) == 0 {
@@ -299,6 +303,20 @@ func parseHIDGesture(lineNo int, fields []string) (hidGesture, error) {
 		return g, fmt.Errorf("unknown gesture %q", op)
 	}
 	return g, nil
+}
+
+// maxDragSteps caps the samples one drag may send. The limit is arbitrary but
+// generous: it exists so a typo cannot flood the device with reports.
+const maxDragSteps = 1000
+
+func validateDragSteps(steps int) error {
+	if steps < 1 {
+		return fmt.Errorf("a drag needs at least 1 step, got %d", steps)
+	}
+	if steps > maxDragSteps {
+		return fmt.Errorf("a drag is limited to %d steps, got %d", maxDragSteps, steps)
+	}
+	return nil
 }
 
 func parsePoint(args []string, want int) (hid.Point, error) {

--- a/cmd_device_hid_test.go
+++ b/cmd_device_hid_test.go
@@ -18,24 +18,25 @@ move -50 50
 type hello world
 button 12 64
 sleep 0.5
+stroke 0.5 100 100 200 200 300 100
 tap 1 1   # trailing comment
 `
 
 	gestures, err := parseHIDGestures(strings.NewReader(script))
 	require.NoError(t, err)
-	require.Len(t, gestures, 8)
+	require.Len(t, gestures, 9)
 
 	ops := make([]string, 0, len(gestures))
 	for _, g := range gestures {
 		ops = append(ops, g.op)
 		assert.NotNil(t, g.run, "every parsed gesture must be runnable")
 	}
-	assert.Equal(t, []string{"tap", "drag", "drag", "move", "type", "button", "sleep", "tap"}, ops)
+	assert.Equal(t, []string{"tap", "drag", "drag", "move", "type", "button", "sleep", "stroke", "tap"}, ops)
 
 	// Line numbers are reported for error messages, so they must survive
 	// comments and blank lines.
 	assert.Equal(t, 3, gestures[0].line)
-	assert.Equal(t, 10, gestures[7].line)
+	assert.Equal(t, 11, gestures[8].line)
 }
 
 func TestParseHIDGesturesRejectsBadInput(t *testing.T) {
@@ -53,6 +54,10 @@ func TestParseHIDGesturesRejectsBadInput(t *testing.T) {
 		{name: "drag zero steps", script: "drag 1 2 3 4 0", wantMessage: "at least 1 step"},
 		{name: "drag too many steps", script: "drag 1 2 3 4 100000", wantMessage: "limited to 1000 steps"},
 		{name: "drag bad duration", script: "drag 1 2 3 4 8 soon", wantMessage: "invalid DURATION"},
+		{name: "stroke without points", script: "stroke 1.0", wantMessage: "stroke wants SECONDS"},
+		{name: "stroke odd coordinate count", script: "stroke 1.0 10 20 30", wantMessage: "stroke wants SECONDS"},
+		{name: "stroke bad seconds", script: "stroke soon 10 20", wantMessage: "invalid SECONDS"},
+		{name: "stroke bad coordinate", script: "stroke 1.0 10 nope", wantMessage: "invalid coordinate"},
 		{name: "move missing arg", script: "move 1", wantMessage: "move wants X Y"},
 		{name: "type without text", script: "type", wantMessage: "type wants TEXT"},
 		{name: "button missing code", script: "button 12", wantMessage: "button wants USAGEPAGE USAGECODE"},

--- a/cmd_device_hid_test.go
+++ b/cmd_device_hid_test.go
@@ -50,6 +50,8 @@ func TestParseHIDGesturesRejectsBadInput(t *testing.T) {
 		{name: "tap non numeric", script: "tap a b", wantMessage: "invalid coordinate"},
 		{name: "drag too few args", script: "drag 1 2 3", wantMessage: "drag wants X Y TOX TOY"},
 		{name: "drag bad steps", script: "drag 1 2 3 4 many", wantMessage: "invalid STEPS"},
+		{name: "drag zero steps", script: "drag 1 2 3 4 0", wantMessage: "at least 1 step"},
+		{name: "drag too many steps", script: "drag 1 2 3 4 100000", wantMessage: "limited to 1000 steps"},
 		{name: "drag bad duration", script: "drag 1 2 3 4 8 soon", wantMessage: "invalid DURATION"},
 		{name: "move missing arg", script: "move 1", wantMessage: "move wants X Y"},
 		{name: "type without text", script: "type", wantMessage: "type wants TEXT"},

--- a/cmd_device_hid_test.go
+++ b/cmd_device_hid_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHIDGesturesAcceptsEveryGesture(t *testing.T) {
+	script := `
+# a comment on its own line
+tap 100 200
+drag 0 0 65535 65535
+drag 0 0 100 100 16 0.25
+move -50 50
+type hello world
+button 12 64
+sleep 0.5
+tap 1 1   # trailing comment
+`
+
+	gestures, err := parseHIDGestures(strings.NewReader(script))
+	require.NoError(t, err)
+	require.Len(t, gestures, 8)
+
+	ops := make([]string, 0, len(gestures))
+	for _, g := range gestures {
+		ops = append(ops, g.op)
+		assert.NotNil(t, g.run, "every parsed gesture must be runnable")
+	}
+	assert.Equal(t, []string{"tap", "drag", "drag", "move", "type", "button", "sleep", "tap"}, ops)
+
+	// Line numbers are reported for error messages, so they must survive
+	// comments and blank lines.
+	assert.Equal(t, 3, gestures[0].line)
+	assert.Equal(t, 10, gestures[7].line)
+}
+
+func TestParseHIDGesturesRejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name        string
+		script      string
+		wantMessage string
+	}{
+		{name: "unknown gesture", script: "wiggle 1 2", wantMessage: `unknown gesture "wiggle"`},
+		{name: "tap missing coordinate", script: "tap 100", wantMessage: "tap wants X Y"},
+		{name: "tap out of range", script: "tap 100 70000", wantMessage: "out of the 0..65535 range"},
+		{name: "tap non numeric", script: "tap a b", wantMessage: "invalid coordinate"},
+		{name: "drag too few args", script: "drag 1 2 3", wantMessage: "drag wants X Y TOX TOY"},
+		{name: "drag bad steps", script: "drag 1 2 3 4 many", wantMessage: "invalid STEPS"},
+		{name: "drag bad duration", script: "drag 1 2 3 4 8 soon", wantMessage: "invalid DURATION"},
+		{name: "move missing arg", script: "move 1", wantMessage: "move wants X Y"},
+		{name: "type without text", script: "type", wantMessage: "type wants TEXT"},
+		{name: "button missing code", script: "button 12", wantMessage: "button wants USAGEPAGE USAGECODE"},
+		{name: "button bad page", script: "button page 64", wantMessage: "invalid USAGEPAGE"},
+		{name: "sleep bad seconds", script: "sleep soon", wantMessage: "invalid SECONDS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseHIDGestures(strings.NewReader(tt.script))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantMessage)
+			assert.Contains(t, err.Error(), "line 1", "errors should point at the offending line")
+		})
+	}
+}
+
+func TestParseHIDGesturesIgnoresBlankAndCommentOnlyScripts(t *testing.T) {
+	gestures, err := parseHIDGestures(strings.NewReader("\n  \n# only a comment\n"))
+	require.NoError(t, err)
+	assert.Empty(t, gestures)
+}
+
+func TestParseHIDGesturesKeepsWholeTypedLine(t *testing.T) {
+	gestures, err := parseHIDGestures(strings.NewReader("type  several   spaced words"))
+	require.NoError(t, err)
+	require.Len(t, gestures, 1)
+	assert.Equal(t, "type", gestures[0].op)
+}
+
+func TestParseNormalisedCoordinate(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    uint16
+		wantErr bool
+	}{
+		{name: "min", in: "0", want: 0},
+		{name: "max", in: "65535", want: 65535},
+		{name: "above max", in: "65536", wantErr: true},
+		{name: "negative", in: "-1", wantErr: true},
+		{name: "not a number", in: "x", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNormalisedCoordinate(tt.in)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cmd_device_registry.go
+++ b/cmd_device_registry.go
@@ -70,6 +70,7 @@ var deviceCommands = []command{
 	commandByBool("crash", runCrashCommand),
 	commandByBool("instruments", runInstrumentsCommand),
 	commandByBool("image", runImageCommand),
+	commandByBool("hid", runHIDCommand),
 	commandByBool("assistivetouch", runAssistiveTouchCommand),
 	commandByBool("voiceover", runVoiceOverCommand),
 	commandByBool("zoom", runZoomCommand),

--- a/internal/clihelp/help.yaml
+++ b/internal/clihelp/help.yaml
@@ -297,7 +297,7 @@ commands:
     summary: Print version.
   - path: hid
     usage: ios hid (services | tap | drag | button | type | session) [options]
-    summary: Inject touch, hardware button and keyboard input (iOS 17+, kernel tunnel).
+    summary: Inject touch, hardware button and keyboard input (iOS 27+, kernel tunnel).
   - path: voiceover
     usage: ios voiceover (enable | disable | toggle | get) [--force] [options]
     summary: Manage VoiceOver state.

--- a/internal/clihelp/help.yaml
+++ b/internal/clihelp/help.yaml
@@ -295,6 +295,9 @@ commands:
   - path: version
     usage: ios --version | version [options]
     summary: Print version.
+  - path: hid
+    usage: ios hid (services | tap | drag | button | type | session) [options]
+    summary: Inject touch, hardware button and keyboard input (iOS 17+, kernel tunnel).
   - path: voiceover
     usage: ios voiceover (enable | disable | toggle | get) [--force] [options]
     summary: Manage VoiceOver state.

--- a/ios/coredevice/coredevice.go
+++ b/ios/coredevice/coredevice.go
@@ -18,3 +18,28 @@ func BuildRequest(deviceId, feature string, input map[string]interface{}) map[st
 		"CoreDevice.invocationIdentifier": u.String(),
 	}
 }
+
+// BuildRequestWithAction builds a CoreDevice request that names the action to
+// invoke, which some services require in addition to the feature identifier.
+//
+// It also advertises a newer DDI protocol version and coreDeviceVersion than
+// BuildRequest: those are the values devicectl sends, and services like
+// com.apple.coredevice.displayservice reject the older envelope. Existing
+// callers of BuildRequest are left on the envelope they were verified against.
+func BuildRequestWithAction(deviceId, feature, action string, input map[string]interface{}) map[string]interface{} {
+	u := uuid.New()
+	return map[string]interface{}{
+		"CoreDevice.CoreDeviceDDIProtocolVersion": int64(2),
+		"CoreDevice.action":                       map[string]interface{}{},
+		"CoreDevice.actionIdentifier":             action,
+		"CoreDevice.coreDeviceVersion": map[string]interface{}{
+			"components":              []interface{}{uint64(629), uint64(3)},
+			"originalComponentsCount": int64(2),
+			"stringValue":             "629.3",
+		},
+		"CoreDevice.deviceIdentifier":     deviceId,
+		"CoreDevice.featureIdentifier":    feature,
+		"CoreDevice.input":                input,
+		"CoreDevice.invocationIdentifier": u.String(),
+	}
+}

--- a/ios/display/display.go
+++ b/ios/display/display.go
@@ -1,6 +1,7 @@
 // Package display drives com.apple.coredevice.displayservice, the CoreDevice
-// service behind Xcode's device screen view, on iOS 17+ devices with a mounted
-// Developer Disk Image.
+// service behind Xcode's device screen view. The service is reachable from iOS
+// 17 with a mounted Developer Disk Image, but only iOS 27 and later will start a
+// stream; 26.3 reports no supported media features and refuses with error 9021.
 //
 // go-ios uses it for one purpose: dtuhidd publishes the HID digitizer surfaces
 // as unauthenticated until a media stream is running, and backboardd silently

--- a/ios/display/display.go
+++ b/ios/display/display.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sync"
 
 	"github.com/danielpaulus/go-ios/ios"
 	"github.com/danielpaulus/go-ios/ios/coredevice"
@@ -52,17 +53,31 @@ const (
 	transportProtocolType = int64(2)
 
 	// negotiationTimeoutSeconds is the timeout the device applies to its side of
-	// the negotiation.
-	negotiationTimeoutSeconds = uint64(20)
+	// the negotiation. Keep it below the caller's own deadline (see
+	// hid.streamStartTimeout) so the device gives up first: if the host gave up
+	// first the device could still bring a stream up that the host never learned
+	// the session id of, and so could never stop.
+	negotiationTimeoutSeconds = uint64(10)
 
 	// DefaultDisplayID is the main display.
 	DefaultDisplayID = 1
 )
 
 // Service is a connection to the device's display service.
+//
+// One request is in flight at a time: the XPC connection carries no request
+// identifiers, so concurrent callers would be handed each other's responses.
+// Calls are serialised internally, and a call abandoned by its context poisons
+// the Service - see invoke.
 type Service struct {
 	conn     *xpc.Connection
 	deviceID string
+
+	mutex sync.Mutex
+	// poisoned is set when a request is abandoned mid-exchange. The response
+	// that eventually arrives would be mis-attributed to the next request, so
+	// the Service refuses further calls instead.
+	poisoned bool
 }
 
 // New connects to the display service. Requires iOS 17+ with the Developer Disk
@@ -149,7 +164,9 @@ func (s *Service) StartVideoStream(ctx context.Context, req VideoStreamRequest) 
 
 	output, err := s.invoke(ctx, featureStartMediaStream, actionMediaStreamStart, input)
 	if err != nil {
-		return StreamAnswer{}, err
+		// The id is returned even on failure: the device may have started the
+		// stream regardless (or be about to), and stopping it needs this id.
+		return StreamAnswer{ClientSessionID: clientSessionID}, err
 	}
 	return StreamAnswer{ClientSessionID: clientSessionID, Output: output}, nil
 }
@@ -181,6 +198,12 @@ func (s *Service) GetMediaSupportInfo(ctx context.Context) (map[string]interface
 // and ctx cancellation abandons it. An abandoned exchange leaves the connection
 // unusable, which is why callers close the Service after a timeout.
 func (s *Service) invoke(ctx context.Context, feature, action string, input map[string]interface{}) (map[string]interface{}, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.poisoned {
+		return nil, fmt.Errorf("display: connection is unusable after an abandoned request, reconnect the service")
+	}
+
 	type result struct {
 		output map[string]interface{}
 		err    error
@@ -213,6 +236,10 @@ func (s *Service) invoke(ctx context.Context, feature, action string, input map[
 		}
 		return r.output, nil
 	case <-ctx.Done():
+		// The goroutine is still parked reading the response. It ends when the
+		// connection is closed; until then any late response would be handed to
+		// the next caller, so refuse to reuse this Service.
+		s.poisoned = true
 		return nil, fmt.Errorf("display: %s did not complete: %w (the device's mediastream daemon may be wedged; rebooting the device clears it)", feature, ctx.Err())
 	}
 }

--- a/ios/display/display.go
+++ b/ios/display/display.go
@@ -3,20 +3,14 @@
 // 17 with a mounted Developer Disk Image, but only iOS 27 and later will start a
 // stream; 26.3 reports no supported media features and refuses with error 9021.
 //
-// go-ios uses it for one purpose: dtuhidd publishes the HID digitizer surfaces
-// as unauthenticated until a media stream is running, and backboardd silently
-// discards touch reports aimed at an unauthenticated surface. Starting a video
-// stream flips the surfaces to authenticated and lets touch input through. The
-// RTP payload itself is discarded - see Receiver - so this package deliberately
+// go-ios uses it for one purpose: a running stream authenticates the HID
+// surfaces, without which touch reports are discarded (see package hid for the
+// gate). The RTP payload is thrown away - see Receiver - so this package
 // implements stream negotiation and nothing about decoding video.
 //
-// The gate is per client: a stream started by Xcode does not authenticate
-// go-ios' reports. Whoever sends the touches must own the stream.
-//
-// Streams are expensive to negotiate and the device's mediastream daemon has
-// been observed to wedge (until a reboot) when many streams are started and
-// stopped in quick succession, so hold one stream open for as long as input is
-// needed rather than one per gesture. hid.Session does this.
+// Negotiation is expensive, and the device's mediastream daemon has been observed
+// to wedge until rebooted when streams are started and stopped in quick
+// succession, so hold one open rather than one per gesture. hid.Session does.
 package display
 
 import (
@@ -36,13 +30,11 @@ const logModule = "go-ios/display"
 const (
 	serviceName = "com.apple.coredevice.displayservice"
 
-	featureStartMediaStream    = "com.apple.coredevice.feature.startmediastream"
-	featureStopMediaStream     = "com.apple.coredevice.feature.stopmediastream"
-	featureGetMediaSupportInfo = "com.apple.coredevice.feature.getmediasupportinfo"
+	featureStartMediaStream = "com.apple.coredevice.feature.startmediastream"
+	featureStopMediaStream  = "com.apple.coredevice.feature.stopmediastream"
 
-	actionMediaStreamStart      = "com.apple.coredevice.action.mediastreamstart"
-	actionMediaStreamStop       = "com.apple.coredevice.action.mediastreamstop"
-	actionMediaStreamGetSupport = "com.apple.coredevice.action.mediastreamgetsupportinfo"
+	actionMediaStreamStart = "com.apple.coredevice.action.mediastreamstart"
+	actionMediaStreamStop  = "com.apple.coredevice.action.mediastreamstop"
 
 	// clientSupportedFeatures is a bit mask captured from devicectl describing
 	// host-side feature support.
@@ -189,13 +181,6 @@ func (s *Service) StopMediaStream(ctx context.Context, clientSessionID uuid.UUID
 	}
 	_, err := s.invoke(ctx, featureStopMediaStream, actionMediaStreamStop, input)
 	return err
-}
-
-// GetMediaSupportInfo reports the media-stream features and AVC framework
-// version the device supports. Useful as a cheap liveness probe of the
-// mediastream daemon before negotiating a stream.
-func (s *Service) GetMediaSupportInfo(ctx context.Context) (map[string]interface{}, error) {
-	return s.invoke(ctx, featureGetMediaSupportInfo, actionMediaStreamGetSupport, map[string]interface{}{})
 }
 
 // invoke sends one CoreDevice request and waits for its response, honouring ctx.

--- a/ios/display/display.go
+++ b/ios/display/display.go
@@ -1,0 +1,216 @@
+// Package display drives com.apple.coredevice.displayservice, the CoreDevice
+// service behind Xcode's device screen view, on iOS 17+ devices with a mounted
+// Developer Disk Image.
+//
+// go-ios uses it for one purpose: dtuhidd publishes the HID digitizer surfaces
+// as unauthenticated until a media stream is running, and backboardd silently
+// discards touch reports aimed at an unauthenticated surface. Starting a video
+// stream flips the surfaces to authenticated and lets touch input through. The
+// RTP payload itself is discarded - see Receiver - so this package deliberately
+// implements stream negotiation and nothing about decoding video.
+//
+// The gate is per client: a stream started by Xcode does not authenticate
+// go-ios' reports. Whoever sends the touches must own the stream.
+//
+// Streams are expensive to negotiate and the device's mediastream daemon has
+// been observed to wedge (until a reboot) when many streams are started and
+// stopped in quick succession, so hold one stream open for as long as input is
+// needed rather than one per gesture. hid.Session does this.
+package display
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/coredevice"
+	"github.com/danielpaulus/go-ios/ios/xpc"
+	"github.com/google/uuid"
+)
+
+const (
+	serviceName = "com.apple.coredevice.displayservice"
+
+	featureStartMediaStream    = "com.apple.coredevice.feature.startmediastream"
+	featureStopMediaStream     = "com.apple.coredevice.feature.stopmediastream"
+	featureGetMediaSupportInfo = "com.apple.coredevice.feature.getmediasupportinfo"
+
+	actionMediaStreamStart      = "com.apple.coredevice.action.mediastreamstart"
+	actionMediaStreamStop       = "com.apple.coredevice.action.mediastreamstop"
+	actionMediaStreamGetSupport = "com.apple.coredevice.action.mediastreamgetsupportinfo"
+
+	// clientSupportedFeatures is a bit mask captured from devicectl describing
+	// host-side feature support.
+	clientSupportedFeatures = uint64(140)
+
+	// The access-network and transport-protocol values captured from a live
+	// screen-sharing session.
+	accessNetworkType     = int64(1)
+	transportProtocolType = int64(2)
+
+	// negotiationTimeoutSeconds is the timeout the device applies to its side of
+	// the negotiation.
+	negotiationTimeoutSeconds = uint64(20)
+
+	// DefaultDisplayID is the main display.
+	DefaultDisplayID = 1
+)
+
+// Service is a connection to the device's display service.
+type Service struct {
+	conn     *xpc.Connection
+	deviceID string
+}
+
+// New connects to the display service. Requires iOS 17+ with the Developer Disk
+// Image mounted; without it the service is not published and connecting fails.
+func New(device ios.DeviceEntry) (*Service, error) {
+	conn, err := ios.ConnectToXpcServiceTunnelIface(device, serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("display.New: failed to connect to %s: %w", serviceName, err)
+	}
+	return &Service{conn: conn, deviceID: uuid.New().String()}, nil
+}
+
+// Close closes the connection to the display service. Stop any running stream
+// first, otherwise the device keeps sending RTP until it times out.
+func (s *Service) Close() error {
+	return s.conn.Close()
+}
+
+// VideoStreamRequest describes where the device should send a display's frames.
+// The receiver socket must already be bound: the device starts sending as soon
+// as it answers.
+type VideoStreamRequest struct {
+	// ReceiverIP and ReceiverPort are the host's tunnel address and bound UDP
+	// port, as reported by a Receiver.
+	ReceiverIP   string
+	ReceiverPort int
+	// SenderIP is the device's address over the tunnel (ios.DeviceEntry.Address).
+	SenderIP string
+	// DisplayID selects the display; use DefaultDisplayID for the main one.
+	DisplayID int
+}
+
+// StreamAnswer is the device's response to a stream start.
+type StreamAnswer struct {
+	// ClientSessionID identifies the stream and is required to stop it.
+	ClientSessionID uuid.UUID
+	// Output is the raw CoreDevice output, which also carries the negotiated
+	// stream configuration. Kept so callers can inspect what was agreed without
+	// this package having to model the whole answer.
+	Output map[string]interface{}
+}
+
+// StartVideoStream negotiates and starts an RTP video stream of one display.
+//
+// ctx bounds the negotiation. The device's mediastream daemon can stop answering
+// entirely - a state that survives reconnecting and is only cleared by rebooting
+// the device - so always pass a ctx with a deadline; on timeout the returned
+// error says so and this Service should be closed.
+func (s *Service) StartVideoStream(ctx context.Context, req VideoStreamRequest) (StreamAnswer, error) {
+	if req.ReceiverIP == "" || req.ReceiverPort == 0 {
+		return StreamAnswer{}, fmt.Errorf("StartVideoStream: receiver address is required, bind a Receiver first")
+	}
+	if req.SenderIP == "" {
+		return StreamAnswer{}, fmt.Errorf("StartVideoStream: sender address is required")
+	}
+	displayID := req.DisplayID
+	if displayID == 0 {
+		displayID = DefaultDisplayID
+	}
+
+	clientSessionID := uuid.New()
+	offer, err := buildVideoNegotiatorOffer(uuid.New(), rand.Uint32())
+	if err != nil {
+		return StreamAnswer{}, err
+	}
+
+	input := map[string]interface{}{
+		"clientSupportedFeatures": clientSupportedFeatures,
+		"direction":               "output",
+		"negotiatorOffer":         offer,
+		"options": map[string]interface{}{
+			"AVCMediaStreamNegotiatorAccessNetworkType":     map[string]interface{}{"int": accessNetworkType},
+			"AVCMediaStreamNegotiatorTransportProtocolType": map[string]interface{}{"int": transportProtocolType},
+			"CoreDeviceVideoDisplayMode":                    map[string]interface{}{"string": "DisplayByID"},
+			"VideoStreamForDisplayID":                       map[string]interface{}{"int": int64(displayID)},
+			"avcMediaStreamOptionClientSessionID":           map[string]interface{}{"uuid": clientSessionID},
+		},
+		"receiverIP":   req.ReceiverIP,
+		"receiverPort": uint64(req.ReceiverPort),
+		"senderIP":     req.SenderIP,
+		"timeout":      negotiationTimeoutSeconds,
+		"type":         "video",
+	}
+
+	output, err := s.invoke(ctx, featureStartMediaStream, actionMediaStreamStart, input)
+	if err != nil {
+		return StreamAnswer{}, err
+	}
+	return StreamAnswer{ClientSessionID: clientSessionID, Output: output}, nil
+}
+
+// StopMediaStream stops a running stream.
+//
+// The device usually tears the channel down while processing the stop, so a
+// closed connection here means the stop was carried out, not that it failed.
+// Errors are therefore worth logging but not acting on, and this Service should
+// be closed afterwards either way.
+func (s *Service) StopMediaStream(ctx context.Context, clientSessionID uuid.UUID) error {
+	input := map[string]interface{}{
+		"avcMediaStreamOptionClientSessionID": map[string]interface{}{"uuid": clientSessionID},
+	}
+	_, err := s.invoke(ctx, featureStopMediaStream, actionMediaStreamStop, input)
+	return err
+}
+
+// GetMediaSupportInfo reports the media-stream features and AVC framework
+// version the device supports. Useful as a cheap liveness probe of the
+// mediastream daemon before negotiating a stream.
+func (s *Service) GetMediaSupportInfo(ctx context.Context) (map[string]interface{}, error) {
+	return s.invoke(ctx, featureGetMediaSupportInfo, actionMediaStreamGetSupport, map[string]interface{}{})
+}
+
+// invoke sends one CoreDevice request and waits for its response, honouring ctx.
+//
+// The XPC connection has no read deadline, so the exchange runs in a goroutine
+// and ctx cancellation abandons it. An abandoned exchange leaves the connection
+// unusable, which is why callers close the Service after a timeout.
+func (s *Service) invoke(ctx context.Context, feature, action string, input map[string]interface{}) (map[string]interface{}, error) {
+	type result struct {
+		output map[string]interface{}
+		err    error
+	}
+	done := make(chan result, 1)
+
+	go func() {
+		request := coredevice.BuildRequestWithAction(s.deviceID, feature, action, input)
+		if err := s.conn.Send(request, xpc.HeartbeatRequestFlag); err != nil {
+			done <- result{err: fmt.Errorf("failed to send %s: %w", feature, err)}
+			return
+		}
+		response, err := s.conn.ReceiveOnServerClientStream()
+		if err != nil {
+			done <- result{err: fmt.Errorf("failed to receive the response to %s: %w", feature, err)}
+			return
+		}
+		output, ok := response["CoreDevice.output"].(map[string]interface{})
+		if !ok {
+			done <- result{err: fmt.Errorf("unexpected response to %s: %+v", feature, response)}
+			return
+		}
+		done <- result{output: output}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			return nil, fmt.Errorf("display: %w", r.err)
+		}
+		return r.output, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("display: %s did not complete: %w (the device's mediastream daemon may be wedged; rebooting the device clears it)", feature, ctx.Err())
+	}
+}

--- a/ios/display/display.go
+++ b/ios/display/display.go
@@ -29,6 +29,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const logModule = "go-ios/display"
+
 const (
 	serviceName = "com.apple.coredevice.displayservice"
 

--- a/ios/display/display.go
+++ b/ios/display/display.go
@@ -171,15 +171,20 @@ func (s *Service) StartVideoStream(ctx context.Context, req VideoStreamRequest) 
 	return StreamAnswer{ClientSessionID: clientSessionID, Output: output}, nil
 }
 
-// StopMediaStream stops a running stream.
+// StopMediaStream stops the streams this client has running.
 //
-// The device usually tears the channel down while processing the stop, so a
-// closed connection here means the stop was carried out, not that it failed.
-// Errors are therefore worth logging but not acting on, and this Service should
-// be closed afterwards either way.
+// The request carries both the session id and stopAll. Verified against iOS 27:
+// omitting stopAll is rejected while decoding ("Expected to find key stopAll"),
+// and sending it as false is rejected as an invalid request - only true is
+// accepted. That is no loss of control here, since a client only ever holds the
+// one stream it started.
+//
+// The device sometimes tears the channel down while processing the stop, so a
+// closed connection means the stop was carried out rather than that it failed.
 func (s *Service) StopMediaStream(ctx context.Context, clientSessionID uuid.UUID) error {
 	input := map[string]interface{}{
 		"avcMediaStreamOptionClientSessionID": map[string]interface{}{"uuid": clientSessionID},
+		"stopAll":                             true,
 	}
 	_, err := s.invoke(ctx, featureStopMediaStream, actionMediaStreamStop, input)
 	return err

--- a/ios/display/offer.go
+++ b/ios/display/offer.go
@@ -1,0 +1,311 @@
+package display
+
+import (
+	"bytes"
+	"compress/zlib"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"howett.net/plist"
+)
+
+// This file builds the negotiatorOffer that
+// com.apple.coredevice.action.mediastreamstart requires. The offer is a binary
+// plist with four keys:
+//
+//	avcMediaStreamOptionRemoteEndpointInfo: protobuf describing the host
+//	avcMediaStreamNegotiatorMode:           5 for video, 6 for audio
+//	avcMediaStreamNegotiatorMediaBlob:      zlib(level 9) compressed protobuf
+//	                                       carrying codec parameters
+//	avcMediaStreamOptionCallID:             upper-case UUID string
+//
+// The mediaBlob layout was reverse engineered from -[AVCMediaStreamNegotiator
+// createOffer]; field numbers come from the __objc_methname table of
+// VCMediaNegotiationBlobVideoSettings:
+//
+//	MediaBlob {
+//	  1: int = 1, 2: int = 1
+//	  5: VideoSettings
+//	  6: string  decoder identity
+//	  8: int = 0
+//	  9: BitrateTier[]  repeated
+//	  13: int  host timestamp (not validated by the daemon)
+//	  14: int = 2, 16: int = 0, 18: int = 1
+//	}
+//
+//	VideoSettings {
+//	  1: int  SSRC / session id, encoded as a 5-byte padded varint
+//	  2: int  allowRTCPFB
+//	  3: CodecBank[]  HEVC then AVC
+//	  7: int  ltrpEnabled
+//	  8: int = 63  pixel formats
+//	  10: int  fecEnabled (omitted when false)
+//	  12: int = 1  blackFrameOnClearScreen
+//	}
+//
+//	CodecBank { 1: payload type, 2: ResEntry[], 3: feature string, 4: int }
+//	ResEntry  { 1: int = 1, 2: pair index, 3: int = 50115, 4: int = 0 }
+//	BitrateTier { 1: tier kind, 2: bps, 3: buffer cap (optional) }
+//
+// The daemon rejects any deviation with an opaque "Invalid Parameter", so
+// offer_test.go pins the encoder against a captured Xcode offer byte for byte.
+
+const (
+	// negotiatorModeVideo is the avcMediaStreamNegotiatorMode value for a video
+	// stream. Audio (6) is not implemented: go-ios only needs a video stream to
+	// hold dtuhidd's touch auth gate open.
+	negotiatorModeVideo = 5
+
+	// defaultDecoderName is matched by the device to pick a compatible decoder.
+	defaultDecoderName = "Viceroy 1.7.0"
+
+	// resEntryCodecCapID is a fixed AVConference codec-capability id that
+	// appears unchanged across all captured offers.
+	resEntryCodecCapID = 50115
+
+	// hevcFeatures and avcFeatures declare per-bank capability flags. "FLS;" is
+	// the AVConference framing marker.
+	hevcFeatures = "FLS;SW:1;"
+	avcFeatures  = "FLS;VRAE:0;SW:1;"
+
+	hevcPayloadType = 123
+	avcPayloadType  = 100
+
+	// capturedVideoTimestamp is the host clock value from the captured offer.
+	// The daemon does not appear to validate it, and keeping the captured value
+	// lets offer_test.go assert byte equality.
+	capturedVideoTimestamp = uint64(17137042128614416384)
+)
+
+// hostIdentity describes the host to the device. The device may pick encoder
+// parameters based on it: under a Mac16,11 identity captured sessions showed
+// frequent encoder stalls, while Mac15,9 (what Xcode reports) is stable.
+var hostIdentity = struct {
+	Model     string
+	OSVersion string
+	Build     string
+}{
+	Model:     "Mac15,9",
+	OSVersion: "2205.3.1",
+	Build:     "25F80",
+}
+
+// bitrateTier is one f9 entry of the media blob. kind 0 is a tier with a
+// network bitrate cap, 4074 a header marker, and 16/4/1 codec-specific markers.
+// bufferCap is only present for the cap-carrying kinds.
+type bitrateTier struct {
+	kind      uint64
+	bps       uint64
+	bufferCap uint64
+	hasBuffer bool
+}
+
+// defaultVideoBitrateTiers is Apple's canonical tier table, in the order the
+// captured offer listed them. The order is part of the byte-equality contract.
+var defaultVideoBitrateTiers = []bitrateTier{
+	{kind: 4074, bps: 0, bufferCap: 16384, hasBuffer: true},
+	{kind: 0, bps: 75_000_000, bufferCap: 524288, hasBuffer: true},
+	{kind: 0, bps: 40_000_000, bufferCap: 12288, hasBuffer: true},
+	{kind: 16, bps: 4100},
+	{kind: 0, bps: 20_000_000, bufferCap: 98304, hasBuffer: true},
+	{kind: 4, bps: 6500},
+	{kind: 0, bps: 6_000_000, bufferCap: 131072, hasBuffer: true},
+	{kind: 0, bps: 100_000_000, bufferCap: 1048576, hasBuffer: true},
+	{kind: 0, bps: 60_000_000, bufferCap: 262144, hasBuffer: true},
+	{kind: 1, bps: 299},
+}
+
+// videoBlobParams are the tunable flags of the video media blob. The zero value
+// is what go-ios sends: LTRP off (it eliminates mid-stream tearing under UDP
+// loss and the device honours the request), FEC on, one tile per frame.
+type videoBlobParams struct {
+	sessionID     uint32
+	allowRTCPFB   bool
+	ltrpEnabled   bool
+	fecEnabled    bool
+	tilesPerFrame uint64
+	timestamp     uint64
+}
+
+func defaultVideoBlobParams(sessionID uint32) videoBlobParams {
+	return videoBlobParams{
+		sessionID:     sessionID,
+		fecEnabled:    true,
+		tilesPerFrame: 1,
+		timestamp:     capturedVideoTimestamp,
+	}
+}
+
+// --- protobuf primitives -----------------------------------------------------
+
+func varint(v uint64) []byte {
+	var out []byte
+	for {
+		b := byte(v & 0x7f)
+		v >>= 7
+		if v != 0 {
+			out = append(out, b|0x80)
+			continue
+		}
+		return append(out, b)
+	}
+}
+
+// varintPadded encodes v as a varint padded to exactly width bytes. Protobuf
+// tolerates redundant continuation bytes, and Apple's offers use this for the
+// 5-byte session id slot so the field can be rewritten in place.
+func varintPadded(v uint64, width int) []byte {
+	raw := varint(v)
+	if len(raw) > width {
+		mask := uint64(1)<<(7*uint(width)) - 1
+		raw = varint(v & mask)
+	}
+	for len(raw) < width {
+		raw[len(raw)-1] |= 0x80
+		raw = append(raw, 0x00)
+	}
+	return raw
+}
+
+func tag(field, wireType uint64) []byte {
+	return varint(field<<3 | wireType)
+}
+
+func fieldVarint(field, value uint64) []byte {
+	return append(tag(field, 0), varint(value)...)
+}
+
+func fieldBytes(field uint64, value []byte) []byte {
+	out := append(tag(field, 2), varint(uint64(len(value)))...)
+	return append(out, value...)
+}
+
+func fieldString(field uint64, value string) []byte {
+	return fieldBytes(field, []byte(value))
+}
+
+func boolVarint(field uint64, b bool) []byte {
+	if b {
+		return fieldVarint(field, 1)
+	}
+	return fieldVarint(field, 0)
+}
+
+// --- media blob --------------------------------------------------------------
+
+// resEntry is one codec-capability tier inside a codec bank.
+func resEntry(pairIndex uint64) []byte {
+	out := fieldVarint(1, 1)
+	out = append(out, fieldVarint(2, pairIndex)...)
+	out = append(out, fieldVarint(3, resEntryCodecCapID)...)
+	return append(out, fieldVarint(4, 0)...)
+}
+
+// codecBank describes one codec. resPairCount is 4 for HEVC and 2 for AVC; the
+// bank carries alternating pair indices 1, 2 repeated that many times.
+func codecBank(payloadType uint64, features string, trailer uint64, resPairCount int) []byte {
+	body := fieldVarint(1, payloadType)
+	for i := 0; i < resPairCount; i++ {
+		body = append(body, fieldBytes(2, resEntry(uint64(1+i%2)))...)
+	}
+	body = append(body, fieldString(3, features)...)
+	return append(body, fieldVarint(4, trailer)...)
+}
+
+func videoSettings(p videoBlobParams) []byte {
+	out := append(tag(1, 0), varintPadded(uint64(p.sessionID), 5)...)
+	out = append(out, boolVarint(2, p.allowRTCPFB)...)
+	out = append(out, fieldBytes(3, codecBank(hevcPayloadType, hevcFeatures, 1, 4))...)
+	out = append(out, fieldBytes(3, codecBank(avcPayloadType, avcFeatures, 14, 2))...)
+	if p.tilesPerFrame != 1 {
+		out = append(out, fieldVarint(6, p.tilesPerFrame)...)
+	}
+	out = append(out, boolVarint(7, p.ltrpEnabled)...)
+	out = append(out, fieldVarint(8, 63)...)
+	if p.fecEnabled {
+		out = append(out, fieldVarint(10, 1)...)
+	}
+	return append(out, fieldVarint(12, 1)...)
+}
+
+// buildVideoMediaBlob assembles the uncompressed video media blob protobuf.
+func buildVideoMediaBlob(p videoBlobParams) []byte {
+	out := fieldVarint(1, 1)
+	out = append(out, fieldVarint(2, 1)...)
+	out = append(out, fieldBytes(5, videoSettings(p))...)
+	out = append(out, fieldString(6, defaultDecoderName)...)
+	out = append(out, fieldVarint(8, 0)...)
+	for _, t := range defaultVideoBitrateTiers {
+		body := fieldVarint(1, t.kind)
+		body = append(body, fieldVarint(2, t.bps)...)
+		if t.hasBuffer {
+			body = append(body, fieldVarint(3, t.bufferCap)...)
+		}
+		out = append(out, fieldBytes(9, body)...)
+	}
+	out = append(out, fieldVarint(13, p.timestamp)...)
+	out = append(out, fieldVarint(14, 2)...)
+	out = append(out, fieldVarint(16, 0)...)
+	return append(out, fieldVarint(18, 1)...)
+}
+
+// buildRemoteEndpointInfo describes the host in the
+// avcMediaStreamOptionRemoteEndpointInfo protobuf.
+func buildRemoteEndpointInfo() []byte {
+	out := fieldVarint(1, 0)
+	out = append(out, fieldVarint(2, 1)...)
+	out = append(out, fieldString(3, hostIdentity.Model)...)
+	out = append(out, fieldString(4, hostIdentity.OSVersion)...)
+	return append(out, fieldString(5, hostIdentity.Build)...)
+}
+
+// --- offer -------------------------------------------------------------------
+
+// negotiatorOffer is the binary plist the device expects. Field order in the
+// struct is irrelevant: plist dictionaries are keyed.
+type negotiatorOffer struct {
+	RemoteEndpointInfo []byte `plist:"avcMediaStreamOptionRemoteEndpointInfo"`
+	NegotiatorMode     int    `plist:"avcMediaStreamNegotiatorMode"`
+	MediaBlob          []byte `plist:"avcMediaStreamNegotiatorMediaBlob"`
+	CallID             string `plist:"avcMediaStreamOptionCallID"`
+}
+
+// buildVideoNegotiatorOffer encodes the full offer plist for a video stream.
+// callID identifies the call and sessionID the media session inside the blob;
+// both are generated per stream by the caller.
+func buildVideoNegotiatorOffer(callID uuid.UUID, sessionID uint32) ([]byte, error) {
+	blob, err := compressMediaBlob(buildVideoMediaBlob(defaultVideoBlobParams(sessionID)))
+	if err != nil {
+		return nil, err
+	}
+	offer := negotiatorOffer{
+		RemoteEndpointInfo: buildRemoteEndpointInfo(),
+		NegotiatorMode:     negotiatorModeVideo,
+		MediaBlob:          blob,
+		CallID:             strings.ToUpper(callID.String()),
+	}
+	data, err := plist.Marshal(offer, plist.BinaryFormat)
+	if err != nil {
+		return nil, fmt.Errorf("buildVideoNegotiatorOffer: failed to marshal offer plist: %w", err)
+	}
+	return data, nil
+}
+
+// compressMediaBlob zlib-compresses the blob. The level matters: Apple uses
+// best compression and the device rejects a stream built with any other level
+// with "Invalid Parameter".
+func compressMediaBlob(blob []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w, err := zlib.NewWriterLevel(&buf, zlib.BestCompression)
+	if err != nil {
+		return nil, fmt.Errorf("compressMediaBlob: failed to create writer: %w", err)
+	}
+	if _, err := w.Write(blob); err != nil {
+		return nil, fmt.Errorf("compressMediaBlob: failed to write blob: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("compressMediaBlob: failed to flush blob: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/ios/display/offer_test.go
+++ b/ios/display/offer_test.go
@@ -1,0 +1,169 @@
+package display
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/hex"
+	"io"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"howett.net/plist"
+)
+
+// capturedVideoMediaBlob is the uncompressed media blob from an offer Xcode sent
+// to a device, with capturedVideoSessionID as the session id. dtuhidd rejects
+// malformed offers with an opaque "Invalid Parameter", so this fixture is the
+// only cheap way to catch encoder drift.
+//
+// The capture had LTRP enabled and FEC disabled; go-ios defaults to the inverse
+// (see videoBlobParams), so the test builds with the captured flags.
+const capturedVideoMediaBlobHex = "080110012a7f088182bae90810001a3f087b120a0801100118c387032000120a" +
+	"0801100218c387032000120a0801100118c387032000120a0801100218c38703" +
+	"20001a09464c533b53573a313b20011a2e0864120a0801100118c38703200012" +
+	"0a0801100218c3870320001a10464c533b565241453a303b53573a313b200e38" +
+	"01403f6001320d56696365726f7920312e372e3040004a0908ea1f1000188080" +
+	"014a0b080010c0d1e123188080204a0a08001080b489131880604a0508101084" +
+	"204a0b08001080dac409188080064a05080410e4324a0b080010809bee021880" +
+	"80084a0b08001080c2d72f188080404a0b080010808ece1c188080104a050801" +
+	"10ab026880c0dd87d2a0c0e9ed017002800100900101"
+
+const capturedVideoSessionID = uint32(2368635137)
+
+// TestBuildVideoMediaBlobMatchesCapture is the contract test for the whole
+// encoder: every protobuf field number, the 5-byte padded session id, the codec
+// banks, the bitrate tier table and its order.
+func TestBuildVideoMediaBlobMatchesCapture(t *testing.T) {
+	captured, err := hex.DecodeString(capturedVideoMediaBlobHex)
+	require.NoError(t, err)
+
+	params := defaultVideoBlobParams(capturedVideoSessionID)
+	params.ltrpEnabled = true // the capture had LTRP on
+	params.fecEnabled = false // ... and FEC off
+
+	built := buildVideoMediaBlob(params)
+
+	require.Equal(t, len(captured), len(built), "media blob length drifted from the captured offer")
+	assert.Equal(t, hex.EncodeToString(captured), hex.EncodeToString(built))
+}
+
+// TestVideoBlobDefaultsDifferFromCaptureOnlyByFlags guards the two deliberate
+// deviations from Apple's capture: LTRP off (removes mid-stream tearing under
+// UDP loss) and FEC on.
+func TestVideoBlobDefaultsDifferFromCaptureOnlyByFlags(t *testing.T) {
+	defaults := buildVideoMediaBlob(defaultVideoBlobParams(capturedVideoSessionID))
+
+	withCapturedFlags := defaultVideoBlobParams(capturedVideoSessionID)
+	withCapturedFlags.ltrpEnabled = true
+	withCapturedFlags.fecEnabled = false
+
+	assert.NotEqual(t, buildVideoMediaBlob(withCapturedFlags), defaults,
+		"defaults are expected to differ from the capture by the LTRP and FEC flags")
+}
+
+func TestVarintPadded(t *testing.T) {
+	tests := []struct {
+		name  string
+		value uint64
+		width int
+		want  string
+	}{
+		{name: "zero pads to width", value: 0, width: 5, want: "8080808000"},
+		{name: "small value pads", value: 1, width: 3, want: "818000"},
+		{name: "exact width unchanged", value: 300, width: 2, want: "ac02"},
+		{name: "captured session id", value: uint64(capturedVideoSessionID), width: 5, want: "8182bae908"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := varintPadded(tt.value, tt.width)
+			assert.Len(t, got, tt.width)
+			assert.Equal(t, tt.want, hex.EncodeToString(got))
+		})
+	}
+}
+
+// TestVarintPaddedIsValueStable verifies the padding does not change the decoded
+// value: redundant continuation bytes must be semantically invisible.
+func TestVarintPaddedIsValueStable(t *testing.T) {
+	for _, v := range []uint64{0, 1, 127, 128, 300, uint64(capturedVideoSessionID)} {
+		padded := varintPadded(v, 5)
+		decoded, n := decodeVarint(t, padded)
+		assert.Equal(t, v, decoded, "padded varint decoded to a different value")
+		assert.Equal(t, 5, n, "padded varint should consume exactly the padded width")
+	}
+}
+
+func decodeVarint(t *testing.T, b []byte) (uint64, int) {
+	t.Helper()
+	var value uint64
+	var shift uint
+	for i, x := range b {
+		value |= uint64(x&0x7f) << shift
+		if x&0x80 == 0 {
+			return value, i + 1
+		}
+		shift += 7
+	}
+	t.Fatalf("varint %x is truncated", b)
+	return 0, 0
+}
+
+// TestBuildVideoNegotiatorOfferEnvelope checks the plist envelope the daemon
+// parses: the four keys, the video negotiator mode, an upper-case call id, and a
+// media blob that is zlib data round-tripping to the uncompressed protobuf.
+func TestBuildVideoNegotiatorOfferEnvelope(t *testing.T) {
+	callID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+	data, err := buildVideoNegotiatorOffer(callID, capturedVideoSessionID)
+	require.NoError(t, err)
+
+	var decoded struct {
+		RemoteEndpointInfo []byte `plist:"avcMediaStreamOptionRemoteEndpointInfo"`
+		NegotiatorMode     int    `plist:"avcMediaStreamNegotiatorMode"`
+		MediaBlob          []byte `plist:"avcMediaStreamNegotiatorMediaBlob"`
+		CallID             string `plist:"avcMediaStreamOptionCallID"`
+	}
+	_, err = plist.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, negotiatorModeVideo, decoded.NegotiatorMode)
+	assert.Equal(t, "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE", decoded.CallID,
+		"the device expects an upper-case call id")
+	assert.NotEmpty(t, decoded.RemoteEndpointInfo)
+
+	r, err := zlib.NewReader(bytes.NewReader(decoded.MediaBlob))
+	require.NoError(t, err, "media blob must be zlib data")
+	inflated, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	assert.Equal(t, buildVideoMediaBlob(defaultVideoBlobParams(capturedVideoSessionID)), inflated)
+}
+
+// TestCompressMediaBlobUsesBestCompression pins the zlib level: the device
+// rejects offers compressed at any other level with "Invalid Parameter".
+func TestCompressMediaBlobUsesBestCompression(t *testing.T) {
+	blob := buildVideoMediaBlob(defaultVideoBlobParams(capturedVideoSessionID))
+
+	got, err := compressMediaBlob(blob)
+	require.NoError(t, err)
+
+	var want bytes.Buffer
+	w, err := zlib.NewWriterLevel(&want, zlib.BestCompression)
+	require.NoError(t, err)
+	_, err = w.Write(blob)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	assert.Equal(t, want.Bytes(), got)
+}
+
+func TestBuildRemoteEndpointInfoCarriesHostIdentity(t *testing.T) {
+	info := buildRemoteEndpointInfo()
+
+	assert.Contains(t, string(info), hostIdentity.Model)
+	assert.Contains(t, string(info), hostIdentity.OSVersion)
+	assert.Contains(t, string(info), hostIdentity.Build)
+}

--- a/ios/display/offer_test.go
+++ b/ios/display/offer_test.go
@@ -49,20 +49,6 @@ func TestBuildVideoMediaBlobMatchesCapture(t *testing.T) {
 	assert.Equal(t, hex.EncodeToString(captured), hex.EncodeToString(built))
 }
 
-// TestVideoBlobDefaultsDifferFromCaptureOnlyByFlags guards the two deliberate
-// deviations from Apple's capture: LTRP off (removes mid-stream tearing under
-// UDP loss) and FEC on.
-func TestVideoBlobDefaultsDifferFromCaptureOnlyByFlags(t *testing.T) {
-	defaults := buildVideoMediaBlob(defaultVideoBlobParams(capturedVideoSessionID))
-
-	withCapturedFlags := defaultVideoBlobParams(capturedVideoSessionID)
-	withCapturedFlags.ltrpEnabled = true
-	withCapturedFlags.fecEnabled = false
-
-	assert.NotEqual(t, buildVideoMediaBlob(withCapturedFlags), defaults,
-		"defaults are expected to differ from the capture by the LTRP and FEC flags")
-}
-
 func TestVarintPadded(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/ios/display/receiver.go
+++ b/ios/display/receiver.go
@@ -1,0 +1,114 @@
+package display
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/danielpaulus/go-ios/ios"
+)
+
+// ErrUserspaceTunnelUnsupported is returned when a media stream is requested on
+// a device reached through the userspace tunnel.
+//
+// Media streaming is the one place where the device connects back to the host:
+// it pushes RTP to an address the host nominates. The kernel tunnel assigns that
+// address to a real TUN/utun interface, so a normal UDP socket is reachable. The
+// userspace tunnel has no OS interface - only a localhost TCP proxy - so inbound
+// UDP cannot reach a host socket. Start the tunnel without --userspace to use
+// touch input.
+var ErrUserspaceTunnelUnsupported = errors.New("media streams require a kernel tunnel: start the tunnel without --userspace")
+
+// receiverReadBuffer sizes the kernel receive buffer for the RTP socket. The
+// payload is discarded, but a small buffer makes the device's sender see drops
+// and back off, which has shown up as encoder stalls in captured sessions.
+const receiverReadBuffer = 1024 * 1024
+
+// Receiver is the UDP sink the device streams RTP to. go-ios does not decode the
+// stream: the packets exist only because dtuhidd gates touch input on a running
+// media stream, so Drain reads and discards them.
+type Receiver struct {
+	conn *net.UDPConn
+	ip   string
+	port int
+}
+
+// OpenReceiver binds a UDP socket on the host's tunnel address, ready to be
+// nominated as a stream's receiver. Close it when the stream is stopped.
+func OpenReceiver(device ios.DeviceEntry) (*Receiver, error) {
+	if device.UserspaceTUN {
+		return nil, ErrUserspaceTunnelUnsupported
+	}
+	hostIP, err := hostTunnelAddress(device)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.ListenUDP("udp6", &net.UDPAddr{IP: hostIP, Port: 0})
+	if err != nil {
+		return nil, fmt.Errorf("OpenReceiver: failed to bind a UDP socket on %s: %w", hostIP, err)
+	}
+	if err := conn.SetReadBuffer(receiverReadBuffer); err != nil {
+		// Not fatal: an undersized buffer only risks dropped frames, and the
+		// frames are discarded anyway.
+		conn.SetReadBuffer(0)
+	}
+	local, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		conn.Close()
+		return nil, fmt.Errorf("OpenReceiver: unexpected local address type %T", conn.LocalAddr())
+	}
+	return &Receiver{conn: conn, ip: hostIP.String(), port: local.Port}, nil
+}
+
+// IP is the host address the device should send RTP to.
+func (r *Receiver) IP() string { return r.ip }
+
+// Port is the UDP port the device should send RTP to.
+func (r *Receiver) Port() int { return r.port }
+
+// Drain reads and discards packets until ctx is cancelled or the socket is
+// closed. Run it in its own goroutine for the lifetime of the stream: without a
+// reader the socket buffer fills and the device's encoder can stall.
+func (r *Receiver) Drain(ctx context.Context) {
+	buf := make([]byte, 65535)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if _, _, err := r.conn.ReadFromUDP(buf); err != nil {
+			// A closed socket or a cancelled context both end the stream; any
+			// other read error would repeat, so stop either way.
+			return
+		}
+	}
+}
+
+// Close closes the socket, which also unblocks Drain.
+func (r *Receiver) Close() error {
+	return r.conn.Close()
+}
+
+// hostTunnelAddress finds the host's own address on the tunnel to this device.
+//
+// Dialing a UDP socket toward the device sends nothing but makes the OS pick the
+// route and bind a local address, which is the tunnel interface address the
+// device can reach us on. Reading it back avoids having to expose the tunnel's
+// client parameters through the ios.DeviceEntry API.
+func hostTunnelAddress(device ios.DeviceEntry) (net.IP, error) {
+	if device.Address == "" {
+		return nil, fmt.Errorf("hostTunnelAddress: device has no tunnel address, start a tunnel first")
+	}
+	// Port 9 is discard; nothing is ever sent to it.
+	conn, err := net.Dial("udp6", net.JoinHostPort(device.Address, "9"))
+	if err != nil {
+		return nil, fmt.Errorf("hostTunnelAddress: no route to device %s, is the tunnel up? %w", device.Address, err)
+	}
+	defer conn.Close()
+
+	local, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return nil, fmt.Errorf("hostTunnelAddress: unexpected local address type %T", conn.LocalAddr())
+	}
+	return local.IP, nil
+}

--- a/ios/display/receiver.go
+++ b/ios/display/receiver.go
@@ -1,7 +1,6 @@
 package display
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -21,9 +20,10 @@ import (
 // touch input.
 var ErrUserspaceTunnelUnsupported = errors.New("media streams require a kernel tunnel: start the tunnel without --userspace")
 
-// receiverReadBuffer sizes the kernel receive buffer for the RTP socket. The
-// payload is discarded, but a small buffer makes the device's sender see drops
-// and back off, which has shown up as encoder stalls in captured sessions.
+// receiverReadBuffer sizes the kernel receive buffer for the RTP socket at 1MB,
+// enough to absorb a burst of frames while the reader is between reads. The
+// payload is discarded, but letting the socket overflow makes the device see
+// packet loss and throttle its encoder, which has shown up as stream stalls.
 const receiverReadBuffer = 1024 * 1024
 
 // Receiver is the UDP sink the device streams RTP to. go-ios does not decode the
@@ -69,19 +69,22 @@ func (r *Receiver) IP() string { return r.ip }
 // Port is the UDP port the device should send RTP to.
 func (r *Receiver) Port() int { return r.port }
 
-// Drain reads and discards packets until ctx is cancelled or the socket is
-// closed. Run it in its own goroutine for the lifetime of the stream: without a
-// reader the socket buffer fills and the device's encoder can stall.
-func (r *Receiver) Drain(ctx context.Context) {
+// Drain reads and discards packets until the socket is closed, and reports why
+// it stopped: nil once Close has been called, otherwise the read error that
+// ended it, which means the host is no longer receiving the stream.
+//
+// Run it in its own goroutine for the lifetime of the stream. Without a reader
+// the socket buffer fills, the device sees packet loss and throttles its
+// encoder. Closing the Receiver is the only way to stop it: a blocked read is
+// not interrupted by anything else.
+func (r *Receiver) Drain() error {
 	buf := make([]byte, 65535)
 	for {
-		if ctx.Err() != nil {
-			return
-		}
 		if _, _, err := r.conn.ReadFromUDP(buf); err != nil {
-			// A closed socket or a cancelled context both end the stream; any
-			// other read error would repeat, so stop either way.
-			return
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("the RTP stream stopped being received: %w", err)
 		}
 	}
 }

--- a/ios/display/receiver.go
+++ b/ios/display/receiver.go
@@ -7,6 +7,7 @@ import (
 	"net"
 
 	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/golog"
 )
 
 // ErrUserspaceTunnelUnsupported is returned when a media stream is requested on
@@ -49,9 +50,10 @@ func OpenReceiver(device ios.DeviceEntry) (*Receiver, error) {
 		return nil, fmt.Errorf("OpenReceiver: failed to bind a UDP socket on %s: %w", hostIP, err)
 	}
 	if err := conn.SetReadBuffer(receiverReadBuffer); err != nil {
-		// Not fatal: an undersized buffer only risks dropped frames, and the
-		// frames are discarded anyway.
-		conn.SetReadBuffer(0)
+		// Not fatal: a smaller buffer only risks dropping frames we discard
+		// anyway. Keep the default rather than failing the stream.
+		golog.Debug("could not enlarge the RTP receive buffer, keeping the default",
+			"module", logModule, "error", err)
 	}
 	local, ok := conn.LocalAddr().(*net.UDPAddr)
 	if !ok {

--- a/ios/hid/hid.go
+++ b/ios/hid/hid.go
@@ -1,6 +1,12 @@
 // Package hid injects HID events - touch, hardware buttons and virtual keyboard -
-// into iOS 17+ devices through the CoreDevice HID services published by the
-// Developer Disk Image's dtuhidd daemon.
+// through the CoreDevice HID services published by the Developer Disk Image's
+// dtuhidd daemon.
+//
+// The services connect from iOS 17, but input only reaches the device on iOS 27
+// and later: the media stream that authenticates the HID surfaces cannot be
+// started on earlier versions. Verified on 26.3, where getMediaSupportInfo
+// reports no supported features and startmediastream fails with CoreDevice error
+// 9021, "Remote control requires iOS 27.0 or later on this device".
 //
 // Two RemoteXPC services are wrapped:
 //

--- a/ios/hid/hid.go
+++ b/ios/hid/hid.go
@@ -36,7 +36,9 @@
 //
 // Session handles all of this and is the intended entry point; the raw
 // SendReport/SendTouchscreen/SendKeyboard primitives are for callers managing the
-// stream themselves.
+// stream themselves. Callers feeding touches from a live input stream should
+// call Session.EnsureStream once after opening, so the stream is up before the
+// first sample arrives rather than during it.
 package hid
 
 import (

--- a/ios/hid/hid.go
+++ b/ios/hid/hid.go
@@ -30,16 +30,13 @@
 // as real UIEventTypeTouches; the stream's RTP payload can be discarded, it only
 // has to exist.
 //
-// Session handles this: it starts a stream through package ios/display the first
-// time a gesture needs one and holds it open for the session's lifetime. Prefer
-// Session over driving UniversalConnection directly, and reach for the raw
-// SendReport/SendTouchscreen/SendKeyboard primitives only when managing the
-// stream yourself.
-//
 // The gate is per client - a stream started by Xcode does not authenticate our
-// reports - and it covers the touchscreen, gesture and keyboard surfaces.
-// Hardware buttons are exempt: their surface is authenticated out of the box, so
-// Session.PressButton never starts a stream.
+// reports - and covers the touchscreen, gesture and keyboard surfaces. Hardware
+// buttons are exempt: dtuhidd already reports that surface as authenticated.
+//
+// Session handles all of this and is the intended entry point; the raw
+// SendReport/SendTouchscreen/SendKeyboard primitives are for callers managing the
+// stream themselves.
 package hid
 
 import (

--- a/ios/hid/hid.go
+++ b/ios/hid/hid.go
@@ -1,0 +1,238 @@
+// Package hid injects HID events - touch, hardware buttons and virtual keyboard -
+// into iOS 17+ devices through the CoreDevice HID services published by the
+// Developer Disk Image's dtuhidd daemon.
+//
+// Two RemoteXPC services are wrapped:
+//
+//   - Indigo (com.apple.coredevice.hid.indigo) delivers hardware button events.
+//   - Universal (com.apple.coredevice.hid.universalhidservice) enumerates the
+//     HID surfaces already registered on the device and posts raw HID reports to
+//     them. Touch and keyboard input are delivered this way.
+//
+// Both services use the plain {messageType, payload, featureIdentifier} envelope
+// that dtuhidd recognises - not the CoreDevice.* envelope built by package
+// coredevice.
+//
+// # Touch requires an active media stream
+//
+// Touch reports are gated on a running media stream. Without one, dtuhidd
+// publishes the HID surfaces as eventSource: externalAccessory and backboardd
+// discards every digitizer event ("ignoring digitizer event for display <main>
+// from unsupported service"). Reports are still accepted without error, so a
+// caller sees success while nothing happens on screen. Starting a media stream
+// flips the surfaces to authenticated/builtIn and routes reports through to UIKit
+// as real UIEventTypeTouches; the stream's RTP payload can be discarded, it only
+// has to exist.
+//
+// Session handles this: it starts a stream through package ios/display the first
+// time a gesture needs one and holds it open for the session's lifetime. Prefer
+// Session over driving UniversalConnection directly, and reach for the raw
+// SendReport/SendTouchscreen/SendKeyboard primitives only when managing the
+// stream yourself.
+//
+// The gate is per client - a stream started by Xcode does not authenticate our
+// reports - and it covers the touchscreen, gesture and keyboard surfaces.
+// Hardware buttons are exempt: their surface is authenticated out of the box, so
+// Session.PressButton never starts a stream.
+package hid
+
+import (
+	"fmt"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/xpc"
+)
+
+const (
+	indigoServiceName    = "com.apple.coredevice.hid.indigo"
+	universalServiceName = "com.apple.coredevice.hid.universalhidservice"
+
+	buttonFeatureIdentifier    = "com.apple.coredevice.feature.remote.hid.button"
+	universalFeatureIdentifier = "com.apple.coredevice.feature.remote.universalhidservice"
+)
+
+// _ServiceIDs of the HID surfaces statically registered on the device. Use
+// ListConnectedServices to discover others - the gesture surface in particular is
+// session-specific in some captures, so prefer the enumerated value when present.
+const (
+	// SurfaceMainTouchscreen is the true digitizer, driven by 58-byte reports.
+	SurfaceMainTouchscreen uint64 = 257 // 0x101
+	// SurfaceTouchscreenGesture is the trackpad-style pointer surface, driven by
+	// 19-byte reports. It moves the visual cursor in a mirror window but does not
+	// by itself produce an on-screen touch.
+	SurfaceTouchscreenGesture uint64 = 1281 // 0x501
+	// SurfaceKeyboardDefault is the default _ServiceID for a host-registered
+	// virtual keyboard. Bit 32 marks it session-specific, matching the convention
+	// macOS Universal Control uses for mirrored peripherals.
+	SurfaceKeyboardDefault uint64 = 0x100002001
+)
+
+// ButtonState is the state transition reported for a hardware button.
+type ButtonState uint64
+
+const (
+	// ButtonDown reports the button being pressed.
+	ButtonDown ButtonState = 1
+	// ButtonUp reports the button being released.
+	ButtonUp ButtonState = 2
+	// ButtonCanceled abandons an in-progress press.
+	ButtonCanceled ButtonState = 3
+)
+
+// IndigoConnection is a connection to the Indigo HID service, which delivers
+// hardware button events.
+//
+// Only the button path is implemented. Indigo's other event kinds (keyboard,
+// scroll, digitizer, vendor-defined) use Apple's Mercury peer-event envelope,
+// whose on-wire form is not known; dtuhidd accepts a dispatch in that shape but
+// logs "Resetting gesture state then canceling" without invoking a handler. Touch
+// is delivered through UniversalConnection instead.
+type IndigoConnection struct {
+	conn *xpc.Connection
+}
+
+// NewIndigo connects to the Indigo HID service on the device. iOS 17+ only, and
+// the Developer Disk Image must be mounted so dtuhidd is running.
+func NewIndigo(device ios.DeviceEntry) (*IndigoConnection, error) {
+	conn, err := ios.ConnectToXpcServiceTunnelIface(device, indigoServiceName)
+	if err != nil {
+		return nil, fmt.Errorf("NewIndigo: %w", err)
+	}
+	return &IndigoConnection{conn: conn}, nil
+}
+
+// SendButton reports a single hardware-button state change.
+//
+// usagePage and usageCode identify the button in HID terms - page 0x0C
+// (Consumer) covers the media buttons, page 0x09 (Button) the generic ones.
+func (c *IndigoConnection) SendButton(usagePage, usageCode uint64, state ButtonState) error {
+	if err := c.conn.Send(buildButtonPayload(usagePage, usageCode, state), xpc.HeartbeatRequestFlag); err != nil {
+		return fmt.Errorf("SendButton: failed to send button event: %w", err)
+	}
+	return nil
+}
+
+// Close closes the connection to the Indigo HID service.
+func (c *IndigoConnection) Close() error {
+	return c.conn.Close()
+}
+
+// UniversalConnection is a connection to the universalhidservice, which exposes
+// the device's registered HID surfaces and accepts raw HID reports for them.
+type UniversalConnection struct {
+	conn *xpc.Connection
+}
+
+// NewUniversal connects to the universalhidservice on the device. iOS 17+ only,
+// and the Developer Disk Image must be mounted so dtuhidd is running.
+func NewUniversal(device ios.DeviceEntry) (*UniversalConnection, error) {
+	conn, err := ios.ConnectToXpcServiceTunnelIface(device, universalServiceName)
+	if err != nil {
+		return nil, fmt.Errorf("NewUniversal: %w", err)
+	}
+	return &UniversalConnection{conn: conn}, nil
+}
+
+// ListConnectedServices enumerates the HID surfaces currently registered on the
+// device. Each entry carries a _ServiceID usable as the target of SendReport.
+func (c *UniversalConnection) ListConnectedServices() (map[string]interface{}, error) {
+	if err := c.conn.Send(buildListServicesPayload(), xpc.HeartbeatRequestFlag); err != nil {
+		return nil, fmt.Errorf("ListConnectedServices: failed to send request: %w", err)
+	}
+	res, err := c.conn.ReceiveOnServerClientStream()
+	if err != nil {
+		return nil, fmt.Errorf("ListConnectedServices: failed to read response: %w", err)
+	}
+	return res, nil
+}
+
+// SendReport delivers a raw HID report to one of the device's HID surfaces.
+//
+// The report layout is surface-specific and its first byte is the HID report ID;
+// use BuildTouchscreenReport, BuildDigitizerReport or BuildKeyboardReport to
+// produce a well-formed one.
+//
+// dtuhidd does not acknowledge reports, so a nil error means the report was
+// written to the channel, not that the device acted on it. See the package
+// documentation on the media-stream gate.
+func (c *UniversalConnection) SendReport(serviceID uint64, report []byte) error {
+	if len(report) == 0 {
+		return fmt.Errorf("SendReport: report is empty")
+	}
+	if err := c.conn.Send(buildSendReportPayload(serviceID, report), xpc.HeartbeatRequestFlag); err != nil {
+		return fmt.Errorf("SendReport: failed to send report to surface %d: %w", serviceID, err)
+	}
+	return nil
+}
+
+// SendTouchscreen posts a single mainTouchscreen report at (x, y).
+//
+// Pass TouchContact for a touch sample and TouchRelease to lift. A tap is one
+// TouchContact followed by one TouchRelease at the same coordinates; a drag is a
+// run of TouchContact reports with advancing coordinates terminated by a single
+// TouchRelease. There is no separate begin/end opcode - every TouchContact means
+// "in contact at this position".
+//
+// Coordinates are in the digitizer's own units, not points; see ListConnectedServices
+// for the surface's logical bounds.
+func (c *UniversalConnection) SendTouchscreen(state TouchState, x, y uint16, serviceID uint64) error {
+	if err := c.SendReport(serviceID, BuildTouchscreenReport(state, x, y, Timestamp())); err != nil {
+		return fmt.Errorf("SendTouchscreen: %w", err)
+	}
+	return nil
+}
+
+// SendDigitizer posts a single gesture/pointer report at (x, y). This moves the
+// visual cursor on the gesture surface; an actual on-screen touch also needs
+// SendTouchscreen.
+func (c *UniversalConnection) SendDigitizer(x, y int32, serviceID uint64) error {
+	if err := c.SendReport(serviceID, BuildDigitizerReport(x, y, Timestamp())); err != nil {
+		return fmt.Errorf("SendDigitizer: %w", err)
+	}
+	return nil
+}
+
+// SendKeyboard posts a single virtual-keyboard report to a surface registered by
+// CreateKeyboardService.
+//
+// usages is the full set of HID keyboard usages currently held down, not a delta:
+// every report replaces whatever the device believed was pressed, so releasing a
+// key means resending without it. Pass no usages to release everything.
+func (c *UniversalConnection) SendKeyboard(serviceID uint64, usages ...uint8) error {
+	if err := c.SendReport(serviceID, BuildKeyboardReport(usages, Timestamp())); err != nil {
+		return fmt.Errorf("SendKeyboard: %w", err)
+	}
+	return nil
+}
+
+// CreateKeyboardService registers a host-side virtual HID keyboard with dtuhidd
+// and returns the _ServiceID it assigned, which is normally the requested one.
+// Address subsequent SendKeyboard calls to the returned value.
+//
+// Unlike the touch surfaces this one is not pre-registered on the device, so it
+// must be created before any keyboard report will be accepted. The same
+// media-stream gate applies: without a running stream the new surface is
+// published as externalAccessory and its reports are dropped.
+func (c *UniversalConnection) CreateKeyboardService(serviceID uint64, product, manufacturer string, vendorID, productID int64) (uint64, error) {
+	if err := c.conn.Send(buildCreateKeyboardPayload(serviceID, product, manufacturer, vendorID, productID), xpc.HeartbeatRequestFlag); err != nil {
+		return 0, fmt.Errorf("CreateKeyboardService: failed to send request: %w", err)
+	}
+	res, err := c.conn.ReceiveOnServerClientStream()
+	if err != nil {
+		return 0, fmt.Errorf("CreateKeyboardService: failed to read response: %w", err)
+	}
+	// dtuhidd echoes the ID it settled on; fall back to the requested one when the
+	// response omits it, which is what the reference implementation does.
+	if assigned, ok := res["serviceID"].(uint64); ok {
+		return assigned, nil
+	}
+	if assigned, ok := res["serviceID"].(int64); ok {
+		return uint64(assigned), nil
+	}
+	return serviceID, nil
+}
+
+// Close closes the connection to the universalhidservice.
+func (c *UniversalConnection) Close() error {
+	return c.conn.Close()
+}

--- a/ios/hid/keys.go
+++ b/ios/hid/keys.go
@@ -1,0 +1,189 @@
+package hid
+
+// HID keyboard usage codes from usage page 0x07. These are the values that go
+// into the bitmap of BuildKeyboardReport. Any usage below 240 can be sent as a
+// raw number; the named ones are those a host frontend commonly needs.
+const (
+	KeyA uint8 = 0x04
+	KeyB uint8 = 0x05
+	KeyC uint8 = 0x06
+	KeyD uint8 = 0x07
+	KeyE uint8 = 0x08
+	KeyF uint8 = 0x09
+	KeyG uint8 = 0x0A
+	KeyH uint8 = 0x0B
+	KeyI uint8 = 0x0C
+	KeyJ uint8 = 0x0D
+	KeyK uint8 = 0x0E
+	KeyL uint8 = 0x0F
+	KeyM uint8 = 0x10
+	KeyN uint8 = 0x11
+	KeyO uint8 = 0x12
+	KeyP uint8 = 0x13
+	KeyQ uint8 = 0x14
+	KeyR uint8 = 0x15
+	KeyS uint8 = 0x16
+	KeyT uint8 = 0x17
+	KeyU uint8 = 0x18
+	KeyV uint8 = 0x19
+	KeyW uint8 = 0x1A
+	KeyX uint8 = 0x1B
+	KeyY uint8 = 0x1C
+	KeyZ uint8 = 0x1D
+
+	Key1 uint8 = 0x1E
+	Key2 uint8 = 0x1F
+	Key3 uint8 = 0x20
+	Key4 uint8 = 0x21
+	Key5 uint8 = 0x22
+	Key6 uint8 = 0x23
+	Key7 uint8 = 0x24
+	Key8 uint8 = 0x25
+	Key9 uint8 = 0x26
+	Key0 uint8 = 0x27
+
+	KeyEnter     uint8 = 0x28
+	KeyEsc       uint8 = 0x29
+	KeyBackspace uint8 = 0x2A
+	KeyTab       uint8 = 0x2B
+	KeySpace     uint8 = 0x2C
+
+	KeyMinus      uint8 = 0x2D
+	KeyEqual      uint8 = 0x2E
+	KeyLBracket   uint8 = 0x2F
+	KeyRBracket   uint8 = 0x30
+	KeyBackslash  uint8 = 0x31
+	KeySemicolon  uint8 = 0x33
+	KeyApostrophe uint8 = 0x34
+	KeyGrave      uint8 = 0x35
+	KeyComma      uint8 = 0x36
+	KeyDot        uint8 = 0x37
+	KeySlash      uint8 = 0x38
+	KeyCapsLock   uint8 = 0x39
+
+	KeyF1  uint8 = 0x3A
+	KeyF2  uint8 = 0x3B
+	KeyF3  uint8 = 0x3C
+	KeyF4  uint8 = 0x3D
+	KeyF5  uint8 = 0x3E
+	KeyF6  uint8 = 0x3F
+	KeyF7  uint8 = 0x40
+	KeyF8  uint8 = 0x41
+	KeyF9  uint8 = 0x42
+	KeyF10 uint8 = 0x43
+	KeyF11 uint8 = 0x44
+	KeyF12 uint8 = 0x45
+
+	KeyRight uint8 = 0x4F
+	KeyLeft  uint8 = 0x50
+	KeyDown  uint8 = 0x51
+	KeyUp    uint8 = 0x52
+
+	KeyLeftCtrl   uint8 = 0xE0
+	KeyLeftShift  uint8 = 0xE1
+	KeyLeftAlt    uint8 = 0xE2
+	KeyLeftGUI    uint8 = 0xE3
+	KeyRightCtrl  uint8 = 0xE4
+	KeyRightShift uint8 = 0xE5
+	KeyRightAlt   uint8 = 0xE6
+	KeyRightGUI   uint8 = 0xE7
+)
+
+// Key is the usage code a character maps to, together with whether Shift must be
+// held to produce it on a US layout.
+type Key struct {
+	Usage uint8
+	Shift bool
+}
+
+// asciiToHID maps printable ASCII to its US-layout usage code. Built once at
+// init rather than written out, so the letter and digit runs cannot drift.
+var asciiToHID = func() map[rune]Key {
+	m := make(map[rune]Key, 128)
+
+	for i := rune(0); i < 26; i++ {
+		usage := KeyA + uint8(i)
+		m['a'+i] = Key{Usage: usage}
+		m['A'+i] = Key{Usage: usage, Shift: true}
+	}
+	// Usages run 1..9 then 0, which is why '0' is handled after the loop.
+	for i := rune(0); i < 9; i++ {
+		m['1'+i] = Key{Usage: Key1 + uint8(i)}
+	}
+	m['0'] = Key{Usage: Key0}
+
+	// Shifted digits.
+	for ch, usage := range map[rune]uint8{
+		'!': Key1, '@': Key2, '#': Key3, '$': Key4, '%': Key5,
+		'^': Key6, '&': Key7, '*': Key8, '(': Key9, ')': Key0,
+	} {
+		m[ch] = Key{Usage: usage, Shift: true}
+	}
+
+	for ch, k := range map[rune]Key{
+		' ':  {Usage: KeySpace},
+		'\t': {Usage: KeyTab},
+		'\n': {Usage: KeyEnter},
+		'-':  {Usage: KeyMinus},
+		'_':  {Usage: KeyMinus, Shift: true},
+		'=':  {Usage: KeyEqual},
+		'+':  {Usage: KeyEqual, Shift: true},
+		'[':  {Usage: KeyLBracket},
+		'{':  {Usage: KeyLBracket, Shift: true},
+		']':  {Usage: KeyRBracket},
+		'}':  {Usage: KeyRBracket, Shift: true},
+		'\\': {Usage: KeyBackslash},
+		'|':  {Usage: KeyBackslash, Shift: true},
+		';':  {Usage: KeySemicolon},
+		':':  {Usage: KeySemicolon, Shift: true},
+		'\'': {Usage: KeyApostrophe},
+		'"':  {Usage: KeyApostrophe, Shift: true},
+		'`':  {Usage: KeyGrave},
+		'~':  {Usage: KeyGrave, Shift: true},
+		',':  {Usage: KeyComma},
+		'<':  {Usage: KeyComma, Shift: true},
+		'.':  {Usage: KeyDot},
+		'>':  {Usage: KeyDot, Shift: true},
+		'/':  {Usage: KeySlash},
+		'?':  {Usage: KeySlash, Shift: true},
+	} {
+		m[ch] = k
+	}
+
+	return m
+}()
+
+// KeyForRune returns the usage code and shift state that produce ch on a US
+// keyboard layout. The second result is false for characters with no mapping.
+func KeyForRune(ch rune) (Key, bool) {
+	k, ok := asciiToHID[ch]
+	return k, ok
+}
+
+// TypeString sends ch by ch through the keyboard surface, pressing and releasing
+// each character in turn and holding Left-Shift for those that need it.
+//
+// Characters with no US-layout mapping are skipped. Because every report carries
+// the full pressed set, each character is two reports: one with the key (and
+// Shift) down, one releasing everything.
+func (c *UniversalConnection) TypeString(serviceID uint64, s string) error {
+	for _, ch := range s {
+		k, ok := KeyForRune(ch)
+		if !ok {
+			continue
+		}
+		usages := []uint8{k.Usage}
+		if k.Shift {
+			usages = append(usages, KeyLeftShift)
+		}
+		if err := c.SendKeyboard(serviceID, usages...); err != nil {
+			return err
+		}
+		// Release everything before the next character, otherwise a repeated
+		// character reads as one continuous press.
+		if err := c.SendKeyboard(serviceID); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/ios/hid/keys.go
+++ b/ios/hid/keys.go
@@ -159,31 +159,3 @@ func KeyForRune(ch rune) (Key, bool) {
 	k, ok := asciiToHID[ch]
 	return k, ok
 }
-
-// TypeString sends ch by ch through the keyboard surface, pressing and releasing
-// each character in turn and holding Left-Shift for those that need it.
-//
-// Characters with no US-layout mapping are skipped. Because every report carries
-// the full pressed set, each character is two reports: one with the key (and
-// Shift) down, one releasing everything.
-func (c *UniversalConnection) TypeString(serviceID uint64, s string) error {
-	for _, ch := range s {
-		k, ok := KeyForRune(ch)
-		if !ok {
-			continue
-		}
-		usages := []uint8{k.Usage}
-		if k.Shift {
-			usages = append(usages, KeyLeftShift)
-		}
-		if err := c.SendKeyboard(serviceID, usages...); err != nil {
-			return err
-		}
-		// Release everything before the next character, otherwise a repeated
-		// character reads as one continuous press.
-		if err := c.SendKeyboard(serviceID); err != nil {
-			return err
-		}
-	}
-	return nil
-}

--- a/ios/hid/payload.go
+++ b/ios/hid/payload.go
@@ -1,0 +1,159 @@
+package hid
+
+// keyboardReportDescriptor declares the virtual surface as a Generic-Desktop
+// Keyboard.
+//
+// The bitmap report BuildKeyboardReport actually sends does not match this
+// descriptor's layout (a modifier byte plus a six-key array). dtuhidd tolerates
+// the divergence - the same divergence appears in a captured macOS Universal
+// Control session - because the descriptor's real job is to identify the surface
+// as a keyboard so backboardd hides the on-screen software keyboard while a host
+// keyboard is attached.
+var keyboardReportDescriptor = []byte{
+	0x05, 0x01, // Usage Page (Generic Desktop)
+	0x09, 0x06, // Usage (Keyboard)
+	0xA1, 0x01, // Collection (Application)
+	0x05, 0x07, // Usage Page (Keyboard)
+	0x19, 0xE0, // Usage Minimum (0xE0)
+	0x29, 0xE7, // Usage Maximum (0xE7) - the 8 modifier keys
+	0x15, 0x00, // Logical Minimum (0)
+	0x25, 0x01, // Logical Maximum (1)
+	0x95, 0x08, // Report Count (8)
+	0x75, 0x01, // Report Size (1)
+	0x81, 0x02, // Input (Data, Variable, Absolute) - modifier byte
+	0x95, 0x01, // Report Count (1)
+	0x75, 0x08, // Report Size (8)
+	0x81, 0x01, // Input (Constant) - reserved byte
+	0x05, 0x07, // Usage Page (Keyboard)
+	0x19, 0x00, // Usage Minimum (0)
+	0x29, 0xFF, // Usage Maximum (0xFF)
+	0x15, 0x00, // Logical Minimum (0)
+	0x26, 0xFF, 0x00, // Logical Maximum (255)
+	0x95, 0x06, // Report Count (6)
+	0x75, 0x08, // Report Size (8)
+	0x81, 0x00, // Input (Data, Array) - 6-key array
+	0x05, 0x08, // Usage Page (LED)
+	0x19, 0x01, // Usage Minimum (1)
+	0x29, 0x05, // Usage Maximum (5)
+	0x15, 0x00, // Logical Minimum (0)
+	0x25, 0x01, // Logical Maximum (1)
+	0x95, 0x05, // Report Count (5)
+	0x75, 0x01, // Report Size (1)
+	0x91, 0x02, // Output (Data, Variable, Absolute) - LEDs
+	0x95, 0x01, // Report Count (1)
+	0x75, 0x03, // Report Size (3)
+	0x91, 0x01, // Output (Constant) - padding
+	0xC0, // End Collection
+}
+
+// buildButtonPayload builds an IndigoButtonEvent envelope.
+func buildButtonPayload(usagePage, usageCode uint64, state ButtonState) map[string]interface{} {
+	return map[string]interface{}{
+		"messageType": "IndigoButtonEvent",
+		"payload": map[string]interface{}{
+			"state":     uint64(state),
+			"usagePage": usagePage,
+			"usageCode": usageCode,
+		},
+		"featureIdentifier": buttonFeatureIdentifier,
+	}
+}
+
+// buildListServicesPayload builds the request enumerating registered HID surfaces.
+func buildListServicesPayload() map[string]interface{} {
+	return map[string]interface{}{
+		"featureIdentifier": universalFeatureIdentifier,
+		"messageType":       "Request",
+		"payload": map[string]interface{}{
+			"connectedServices": map[string]interface{}{},
+		},
+	}
+}
+
+// buildSendReportPayload builds the request posting a raw HID report to a surface.
+// The report goes over the wire as an XPC data object and the surface ID as UInt64.
+func buildSendReportPayload(serviceID uint64, report []byte) map[string]interface{} {
+	return map[string]interface{}{
+		"featureIdentifier": universalFeatureIdentifier,
+		"messageType":       "Request",
+		"payload": map[string]interface{}{
+			"send": map[string]interface{}{
+				"_0": report,
+				"_1": serviceID,
+			},
+		},
+	}
+}
+
+// buildCreateKeyboardPayload builds the request registering a host-side virtual
+// HID keyboard.
+//
+// The shape mirrors a captured macOS Universal Control session registering a real
+// keyboard onto the device, and dtuhidd's decoder is strict about it in two ways
+// that are easy to get wrong:
+//
+//   - Integer widths differ by position. PrimaryUsage and PrimaryUsagePage are
+//     UInt64 at the top level but Int64 inside the storage block, while
+//     ProductID, VendorID and the DeviceUsage pairs are Int64 everywhere and
+//     _ServiceID is UInt64 everywhere.
+//   - Every leaf inside _CoreDevice_codablePropertyStorage is wrapped in a
+//     Swift-Codable type envelope ({"string": ...}, {"int": ...}, {"bool": ...},
+//     {"data": ...}, {"uint": ...}, {"array": [...]}, {"dictionary": {...}}).
+//     A raw bool or int under that key is rejected with
+//     DecodingError.typeMismatch: dictionary required here.
+//
+// Manufacturer, Transport, ReportDescriptor and UniversalControlVirtualService
+// exist only inside the storage block, not at the top level.
+func buildCreateKeyboardPayload(serviceID uint64, product, manufacturer string, vendorID, productID int64) map[string]interface{} {
+	const (
+		usagePageGenericDesktop int64 = 1
+		usageKeyboard           int64 = 6
+	)
+
+	storage := map[string]interface{}{
+		"Manufacturer":     map[string]interface{}{"string": manufacturer},
+		"Product":          map[string]interface{}{"string": product},
+		"ProductID":        map[string]interface{}{"int": productID},
+		"VendorID":         map[string]interface{}{"int": vendorID},
+		"PrimaryUsage":     map[string]interface{}{"int": usageKeyboard},
+		"PrimaryUsagePage": map[string]interface{}{"int": usagePageGenericDesktop},
+		"DeviceUsagePairs": map[string]interface{}{
+			"array": []interface{}{
+				map[string]interface{}{
+					"dictionary": map[string]interface{}{
+						"DeviceUsage":     map[string]interface{}{"int": usageKeyboard},
+						"DeviceUsagePage": map[string]interface{}{"int": usagePageGenericDesktop},
+					},
+				},
+			},
+		},
+		"Transport":                      map[string]interface{}{"string": "USB"},
+		"ReportDescriptor":               map[string]interface{}{"data": keyboardReportDescriptor},
+		"UniversalControlVirtualService": map[string]interface{}{"bool": true},
+		"_ServiceID":                     map[string]interface{}{"uint": serviceID},
+	}
+
+	return map[string]interface{}{
+		"featureIdentifier": universalFeatureIdentifier,
+		"messageType":       "Request",
+		"payload": map[string]interface{}{
+			"createService": map[string]interface{}{
+				"_0": map[string]interface{}{
+					"DeviceUsagePairs": []interface{}{
+						map[string]interface{}{
+							"DeviceUsage":     usageKeyboard,
+							"DeviceUsagePage": usagePageGenericDesktop,
+						},
+					},
+					"PrimaryUsage":                       uint64(usageKeyboard),
+					"PrimaryUsagePage":                   uint64(usagePageGenericDesktop),
+					"Product":                            product,
+					"ProductID":                          productID,
+					"VendorID":                           vendorID,
+					"_CoreDevice_codablePropertyStorage": storage,
+					"_ServiceID":                         serviceID,
+				},
+			},
+		},
+	}
+}

--- a/ios/hid/payload_test.go
+++ b/ios/hid/payload_test.go
@@ -1,0 +1,216 @@
+package hid
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/danielpaulus/go-ios/ios/xpc"
+)
+
+// roundTrip encodes a payload with the real XPC codec and decodes it again.
+//
+// This is the check that matters for a wire-protocol port: the encoder rejects
+// any Go type it cannot represent, and it maps Go's integer types onto distinct
+// XPC types. dtuhidd's Swift decoder is strict about those widths, so a uint64
+// silently written as int64 would be rejected on the device where no unit test
+// on the map alone would notice.
+func roundTrip(t *testing.T, payload map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	buf := bytes.NewBuffer(nil)
+	if err := xpc.EncodeMessage(buf, xpc.Message{
+		Flags: xpc.AlwaysSetFlag | xpc.DataFlag,
+		Body:  payload,
+	}); err != nil {
+		t.Fatalf("payload is not XPC-encodable: %v", err)
+	}
+	msg, err := xpc.DecodeMessage(buf)
+	if err != nil {
+		t.Fatalf("failed to decode the payload we just encoded: %v", err)
+	}
+	return msg.Body
+}
+
+func dict(t *testing.T, m map[string]interface{}, key string) map[string]interface{} {
+	t.Helper()
+	v, ok := m[key].(map[string]interface{})
+	if !ok {
+		t.Fatalf("%q is not a dictionary, got %T", key, m[key])
+	}
+	return v
+}
+
+func TestButtonPayload(t *testing.T) {
+	body := roundTrip(t, buildButtonPayload(0x0C, 0x40, ButtonDown))
+
+	if got := body["messageType"]; got != "IndigoButtonEvent" {
+		t.Errorf("messageType = %v, want IndigoButtonEvent", got)
+	}
+	if got := body["featureIdentifier"]; got != buttonFeatureIdentifier {
+		t.Errorf("featureIdentifier = %v, want %s", got, buttonFeatureIdentifier)
+	}
+
+	payload := dict(t, body, "payload")
+	// All three must survive as UInt64 - dtuhidd's decoder rejects Int64 here.
+	for key, want := range map[string]uint64{
+		"state":     uint64(ButtonDown),
+		"usagePage": 0x0C,
+		"usageCode": 0x40,
+	} {
+		got, ok := payload[key].(uint64)
+		if !ok {
+			t.Errorf("%s is %T, want uint64", key, payload[key])
+			continue
+		}
+		if got != want {
+			t.Errorf("%s = %d, want %d", key, got, want)
+		}
+	}
+}
+
+func TestListServicesPayload(t *testing.T) {
+	body := roundTrip(t, buildListServicesPayload())
+
+	if got := body["messageType"]; got != "Request" {
+		t.Errorf("messageType = %v, want Request", got)
+	}
+	if got := body["featureIdentifier"]; got != universalFeatureIdentifier {
+		t.Errorf("featureIdentifier = %v, want %s", got, universalFeatureIdentifier)
+	}
+	payload := dict(t, body, "payload")
+	if _, ok := payload["connectedServices"].(map[string]interface{}); !ok {
+		t.Errorf("connectedServices is %T, want an empty dictionary", payload["connectedServices"])
+	}
+}
+
+func TestSendReportPayload(t *testing.T) {
+	report := BuildTouchscreenReport(TouchContact, 42, 43, goldenTimestamp)
+	body := roundTrip(t, buildSendReportPayload(SurfaceMainTouchscreen, report))
+
+	send := dict(t, dict(t, body, "payload"), "send")
+
+	// The report must cross the wire as an XPC data object, byte-for-byte.
+	got, ok := send["_0"].([]byte)
+	if !ok {
+		t.Fatalf("_0 is %T, want []byte encoded as XPC data", send["_0"])
+	}
+	if !bytes.Equal(got, report) {
+		t.Errorf("report was altered in transit\n got %x\nwant %x", got, report)
+	}
+
+	serviceID, ok := send["_1"].(uint64)
+	if !ok {
+		t.Fatalf("_1 is %T, want uint64", send["_1"])
+	}
+	if serviceID != SurfaceMainTouchscreen {
+		t.Errorf("_1 = %d, want %d", serviceID, SurfaceMainTouchscreen)
+	}
+}
+
+// The create-keyboard payload is the one place where the same logical field takes
+// a different integer width depending on where it appears. Getting it wrong fails
+// only on the device, so pin the widths here.
+func TestCreateKeyboardPayloadIntegerWidths(t *testing.T) {
+	body := roundTrip(t, buildCreateKeyboardPayload(SurfaceKeyboardDefault, "test kbd", "go-ios", 0x05AC, 0x0250))
+
+	svc := dict(t, dict(t, dict(t, body, "payload"), "createService"), "_0")
+
+	// Top level: usages are UInt64, IDs are Int64, _ServiceID is UInt64.
+	if _, ok := svc["PrimaryUsage"].(uint64); !ok {
+		t.Errorf("top-level PrimaryUsage is %T, want uint64", svc["PrimaryUsage"])
+	}
+	if _, ok := svc["PrimaryUsagePage"].(uint64); !ok {
+		t.Errorf("top-level PrimaryUsagePage is %T, want uint64", svc["PrimaryUsagePage"])
+	}
+	if _, ok := svc["ProductID"].(int64); !ok {
+		t.Errorf("top-level ProductID is %T, want int64", svc["ProductID"])
+	}
+	if _, ok := svc["VendorID"].(int64); !ok {
+		t.Errorf("top-level VendorID is %T, want int64", svc["VendorID"])
+	}
+	if got, ok := svc["_ServiceID"].(uint64); !ok {
+		t.Errorf("top-level _ServiceID is %T, want uint64", svc["_ServiceID"])
+	} else if got != SurfaceKeyboardDefault {
+		t.Errorf("_ServiceID = %#x, want %#x", got, SurfaceKeyboardDefault)
+	}
+
+	// Storage block: the same usages are Int64 here, and every leaf is wrapped
+	// in a Swift-Codable type envelope.
+	storage := dict(t, svc, "_CoreDevice_codablePropertyStorage")
+
+	if _, ok := dict(t, storage, "PrimaryUsage")["int"].(int64); !ok {
+		t.Errorf("storage PrimaryUsage is not wrapped as {int: int64}")
+	}
+	if _, ok := dict(t, storage, "PrimaryUsagePage")["int"].(int64); !ok {
+		t.Errorf("storage PrimaryUsagePage is not wrapped as {int: int64}")
+	}
+	if _, ok := dict(t, storage, "_ServiceID")["uint"].(uint64); !ok {
+		t.Errorf("storage _ServiceID is not wrapped as {uint: uint64}")
+	}
+	if got, ok := dict(t, storage, "UniversalControlVirtualService")["bool"].(bool); !ok || !got {
+		t.Errorf("storage UniversalControlVirtualService is not wrapped as {bool: true}")
+	}
+	if got, ok := dict(t, storage, "Manufacturer")["string"].(string); !ok || got != "go-ios" {
+		t.Errorf("storage Manufacturer = %v, want {string: go-ios}", storage["Manufacturer"])
+	}
+	if got, ok := dict(t, storage, "Transport")["string"].(string); !ok || got != "USB" {
+		t.Errorf("storage Transport = %v, want {string: USB}", storage["Transport"])
+	}
+
+	// The report descriptor has to arrive as data, unmodified.
+	descriptor, ok := dict(t, storage, "ReportDescriptor")["data"].([]byte)
+	if !ok {
+		t.Fatalf("storage ReportDescriptor is not wrapped as {data: []byte}")
+	}
+	if !bytes.Equal(descriptor, keyboardReportDescriptor) {
+		t.Errorf("report descriptor altered in transit")
+	}
+
+	// Fields that belong only in the storage block must not leak to the top level.
+	for _, key := range []string{"Manufacturer", "Transport", "ReportDescriptor", "UniversalControlVirtualService"} {
+		if _, present := svc[key]; present {
+			t.Errorf("%s must live only inside the storage block", key)
+		}
+	}
+}
+
+func TestCreateKeyboardPayloadDeviceUsagePairs(t *testing.T) {
+	body := roundTrip(t, buildCreateKeyboardPayload(SurfaceKeyboardDefault, "p", "m", 1, 2))
+	svc := dict(t, dict(t, dict(t, body, "payload"), "createService"), "_0")
+
+	// Top-level pairs are a plain array of plain dictionaries.
+	pairs, ok := svc["DeviceUsagePairs"].([]interface{})
+	if !ok {
+		t.Fatalf("top-level DeviceUsagePairs is %T, want []interface{}", svc["DeviceUsagePairs"])
+	}
+	if len(pairs) != 1 {
+		t.Fatalf("top-level DeviceUsagePairs has %d entries, want 1", len(pairs))
+	}
+	pair, ok := pairs[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("pair is %T, want a dictionary", pairs[0])
+	}
+	if _, ok := pair["DeviceUsage"].(int64); !ok {
+		t.Errorf("top-level DeviceUsage is %T, want int64", pair["DeviceUsage"])
+	}
+
+	// Storage pairs are the same data wrapped twice: {array: [{dictionary: {...}}]}.
+	storage := dict(t, svc, "_CoreDevice_codablePropertyStorage")
+	wrapped, ok := dict(t, storage, "DeviceUsagePairs")["array"].([]interface{})
+	if !ok {
+		t.Fatalf("storage DeviceUsagePairs is not wrapped as {array: [...]}")
+	}
+	if len(wrapped) != 1 {
+		t.Fatalf("storage DeviceUsagePairs has %d entries, want 1", len(wrapped))
+	}
+	entry, ok := wrapped[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("storage pair is %T, want a dictionary", wrapped[0])
+	}
+	inner, ok := entry["dictionary"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("storage pair is not wrapped as {dictionary: {...}}")
+	}
+	if _, ok := dict(t, inner, "DeviceUsage")["int"].(int64); !ok {
+		t.Errorf("storage DeviceUsage is not wrapped as {int: int64}")
+	}
+}

--- a/ios/hid/report.go
+++ b/ios/hid/report.go
@@ -1,0 +1,118 @@
+package hid
+
+import (
+	"encoding/binary"
+	"time"
+)
+
+// HID report IDs, carried in the first byte of every report.
+const (
+	reportIDKeyboard    = 0x01
+	reportIDTouchscreen = 0x09
+	reportIDDigitizer   = 0x13
+)
+
+// Report lengths. The device rejects reports of any other size for these surfaces.
+const (
+	// DigitizerReportLen is the length of a gesture/pointer report.
+	DigitizerReportLen = 19
+	// TouchscreenReportLen is the length of a mainTouchscreen report.
+	TouchscreenReportLen = 58
+	// KeyboardReportLen is the length of a virtual-keyboard report.
+	KeyboardReportLen = 39
+)
+
+// timestampBits is the width of the report timestamp field. Six bytes on the
+// wire, so values are masked to 48 bits.
+const timestampBits = 48
+
+// TouchState is the contact state carried in a mainTouchscreen report.
+type TouchState uint8
+
+const (
+	// TouchContact means "a contact is in progress at this position".
+	TouchContact TouchState = 0xC2
+	// TouchRelease lifts the contact.
+	TouchRelease TouchState = 0x02
+)
+
+// keyboardBitmapLen is the size of the pressed-usage bitmap in a keyboard report.
+const keyboardBitmapLen = 30
+
+// maxKeyboardUsage is one past the highest usage the bitmap can represent.
+const maxKeyboardUsage = keyboardBitmapLen * 8 // 240
+
+// processStart anchors Timestamp to a monotonic origin. time.Since reads Go's
+// monotonic clock, so the sequence is unaffected by wall-clock adjustments.
+var processStart = time.Now()
+
+// Timestamp returns the 48-bit monotonic value to stamp a report with.
+//
+// The device's gesture recogniser only reads monotonicity and inter-report
+// deltas from this field, not absolute time, so any monotonic source works.
+func Timestamp() uint64 {
+	return uint64(time.Since(processStart).Nanoseconds()) & (1<<timestampBits - 1)
+}
+
+// putTimestamp writes the low 48 bits of ts little-endian into the first six
+// bytes of b.
+func putTimestamp(b []byte, ts uint64) {
+	var full [8]byte
+	binary.LittleEndian.PutUint64(full[:], ts&(1<<timestampBits-1))
+	copy(b, full[:6])
+}
+
+// BuildDigitizerReport builds a gesture/pointer report placing the pointer at
+// (x, y). Coordinates are signed 32-bit. Use Timestamp for ts.
+//
+// Layout: [0]=report ID, [1:5]=X int32 LE, [5:9]=Y int32 LE, [9:11] reserved,
+// [11:17]=timestamp, [17:19] reserved.
+func BuildDigitizerReport(x, y int32, ts uint64) []byte {
+	report := make([]byte, DigitizerReportLen)
+	report[0] = reportIDDigitizer
+	binary.LittleEndian.PutUint32(report[1:5], uint32(x))
+	binary.LittleEndian.PutUint32(report[5:9], uint32(y))
+	putTimestamp(report[11:17], ts)
+	return report
+}
+
+// BuildTouchscreenReport builds a mainTouchscreen report carrying a contact
+// state and position. Use Timestamp for ts.
+//
+// Layout: [0]=report ID, [1:3]=constants 0x01 0x05, [3]=state, [4:6]=X uint16 LE,
+// [6:8]=Y uint16 LE, [8:40] reserved, [40:44]=constant 0x02 0x00 0x00 0x00,
+// [44:50]=timestamp, [50:58] reserved.
+func BuildTouchscreenReport(state TouchState, x, y uint16, ts uint64) []byte {
+	report := make([]byte, TouchscreenReportLen)
+	report[0] = reportIDTouchscreen
+	report[1] = 0x01
+	report[2] = 0x05
+	report[3] = uint8(state)
+	binary.LittleEndian.PutUint16(report[4:6], x)
+	binary.LittleEndian.PutUint16(report[6:8], y)
+	report[40] = 0x02
+	putTimestamp(report[44:50], ts)
+	return report
+}
+
+// BuildKeyboardReport builds a virtual-keyboard report from the set of HID
+// keyboard usages (page 0x07) currently held down. Use Timestamp for ts.
+//
+// The report carries the full pressed set rather than a delta, so releasing a key
+// means rebuilding without it. Bit u%8 of byte 1+(u/8) is set when usage u is
+// pressed; usages at or above 240 cannot be represented and are ignored.
+//
+// Layout: [0]=report ID, [1:31]=240-bit usage bitmap, [31:37]=timestamp,
+// [37:39] reserved.
+func BuildKeyboardReport(usages []uint8, ts uint64) []byte {
+	report := make([]byte, KeyboardReportLen)
+	report[0] = reportIDKeyboard
+	for _, usage := range usages {
+		if usage >= maxKeyboardUsage {
+			continue
+		}
+		report[1+usage/8] |= 1 << (usage % 8)
+	}
+	putTimestamp(report[31:37], ts)
+	return report
+}

--- a/ios/hid/report_test.go
+++ b/ios/hid/report_test.go
@@ -1,0 +1,208 @@
+package hid
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// goldenTimestamp is an arbitrary 48-bit value with distinct bytes, so a
+// mis-ordered or mis-sized timestamp field shows up immediately.
+const goldenTimestamp uint64 = 0x123456789ABC
+
+// The expected byte strings below were produced by the reference implementation
+// in pymobiledevice3 (remote/core_device/hid_service.py) at goldenTimestamp, so
+// these tests pin this port to the wire format the device is known to accept
+// rather than to our own reading of it.
+
+func TestBuildDigitizerReport(t *testing.T) {
+	tests := []struct {
+		name string
+		x, y int32
+		want string
+	}{
+		{
+			name: "positive coordinates",
+			x:    100,
+			y:    200,
+			want: "1364000000c80000000000bc9a785634120000",
+		},
+		{
+			// Coordinates are signed, so negatives must sign-extend across all
+			// four bytes rather than being clamped at zero.
+			name: "negative coordinates",
+			x:    -1,
+			y:    -2,
+			want: "13fffffffffeffffff0000bc9a785634120000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildDigitizerReport(tt.x, tt.y, goldenTimestamp)
+			if len(got) != DigitizerReportLen {
+				t.Errorf("length = %d, want %d", len(got), DigitizerReportLen)
+			}
+			if hex.EncodeToString(got) != tt.want {
+				t.Errorf("report mismatch\n got %s\nwant %s", hex.EncodeToString(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildTouchscreenReport(t *testing.T) {
+	tests := []struct {
+		name  string
+		state TouchState
+		x, y  uint16
+		want  string
+	}{
+		{
+			name:  "contact",
+			state: TouchContact,
+			x:     500,
+			y:     1000,
+			want: "090105c2f401e803000000000000000000000000000000000000000000000000" +
+				"000000000000000002000000bc9a785634120000000000000000",
+		},
+		{
+			name:  "release",
+			state: TouchRelease,
+			x:     500,
+			y:     1000,
+			want: "09010502f401e803000000000000000000000000000000000000000000000000" +
+				"000000000000000002000000bc9a785634120000000000000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildTouchscreenReport(tt.state, tt.x, tt.y, goldenTimestamp)
+			if len(got) != TouchscreenReportLen {
+				t.Errorf("length = %d, want %d", len(got), TouchscreenReportLen)
+			}
+			if hex.EncodeToString(got) != tt.want {
+				t.Errorf("report mismatch\n got %s\nwant %s", hex.EncodeToString(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildKeyboardReport(t *testing.T) {
+	tests := []struct {
+		name   string
+		usages []uint8
+		want   string
+	}{
+		{
+			name:   "no keys pressed releases everything",
+			usages: nil,
+			want:   "01" + "000000000000000000000000000000000000000000000000000000000000" + "bc9a785634120000",
+		},
+		{
+			// Usage 0x04 is bit 4 of the first bitmap byte.
+			name:   "single letter",
+			usages: []uint8{KeyA},
+			want:   "01" + "100000000000000000000000000000000000000000000000000000000000" + "bc9a785634120000",
+		},
+		{
+			// Left-Shift is usage 0xE1, i.e. bit 1 of bitmap byte 28.
+			name:   "letter with modifier",
+			usages: []uint8{KeyA, KeyLeftShift},
+			want:   "01" + "100000000000000000000000000000000000000000000000000000000200" + "bc9a785634120000",
+		},
+		{
+			name:   "highest representable usage",
+			usages: []uint8{239},
+			want:   "01" + "000000000000000000000000000000000000000000000000000000000080" + "bc9a785634120000",
+		},
+		{
+			// The bitmap is 240 bits wide, so anything beyond it has to be
+			// dropped rather than wrapping onto another key or panicking.
+			name:   "usage beyond the bitmap is ignored",
+			usages: []uint8{240},
+			want:   "01" + "000000000000000000000000000000000000000000000000000000000000" + "bc9a785634120000",
+		},
+		{
+			name:   "usage beyond the bitmap does not panic at the top of the range",
+			usages: []uint8{255},
+			want:   "01" + "000000000000000000000000000000000000000000000000000000000000" + "bc9a785634120000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildKeyboardReport(tt.usages, goldenTimestamp)
+			if len(got) != KeyboardReportLen {
+				t.Errorf("length = %d, want %d", len(got), KeyboardReportLen)
+			}
+			if hex.EncodeToString(got) != tt.want {
+				t.Errorf("report mismatch\n got %s\nwant %s", hex.EncodeToString(got), tt.want)
+			}
+		})
+	}
+}
+
+// The timestamp field is six bytes wide, so a value that does not fit has to be
+// truncated to its low 48 bits instead of corrupting the trailing reserved bytes.
+func TestTimestampIsTruncatedToFieldWidth(t *testing.T) {
+	got := BuildDigitizerReport(0, 0, 0xFFFFFFFFFFFFFFFF)
+	want := "1300000000000000000000ffffffffffff0000"
+	if hex.EncodeToString(got) != want {
+		t.Errorf("oversized timestamp not masked\n got %s\nwant %s", hex.EncodeToString(got), want)
+	}
+	if len(got) != DigitizerReportLen {
+		t.Errorf("length = %d, want %d", len(got), DigitizerReportLen)
+	}
+}
+
+func TestTimestampFitsInFieldAndAdvances(t *testing.T) {
+	first := Timestamp()
+	if first >= 1<<timestampBits {
+		t.Errorf("Timestamp() = %d, wider than the %d-bit field", first, timestampBits)
+	}
+	second := Timestamp()
+	if second < first {
+		t.Errorf("Timestamp() went backwards: %d then %d", first, second)
+	}
+}
+
+func TestKeyForRune(t *testing.T) {
+	tests := []struct {
+		ch    rune
+		usage uint8
+		shift bool
+	}{
+		{'a', KeyA, false},
+		{'z', KeyZ, false},
+		{'A', KeyA, true},
+		{'Z', KeyZ, true},
+		{'1', Key1, false},
+		{'9', Key9, false},
+		// '0' sits after '9' in the usage table, not before '1'.
+		{'0', Key0, false},
+		{'!', Key1, true},
+		{')', Key0, true},
+		{' ', KeySpace, false},
+		{'\n', KeyEnter, false},
+		{',', KeyComma, false},
+		{'?', KeySlash, true},
+		{'~', KeyGrave, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.ch), func(t *testing.T) {
+			k, ok := KeyForRune(tt.ch)
+			if !ok {
+				t.Fatalf("KeyForRune(%q) not found", tt.ch)
+			}
+			if k.Usage != tt.usage || k.Shift != tt.shift {
+				t.Errorf("KeyForRune(%q) = {0x%02X, shift=%v}, want {0x%02X, shift=%v}",
+					tt.ch, k.Usage, k.Shift, tt.usage, tt.shift)
+			}
+		})
+	}
+
+	if _, ok := KeyForRune('é'); ok {
+		t.Error("KeyForRune should report no mapping for a non-US-layout rune")
+	}
+}

--- a/ios/hid/session.go
+++ b/ios/hid/session.go
@@ -1,0 +1,434 @@
+package hid
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/display"
+	"github.com/danielpaulus/go-ios/ios/golog"
+	"github.com/google/uuid"
+)
+
+const logModule = "go-ios/hid"
+
+const (
+	// streamStartTimeout bounds the media-stream negotiation. A wedged
+	// mediastream daemon never answers at all, so failing fast with an
+	// actionable error beats hanging.
+	streamStartTimeout = 10 * time.Second
+
+	// streamStopTimeout bounds the best-effort stop during Close.
+	streamStopTimeout = 5 * time.Second
+
+	// surfaceSettleDelay gives backboardd a moment to re-match the HID surfaces
+	// against the newly authenticated stream. Without it the first report of a
+	// gesture can still land while the surface is externalAccessory and be
+	// dropped.
+	surfaceSettleDelay = 300 * time.Millisecond
+
+	// defaultTypingInterval paces keyboard reports; typing with no delay drops
+	// characters on the device side.
+	defaultTypingInterval = 20 * time.Millisecond
+)
+
+// Point is a position on the touchscreen in normalised coordinates: 0 is the
+// left/top edge and 65535 the right/bottom edge, independent of the display's
+// pixel size or the current orientation.
+type Point struct {
+	X uint16
+	Y uint16
+}
+
+// Session delivers HID input to a device and owns the media stream that touch
+// input requires.
+//
+// Open one session and reuse it for as many gestures as needed. Touch reports
+// only reach the app while a media stream holds dtuhidd's auth gate open, and
+// negotiating a stream per gesture both adds seconds of latency and has been
+// observed to wedge the device's mediastream daemon until it is rebooted.
+//
+// The stream is started lazily, on the first gesture that needs it: pressing
+// hardware buttons never starts one, because the button surface is authenticated
+// out of the box.
+//
+// A Session is safe for concurrent use; gestures are serialised.
+type Session struct {
+	device ios.DeviceEntry
+
+	mutex sync.Mutex
+	hid   *UniversalConnection
+
+	// Stream state, all guarded by mutex and populated by ensureStream.
+	displayService *display.Service
+	receiver       *display.Receiver
+	streamAnswer   display.StreamAnswer
+	drainCancel    context.CancelFunc
+	drainDone      chan struct{}
+
+	// keyboardServiceID is the surface registered on first use by Type.
+	keyboardServiceID uint64
+	keyboardCreated   bool
+
+	closed bool
+
+	// displayID selects which display the stream mirrors.
+	displayID int
+	// typingInterval paces keyboard reports.
+	typingInterval time.Duration
+}
+
+// SessionOption configures a Session at open time.
+type SessionOption func(*Session)
+
+// WithDisplayID selects the display whose stream holds the auth gate open.
+// Defaults to the main display.
+func WithDisplayID(id int) SessionOption {
+	return func(s *Session) { s.displayID = id }
+}
+
+// WithTypingInterval sets the delay between keyboard reports sent by Type.
+func WithTypingInterval(d time.Duration) SessionOption {
+	return func(s *Session) { s.typingInterval = d }
+}
+
+// NewSession connects to the HID service on the device. It does not start a
+// media stream: that happens on the first gesture that needs one.
+//
+// Requires iOS 17+ with the Developer Disk Image mounted, and - because touch
+// input needs the device to stream back to the host - a kernel tunnel. On a
+// userspace tunnel the session opens but the first touch fails with
+// display.ErrUserspaceTunnelUnsupported.
+func NewSession(device ios.DeviceEntry, opts ...SessionOption) (*Session, error) {
+	s := &Session{
+		device:         device,
+		displayID:      display.DefaultDisplayID,
+		typingInterval: defaultTypingInterval,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	conn, err := NewUniversal(device)
+	if err != nil {
+		return nil, fmt.Errorf("NewSession: %w", err)
+	}
+	s.hid = conn
+	return s, nil
+}
+
+// ListServices enumerates the HID surfaces registered on the device.
+func (s *Session) ListServices() (map[string]interface{}, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if err := s.checkOpen(); err != nil {
+		return nil, err
+	}
+	return s.hid.ListConnectedServices()
+}
+
+// Tap taps once at p: one contact report followed by a release at the same
+// position.
+func (s *Session) Tap(ctx context.Context, p Point) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if err := s.beginGatedGesture(ctx); err != nil {
+		return err
+	}
+	if err := s.hid.SendTouchscreen(TouchContact, p.X, p.Y, SurfaceMainTouchscreen); err != nil {
+		return fmt.Errorf("Tap: %w", err)
+	}
+	if err := s.hid.SendTouchscreen(TouchRelease, p.X, p.Y, SurfaceMainTouchscreen); err != nil {
+		return fmt.Errorf("Tap: %w", err)
+	}
+	return nil
+}
+
+// Drag holds a contact down while moving it from one point to another, then
+// releases at the end position.
+//
+// steps is how many intermediate contact samples to send and duration how long
+// the drag takes; together they set the velocity the device's gesture recogniser
+// reads from the report timestamps. A short duration over a modest distance
+// reads as a flick - which is how VoiceOver navigation is driven - while a long
+// one reads as a slow drag. steps below 1 is treated as 1.
+func (s *Session) Drag(ctx context.Context, from, to Point, steps int, duration time.Duration) error {
+	if steps < 1 {
+		steps = 1
+	}
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if err := s.beginGatedGesture(ctx); err != nil {
+		return err
+	}
+
+	var interval time.Duration
+	if duration > 0 {
+		interval = duration / time.Duration(steps)
+	}
+	for i := 1; i <= steps; i++ {
+		x := interpolate(from.X, to.X, i, steps)
+		y := interpolate(from.Y, to.Y, i, steps)
+		if err := s.hid.SendTouchscreen(TouchContact, x, y, SurfaceMainTouchscreen); err != nil {
+			return fmt.Errorf("Drag: contact sample %d/%d: %w", i, steps, err)
+		}
+		if interval > 0 && i < steps {
+			if err := sleepCtx(ctx, interval); err != nil {
+				return fmt.Errorf("Drag: %w", err)
+			}
+		}
+	}
+	if err := s.hid.SendTouchscreen(TouchRelease, to.X, to.Y, SurfaceMainTouchscreen); err != nil {
+		return fmt.Errorf("Drag: release: %w", err)
+	}
+	return nil
+}
+
+// Move posts a single pointer sample on the gesture surface. It moves the
+// pointer a mirroring host draws without putting a contact on the screen, so it
+// does not by itself produce a touch.
+func (s *Session) Move(ctx context.Context, x, y int32) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if err := s.beginGatedGesture(ctx); err != nil {
+		return err
+	}
+	if err := s.hid.SendDigitizer(x, y, SurfaceTouchscreenGesture); err != nil {
+		return fmt.Errorf("Move: %w", err)
+	}
+	return nil
+}
+
+// Type sends text through a virtual keyboard, registering the keyboard surface
+// on first use. Characters without a HID mapping are skipped.
+func (s *Session) Type(ctx context.Context, text string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if err := s.beginGatedGesture(ctx); err != nil {
+		return err
+	}
+	if !s.keyboardCreated {
+		id, err := s.hid.CreateKeyboardService(SurfaceKeyboardDefault, "go-ios Keyboard", "go-ios", 0x05AC, 0x0267)
+		if err != nil {
+			return fmt.Errorf("Type: %w", err)
+		}
+		s.keyboardServiceID = id
+		s.keyboardCreated = true
+	}
+
+	for _, ch := range text {
+		key, ok := KeyForRune(ch)
+		if !ok {
+			golog.Warn("skipping character without a HID mapping", "module", logModule, "char", string(ch))
+			continue
+		}
+		usages := []uint8{key.Usage}
+		if key.Shift {
+			usages = append(usages, KeyLeftShift)
+		}
+		if err := s.hid.SendKeyboard(s.keyboardServiceID, usages...); err != nil {
+			return fmt.Errorf("Type: failed to press %q: %w", string(ch), err)
+		}
+		// Release everything before the next character, otherwise repeated
+		// characters collapse into one keypress.
+		if err := s.hid.SendKeyboard(s.keyboardServiceID); err != nil {
+			return fmt.Errorf("Type: failed to release %q: %w", string(ch), err)
+		}
+		if err := sleepCtx(ctx, s.typingInterval); err != nil {
+			return fmt.Errorf("Type: %w", err)
+		}
+	}
+	return nil
+}
+
+// PressButton presses and releases a hardware button, identified in HID terms:
+// usage page 0x0C (Consumer) covers the media buttons, 0x09 (Button) the generic
+// ones.
+//
+// Buttons need no media stream, so this never starts one.
+func (s *Session) PressButton(ctx context.Context, usagePage, usageCode uint64) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+
+	indigo, err := NewIndigo(s.device)
+	if err != nil {
+		return fmt.Errorf("PressButton: %w", err)
+	}
+	defer indigo.Close()
+
+	if err := indigo.SendButton(usagePage, usageCode, ButtonDown); err != nil {
+		return fmt.Errorf("PressButton: %w", err)
+	}
+	if err := indigo.SendButton(usagePage, usageCode, ButtonUp); err != nil {
+		return fmt.Errorf("PressButton: %w", err)
+	}
+	return nil
+}
+
+// Close stops the media stream if one is running and closes every connection.
+// It is idempotent.
+func (s *Session) Close() error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+
+	s.teardownStream()
+
+	if s.hid != nil {
+		if err := s.hid.Close(); err != nil {
+			return fmt.Errorf("Session.Close: %w", err)
+		}
+		s.hid = nil
+	}
+	return nil
+}
+
+// StreamActive reports whether the media stream that gates touch input is
+// currently running. Exposed for diagnostics and tests.
+func (s *Session) StreamActive() bool {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.displayService != nil
+}
+
+// beginGatedGesture is the common preamble for gestures that need the auth gate
+// open. Call with the mutex held.
+func (s *Session) beginGatedGesture(ctx context.Context) error {
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	return s.ensureStream(ctx)
+}
+
+func (s *Session) checkOpen() error {
+	if s.closed || s.hid == nil {
+		return fmt.Errorf("session is closed")
+	}
+	return nil
+}
+
+// ensureStream starts the media stream that authenticates the touch surfaces,
+// unless it is already running. Call with the mutex held.
+//
+// On any failure it tears down whatever was already set up, so a failed gesture
+// leaves no half-open stream behind and the next attempt starts clean.
+func (s *Session) ensureStream(ctx context.Context) error {
+	if s.displayService != nil {
+		return nil
+	}
+
+	receiver, err := display.OpenReceiver(s.device)
+	if err != nil {
+		return fmt.Errorf("failed to prepare the media stream touch input requires: %w", err)
+	}
+	s.receiver = receiver
+
+	svc, err := display.New(s.device)
+	if err != nil {
+		s.teardownStream()
+		return fmt.Errorf("failed to prepare the media stream touch input requires: %w", err)
+	}
+	s.displayService = svc
+
+	startCtx, cancel := context.WithTimeout(ctx, streamStartTimeout)
+	defer cancel()
+
+	answer, err := svc.StartVideoStream(startCtx, display.VideoStreamRequest{
+		ReceiverIP:   receiver.IP(),
+		ReceiverPort: receiver.Port(),
+		SenderIP:     s.device.Address,
+		DisplayID:    s.displayID,
+	})
+	if err != nil {
+		s.teardownStream()
+		return fmt.Errorf("failed to start the media stream touch input requires: %w", err)
+	}
+	s.streamAnswer = answer
+
+	drainCtx, drainCancel := context.WithCancel(context.Background())
+	s.drainCancel = drainCancel
+	s.drainDone = make(chan struct{})
+	go func(done chan struct{}) {
+		defer close(done)
+		receiver.Drain(drainCtx)
+	}(s.drainDone)
+
+	golog.Debug("media stream started, touch surfaces authenticated", "module", logModule,
+		"receiver", receiver.IP(), "port", receiver.Port())
+
+	if err := sleepCtx(ctx, surfaceSettleDelay); err != nil {
+		s.teardownStream()
+		return err
+	}
+	return nil
+}
+
+// teardownStream reverses ensureStream. Call with the mutex held. Safe to call
+// at any point of a partially completed setup.
+func (s *Session) teardownStream() {
+	if s.drainCancel != nil {
+		s.drainCancel()
+		s.drainCancel = nil
+	}
+
+	if s.displayService != nil {
+		if s.streamAnswer.ClientSessionID != uuid.Nil {
+			stopCtx, cancel := context.WithTimeout(context.Background(), streamStopTimeout)
+			// The device routinely drops the channel while processing the stop,
+			// which surfaces as an error even though the stop took effect.
+			if err := s.displayService.StopMediaStream(stopCtx, s.streamAnswer.ClientSessionID); err != nil {
+				golog.Debug("stopping the media stream reported an error, which is expected when the device closes the channel first",
+					"module", logModule, "error", err)
+			}
+			cancel()
+		}
+		if err := s.displayService.Close(); err != nil {
+			golog.Debug("closing the display service failed", "module", logModule, "error", err)
+		}
+		s.displayService = nil
+	}
+
+	if s.receiver != nil {
+		if err := s.receiver.Close(); err != nil {
+			golog.Debug("closing the RTP receiver failed", "module", logModule, "error", err)
+		}
+		s.receiver = nil
+	}
+
+	// The drain goroutine exits once the socket is closed; wait so Close does
+	// not leave it running.
+	if s.drainDone != nil {
+		<-s.drainDone
+		s.drainDone = nil
+	}
+
+	s.streamAnswer = display.StreamAnswer{}
+}
+
+func interpolate(from, to uint16, step, steps int) uint16 {
+	delta := (int(to) - int(from)) * step / steps
+	return uint16(int(from) + delta)
+}
+
+// sleepCtx sleeps for d unless ctx is cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/ios/hid/session.go
+++ b/ios/hid/session.go
@@ -90,25 +90,6 @@ type Session struct {
 	keyboardCreated   bool
 
 	closed bool
-
-	// displayID selects which display the stream mirrors.
-	displayID int
-	// typingInterval paces keyboard reports.
-	typingInterval time.Duration
-}
-
-// SessionOption configures a Session at open time.
-type SessionOption func(*Session)
-
-// WithDisplayID selects the display whose stream holds the auth gate open.
-// Defaults to the main display.
-func WithDisplayID(id int) SessionOption {
-	return func(s *Session) { s.displayID = id }
-}
-
-// WithTypingInterval sets the delay between keyboard reports sent by Type.
-func WithTypingInterval(d time.Duration) SessionOption {
-	return func(s *Session) { s.typingInterval = d }
 }
 
 // NewSession connects to the HID service on the device. It does not start a
@@ -119,15 +100,8 @@ func WithTypingInterval(d time.Duration) SessionOption {
 // older versions and on a userspace tunnel; the first gesture needing a stream
 // is what fails, with CoreDevice error 9021 below iOS 27 and with
 // display.ErrUserspaceTunnelUnsupported on a userspace tunnel.
-func NewSession(device ios.DeviceEntry, opts ...SessionOption) (*Session, error) {
-	s := &Session{
-		device:         device,
-		displayID:      display.DefaultDisplayID,
-		typingInterval: defaultTypingInterval,
-	}
-	for _, opt := range opts {
-		opt(s)
-	}
+func NewSession(device ios.DeviceEntry) (*Session, error) {
+	s := &Session{device: device}
 
 	conn, err := NewUniversal(device)
 	if err != nil {
@@ -318,7 +292,7 @@ func (s *Session) Type(ctx context.Context, text string) error {
 		if err := s.hid.SendKeyboard(s.keyboardServiceID); err != nil {
 			return fmt.Errorf("Type: failed to release %q: %w", string(ch), err)
 		}
-		if err := sleepCtx(ctx, s.typingInterval); err != nil {
+		if err := sleepCtx(ctx, defaultTypingInterval); err != nil {
 			return fmt.Errorf("Type: %w", err)
 		}
 	}
@@ -534,7 +508,7 @@ func (s *Session) ensureStream(ctx context.Context) error {
 		ReceiverIP:   receiver.IP(),
 		ReceiverPort: receiver.Port(),
 		SenderIP:     s.device.Address,
-		DisplayID:    s.displayID,
+		DisplayID:    display.DefaultDisplayID,
 	})
 	s.streamAnswer = answer
 	if err != nil {

--- a/ios/hid/session.go
+++ b/ios/hid/session.go
@@ -18,8 +18,11 @@ const logModule = "go-ios/hid"
 const (
 	// streamStartTimeout bounds the media-stream negotiation. A wedged
 	// mediastream daemon never answers at all, so failing fast with an
-	// actionable error beats hanging.
-	streamStartTimeout = 10 * time.Second
+	// actionable error beats hanging. It is deliberately longer than the
+	// deadline the device applies to its own side (display's
+	// negotiationTimeoutSeconds): the device gives up first and tells us, rather
+	// than us abandoning a negotiation it goes on to complete.
+	streamStartTimeout = 15 * time.Second
 
 	// streamStopTimeout bounds the best-effort stop during Close.
 	streamStopTimeout = 5 * time.Second

--- a/ios/hid/session.go
+++ b/ios/hid/session.go
@@ -448,12 +448,13 @@ func (s *Session) teardownStream() {
 	if s.displayService != nil {
 		if s.streamAnswer.ClientSessionID != uuid.Nil {
 			stopCtx, cancel := context.WithTimeout(context.Background(), streamStopTimeout)
-			// The device routinely drops the channel while processing the stop,
-			// which surfaces as an error even though the stop took effect. The
-			// receiver is still draining here, so the device is not throttled
-			// while it works through it.
+			// The receiver is still draining here, so the device is not
+			// throttled while it works through the stop. An error is worth
+			// surfacing: a stream left running is what wedges the device's
+			// mediastream daemon, though the device dropping the channel
+			// mid-stop is normal and means the stop took effect.
 			if err := s.displayService.StopMediaStream(stopCtx, s.streamAnswer.ClientSessionID); err != nil {
-				golog.Debug("stopping the media stream reported an error, which is expected when the device closes the channel first",
+				golog.Warn("stopping the media stream failed; if this repeats, the device may need a reboot",
 					"module", logModule, "error", err)
 			}
 			cancel()

--- a/ios/hid/session.go
+++ b/ios/hid/session.go
@@ -541,7 +541,10 @@ func (s *Session) ensureStream(ctx context.Context) error {
 		return fmt.Errorf("failed to start the media stream touch input requires: %w", err)
 	}
 
-	golog.Debug("media stream started, touch surfaces authenticated", "module", logModule,
+	// Logged at info: it happens once per session, and it is the only positive
+	// evidence that touch reports will actually reach the app rather than being
+	// silently discarded.
+	golog.Info("media stream started, touch surfaces authenticated", "module", logModule,
 		"receiver", receiver.IP(), "port", receiver.Port())
 
 	// Give backboardd a moment to re-match the surfaces against the new stream.

--- a/ios/hid/session.go
+++ b/ios/hid/session.go
@@ -439,6 +439,24 @@ func (s *Session) StreamActive() bool {
 	return s.displayService != nil && !s.streamLost.Load()
 }
 
+// EnsureStream starts the media stream that gates touch input, unless one is
+// already running.
+//
+// Gestures start it on demand, so calling this is optional. It matters for
+// callers driving touches from a live input stream: on the first gesture the
+// negotiation and the surface settle delay land in the middle of that gesture,
+// and reports sent before the surfaces are authenticated are discarded without
+// error - so the first drag of a session can silently do nothing. Calling this
+// once after NewSession moves that cost, and any failure, to session setup.
+func (s *Session) EnsureStream(ctx context.Context) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	return s.ensureStream(ctx)
+}
+
 // beginGatedGesture is the common preamble for gestures that need the auth gate
 // open. Call with the mutex held.
 func (s *Session) beginGatedGesture(ctx context.Context) error {

--- a/ios/hid/session.go
+++ b/ios/hid/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/danielpaulus/go-ios/ios"
@@ -61,12 +62,19 @@ type Session struct {
 	mutex sync.Mutex
 	hid   *UniversalConnection
 
+	// indigo is created on the first button press and reused afterwards, so a
+	// script full of button presses does not redial the service each time.
+	indigo *IndigoConnection
+
 	// Stream state, all guarded by mutex and populated by ensureStream.
 	displayService *display.Service
 	receiver       *display.Receiver
 	streamAnswer   display.StreamAnswer
-	drainCancel    context.CancelFunc
 	drainDone      chan struct{}
+	// streamLost is set by the drain goroutine when the host stops receiving the
+	// stream. Reports would still be accepted and silently dropped from that
+	// point on, so the next gesture re-negotiates instead.
+	streamLost atomic.Bool
 
 	// keyboardServiceID is the surface registered on first use by Type.
 	keyboardServiceID uint64
@@ -164,39 +172,55 @@ func (s *Session) Drag(ctx context.Context, from, to Point, steps int, duration 
 		return err
 	}
 
+	// Once a contact is down the device believes a finger is on the screen until
+	// it is lifted, so the release has to happen even if a sample or the context
+	// fails part way through - otherwise every later gesture, in this session or
+	// the next, lands on a device that still thinks it is being touched.
+	contactDown := false
+	defer func() {
+		if !contactDown {
+			return
+		}
+		if err := s.hid.SendTouchscreen(TouchRelease, to.X, to.Y, SurfaceMainTouchscreen); err != nil {
+			golog.Warn("failed to lift the contact after a drag, the device may still consider the screen touched",
+				"module", logModule, "error", err)
+		}
+	}()
+
 	var interval time.Duration
 	if duration > 0 {
 		interval = duration / time.Duration(steps)
 	}
-	for i := 1; i <= steps; i++ {
+	// steps is the number of moves, so steps+1 samples are sent: the touch-down
+	// at from, which is what UIKit hit-tests, then one per step up to to.
+	for i := 0; i <= steps; i++ {
 		x := interpolate(from.X, to.X, i, steps)
 		y := interpolate(from.Y, to.Y, i, steps)
 		if err := s.hid.SendTouchscreen(TouchContact, x, y, SurfaceMainTouchscreen); err != nil {
 			return fmt.Errorf("Drag: contact sample %d/%d: %w", i, steps, err)
 		}
-		if interval > 0 && i < steps {
-			if err := sleepCtx(ctx, interval); err != nil {
-				return fmt.Errorf("Drag: %w", err)
-			}
+		contactDown = true
+		if err := sleepCtx(ctx, interval); err != nil {
+			return fmt.Errorf("Drag: %w", err)
 		}
-	}
-	if err := s.hid.SendTouchscreen(TouchRelease, to.X, to.Y, SurfaceMainTouchscreen); err != nil {
-		return fmt.Errorf("Drag: release: %w", err)
 	}
 	return nil
 }
 
-// Move posts a single pointer sample on the gesture surface. It moves the
-// pointer a mirroring host draws without putting a contact on the screen, so it
-// does not by itself produce a touch.
-func (s *Session) Move(ctx context.Context, x, y int32) error {
+// MoveDigitizer posts a single pointer sample on the trackpad-style gesture
+// surface. It moves the pointer a mirroring host draws without putting a contact
+// on the screen, so it does not by itself produce a touch.
+//
+// Unlike Tap and Drag, which take normalised Points, the coordinates here are
+// the gesture surface's own digitizer units.
+func (s *Session) MoveDigitizer(ctx context.Context, x, y int32) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	if err := s.beginGatedGesture(ctx); err != nil {
 		return err
 	}
 	if err := s.hid.SendDigitizer(x, y, SurfaceTouchscreenGesture); err != nil {
-		return fmt.Errorf("Move: %w", err)
+		return fmt.Errorf("MoveDigitizer: %w", err)
 	}
 	return nil
 }
@@ -217,6 +241,15 @@ func (s *Session) Type(ctx context.Context, text string) error {
 		s.keyboardServiceID = id
 		s.keyboardCreated = true
 	}
+
+	// A key stays held on the device until a report without it arrives, so make
+	// sure everything is released even if we stop mid-word.
+	defer func() {
+		if err := s.hid.SendKeyboard(s.keyboardServiceID); err != nil {
+			golog.Warn("failed to release the keyboard, the device may still consider a key held",
+				"module", logModule, "error", err)
+		}
+	}()
 
 	for _, ch := range text {
 		key, ok := KeyForRune(ch)
@@ -255,16 +288,24 @@ func (s *Session) PressButton(ctx context.Context, usagePage, usageCode uint64) 
 		return err
 	}
 
-	indigo, err := NewIndigo(s.device)
-	if err != nil {
-		return fmt.Errorf("PressButton: %w", err)
+	if s.indigo == nil {
+		indigo, err := NewIndigo(s.device)
+		if err != nil {
+			return fmt.Errorf("PressButton: %w", err)
+		}
+		s.indigo = indigo
 	}
-	defer indigo.Close()
 
-	if err := indigo.SendButton(usagePage, usageCode, ButtonDown); err != nil {
+	if err := s.indigo.SendButton(usagePage, usageCode, ButtonDown); err != nil {
 		return fmt.Errorf("PressButton: %w", err)
 	}
-	if err := indigo.SendButton(usagePage, usageCode, ButtonUp); err != nil {
+	if err := s.indigo.SendButton(usagePage, usageCode, ButtonUp); err != nil {
+		// The device considers the button held until it hears otherwise; cancel
+		// the press so it does not stay down.
+		if cancelErr := s.indigo.SendButton(usagePage, usageCode, ButtonCanceled); cancelErr != nil {
+			golog.Warn("failed to cancel a button press, the device may still consider it held",
+				"module", logModule, "error", cancelErr)
+		}
 		return fmt.Errorf("PressButton: %w", err)
 	}
 	return nil
@@ -272,6 +313,9 @@ func (s *Session) PressButton(ctx context.Context, usagePage, usageCode uint64) 
 
 // Close stops the media stream if one is running and closes every connection.
 // It is idempotent.
+//
+// Close waits for any gesture in flight, including a media-stream negotiation,
+// so it can block for as long as that negotiation is allowed to take.
 func (s *Session) Close() error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -282,6 +326,13 @@ func (s *Session) Close() error {
 
 	s.teardownStream()
 
+	if s.indigo != nil {
+		if err := s.indigo.Close(); err != nil {
+			golog.Debug("closing the Indigo connection failed", "module", logModule, "error", err)
+		}
+		s.indigo = nil
+	}
+
 	if s.hid != nil {
 		if err := s.hid.Close(); err != nil {
 			return fmt.Errorf("Session.Close: %w", err)
@@ -291,12 +342,13 @@ func (s *Session) Close() error {
 	return nil
 }
 
-// StreamActive reports whether the media stream that gates touch input is
-// currently running. Exposed for diagnostics and tests.
+// StreamActive reports whether a media stream is currently holding the touch
+// auth gate open. It turns false again if the host stops receiving the stream.
+// Exposed for diagnostics and tests.
 func (s *Session) StreamActive() bool {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	return s.displayService != nil
+	return s.displayService != nil && !s.streamLost.Load()
 }
 
 // beginGatedGesture is the common preamble for gestures that need the auth gate
@@ -316,13 +368,21 @@ func (s *Session) checkOpen() error {
 }
 
 // ensureStream starts the media stream that authenticates the touch surfaces,
-// unless it is already running. Call with the mutex held.
+// unless one is already running. Call with the mutex held.
+//
+// A stream the host has stopped receiving is torn down and re-negotiated: the
+// device would keep accepting reports and silently dropping them, which is the
+// failure this package exists to prevent.
 //
 // On any failure it tears down whatever was already set up, so a failed gesture
 // leaves no half-open stream behind and the next attempt starts clean.
 func (s *Session) ensureStream(ctx context.Context) error {
 	if s.displayService != nil {
-		return nil
+		if !s.streamLost.Load() {
+			return nil
+		}
+		golog.Warn("the media stream stopped, re-negotiating before continuing", "module", logModule)
+		s.teardownStream()
 	}
 
 	receiver, err := display.OpenReceiver(s.device)
@@ -338,52 +398,57 @@ func (s *Session) ensureStream(ctx context.Context) error {
 	}
 	s.displayService = svc
 
+	// Start draining before the stream is negotiated: the device begins sending
+	// as soon as it answers, and an unread socket makes it throttle its encoder.
+	s.streamLost.Store(false)
+	s.drainDone = make(chan struct{})
+	go func(done chan struct{}) {
+		defer close(done)
+		if err := receiver.Drain(); err != nil {
+			golog.Warn("the media stream that gates touch input stopped",
+				"module", logModule, "error", err)
+			s.streamLost.Store(true)
+		}
+	}(s.drainDone)
+
 	startCtx, cancel := context.WithTimeout(ctx, streamStartTimeout)
 	defer cancel()
 
+	// The answer carries the session id even on failure, because the device may
+	// have brought the stream up anyway; keep it so teardown can stop it.
 	answer, err := svc.StartVideoStream(startCtx, display.VideoStreamRequest{
 		ReceiverIP:   receiver.IP(),
 		ReceiverPort: receiver.Port(),
 		SenderIP:     s.device.Address,
 		DisplayID:    s.displayID,
 	})
+	s.streamAnswer = answer
 	if err != nil {
 		s.teardownStream()
 		return fmt.Errorf("failed to start the media stream touch input requires: %w", err)
 	}
-	s.streamAnswer = answer
-
-	drainCtx, drainCancel := context.WithCancel(context.Background())
-	s.drainCancel = drainCancel
-	s.drainDone = make(chan struct{})
-	go func(done chan struct{}) {
-		defer close(done)
-		receiver.Drain(drainCtx)
-	}(s.drainDone)
 
 	golog.Debug("media stream started, touch surfaces authenticated", "module", logModule,
 		"receiver", receiver.IP(), "port", receiver.Port())
 
-	if err := sleepCtx(ctx, surfaceSettleDelay); err != nil {
-		s.teardownStream()
-		return err
-	}
+	// Give backboardd a moment to re-match the surfaces against the new stream.
+	// This is deliberately not tied to ctx: the stream is already negotiated, and
+	// discarding it here would mean re-negotiating on the next gesture, which is
+	// the churn that wedges the device's mediastream daemon.
+	time.Sleep(surfaceSettleDelay)
 	return nil
 }
 
 // teardownStream reverses ensureStream. Call with the mutex held. Safe to call
 // at any point of a partially completed setup.
 func (s *Session) teardownStream() {
-	if s.drainCancel != nil {
-		s.drainCancel()
-		s.drainCancel = nil
-	}
-
 	if s.displayService != nil {
 		if s.streamAnswer.ClientSessionID != uuid.Nil {
 			stopCtx, cancel := context.WithTimeout(context.Background(), streamStopTimeout)
 			// The device routinely drops the channel while processing the stop,
-			// which surfaces as an error even though the stop took effect.
+			// which surfaces as an error even though the stop took effect. The
+			// receiver is still draining here, so the device is not throttled
+			// while it works through it.
 			if err := s.displayService.StopMediaStream(stopCtx, s.streamAnswer.ClientSessionID); err != nil {
 				golog.Debug("stopping the media stream reported an error, which is expected when the device closes the channel first",
 					"module", logModule, "error", err)
@@ -396,32 +461,36 @@ func (s *Session) teardownStream() {
 		s.displayService = nil
 	}
 
+	// Closing the socket is what unblocks Drain: a blocked read is not
+	// interrupted by anything else, so this has to happen before the wait below.
 	if s.receiver != nil {
 		if err := s.receiver.Close(); err != nil {
 			golog.Debug("closing the RTP receiver failed", "module", logModule, "error", err)
 		}
 		s.receiver = nil
 	}
-
-	// The drain goroutine exits once the socket is closed; wait so Close does
-	// not leave it running.
 	if s.drainDone != nil {
 		<-s.drainDone
 		s.drainDone = nil
 	}
 
 	s.streamAnswer = display.StreamAnswer{}
+	s.streamLost.Store(false)
 }
 
+// interpolate returns the coordinate at step of steps between from and to.
+// The arithmetic is 64-bit: the product reaches 65535*steps, which overflows a
+// 32-bit int on the platforms go-ios builds for.
 func interpolate(from, to uint16, step, steps int) uint16 {
-	delta := (int(to) - int(from)) * step / steps
-	return uint16(int(from) + delta)
+	delta := (int64(to) - int64(from)) * int64(step) / int64(steps)
+	return uint16(int64(from) + delta)
 }
 
-// sleepCtx sleeps for d unless ctx is cancelled first.
+// sleepCtx sleeps for d unless ctx is cancelled first. A non-positive d does not
+// sleep and does not report the context: callers check ctx where it matters.
 func sleepCtx(ctx context.Context, d time.Duration) error {
 	if d <= 0 {
-		return ctx.Err()
+		return nil
 	}
 	timer := time.NewTimer(d)
 	defer timer.Stop()

--- a/ios/hid/session.go
+++ b/ios/hid/session.go
@@ -54,9 +54,9 @@ type Point struct {
 // negotiating a stream per gesture both adds seconds of latency and has been
 // observed to wedge the device's mediastream daemon until it is rebooted.
 //
-// The stream is started lazily, on the first gesture that needs it: pressing
-// hardware buttons never starts one, because the button surface is authenticated
-// out of the box.
+// The stream is started lazily, on the first gesture that needs it. Pressing
+// hardware buttons never starts one: dtuhidd already reports that surface as
+// authenticated.
 //
 // A Session is safe for concurrent use; gestures are serialised.
 type Session struct {
@@ -114,10 +114,11 @@ func WithTypingInterval(d time.Duration) SessionOption {
 // NewSession connects to the HID service on the device. It does not start a
 // media stream: that happens on the first gesture that needs one.
 //
-// Requires iOS 17+ with the Developer Disk Image mounted, and - because touch
-// input needs the device to stream back to the host - a kernel tunnel. On a
-// userspace tunnel the session opens but the first touch fails with
-// display.ErrUserspaceTunnelUnsupported.
+// Requires the Developer Disk Image mounted, iOS 27 or later, and - because the
+// device streams back to the host - a kernel tunnel. The session still opens on
+// older versions and on a userspace tunnel; the first gesture needing a stream
+// is what fails, with CoreDevice error 9021 below iOS 27 and with
+// display.ErrUserspaceTunnelUnsupported on a userspace tunnel.
 func NewSession(device ios.DeviceEntry, opts ...SessionOption) (*Session, error) {
 	s := &Session{
 		device:         device,

--- a/ios/hid/session.go
+++ b/ios/hid/session.go
@@ -79,6 +79,12 @@ type Session struct {
 	// point on, so the next gesture re-negotiates instead.
 	streamLost atomic.Bool
 
+	// contactDown tracks a contact held by the streaming Touch* methods, so a
+	// session that is closed mid-gesture can lift it instead of leaving the
+	// device believing a finger is still on the screen.
+	contactDown bool
+	lastContact Point
+
 	// keyboardServiceID is the surface registered on first use by Type.
 	keyboardServiceID uint64
 	keyboardCreated   bool
@@ -318,6 +324,61 @@ func (s *Session) Type(ctx context.Context, text string) error {
 	return nil
 }
 
+// TouchDown puts a contact on the screen at p and leaves it there.
+//
+// TouchDown, TouchMove and TouchUp are the streaming counterpart to Tap and
+// Drag: they exist for live input, where each pointer sample arrives separately
+// (a user dragging a finger in a remote-control UI) rather than as a gesture
+// known up front. The device's model is absolute - every contact report says
+// "in contact at this position" - so a stream is TouchDown, any number of
+// TouchMove, then TouchUp.
+//
+// A contact left down is released by Close, but a caller that drops a stream
+// should send TouchUp itself: until then the device believes a finger is down
+// and interprets everything else in that light.
+func (s *Session) TouchDown(ctx context.Context, p Point) error {
+	return s.sendContact(ctx, p, "TouchDown")
+}
+
+// TouchMove moves a contact that is already down. It is equivalent to
+// TouchDown at the new position - the device tracks position, not transitions -
+// but the separate name keeps caller code honest about intent.
+func (s *Session) TouchMove(ctx context.Context, p Point) error {
+	return s.sendContact(ctx, p, "TouchMove")
+}
+
+// TouchUp lifts the contact at p. It is a no-op when nothing is down, so an
+// input stream that sends a stray release cannot desynchronise the device.
+func (s *Session) TouchUp(ctx context.Context, p Point) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if err := s.checkOpen(); err != nil {
+		return err
+	}
+	if !s.contactDown {
+		return nil
+	}
+	if err := s.hid.SendTouchscreen(TouchRelease, p.X, p.Y, SurfaceMainTouchscreen); err != nil {
+		return fmt.Errorf("TouchUp: %w", err)
+	}
+	s.contactDown = false
+	return nil
+}
+
+func (s *Session) sendContact(ctx context.Context, p Point, op string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if err := s.beginGatedGesture(ctx); err != nil {
+		return err
+	}
+	if err := s.hid.SendTouchscreen(TouchContact, p.X, p.Y, SurfaceMainTouchscreen); err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	s.contactDown = true
+	s.lastContact = p
+	return nil
+}
+
 // PressButton presses and releases a hardware button, identified in HID terms:
 // usage page 0x0C (Consumer) covers the media buttons, 0x09 (Button) the generic
 // ones.
@@ -365,6 +426,16 @@ func (s *Session) Close() error {
 		return nil
 	}
 	s.closed = true
+
+	// Lift a contact left down by an interrupted input stream first: once the
+	// stream is gone the device would keep believing a finger is on the screen.
+	if s.contactDown {
+		if err := s.hid.SendTouchscreen(TouchRelease, s.lastContact.X, s.lastContact.Y, SurfaceMainTouchscreen); err != nil {
+			golog.Warn("failed to lift a held contact while closing, the device may still consider the screen touched",
+				"module", logModule, "error", err)
+		}
+		s.contactDown = false
+	}
 
 	s.teardownStream()
 

--- a/ios/hid/session.go
+++ b/ios/hid/session.go
@@ -169,42 +169,81 @@ func (s *Session) Drag(ctx context.Context, from, to Point, steps int, duration 
 	if steps < 1 {
 		steps = 1
 	}
+	// steps is the number of moves, so steps+1 samples are sent: the touch-down
+	// at from, which is what UIKit hit-tests, then one per step up to to.
+	points := make([]Point, 0, steps+1)
+	for i := 0; i <= steps; i++ {
+		points = append(points, Point{
+			X: interpolate(from.X, to.X, i, steps),
+			Y: interpolate(from.Y, to.Y, i, steps),
+		})
+	}
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	if err := s.beginGatedGesture(ctx); err != nil {
 		return err
 	}
+	if err := s.stroke(ctx, points, duration); err != nil {
+		return fmt.Errorf("Drag: %w", err)
+	}
+	return nil
+}
 
-	// Once a contact is down the device believes a finger is on the screen until
-	// it is lifted, so the release has to happen even if a sample or the context
-	// fails part way through - otherwise every later gesture, in this session or
-	// the next, lands on a device that still thinks it is being touched.
+// Stroke drags a single contact through every point in order and releases at the
+// last one, which is how any path that is not a straight line - an arc, a
+// circle, a hand-drawn shape - is drawn. Drag is the two-point case.
+//
+// duration is spread evenly across the path, so it sets the speed the device's
+// gesture recogniser reads from the report timestamps. A path of one point is a
+// tap.
+func (s *Session) Stroke(ctx context.Context, points []Point, duration time.Duration) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if err := s.beginGatedGesture(ctx); err != nil {
+		return err
+	}
+	if err := s.stroke(ctx, points, duration); err != nil {
+		return fmt.Errorf("Stroke: %w", err)
+	}
+	return nil
+}
+
+// stroke sends the contact samples for a path. Call with the mutex held and the
+// stream already ensured.
+//
+// Once a contact is down the device believes a finger is on the screen until it
+// is lifted, so the release has to happen even if a sample or the context fails
+// part way through - otherwise every later gesture, in this session or the next,
+// lands on a device that still thinks it is being touched.
+func (s *Session) stroke(ctx context.Context, points []Point, duration time.Duration) error {
+	if len(points) == 0 {
+		return fmt.Errorf("a stroke needs at least one point")
+	}
+
 	contactDown := false
+	last := points[len(points)-1]
 	defer func() {
 		if !contactDown {
 			return
 		}
-		if err := s.hid.SendTouchscreen(TouchRelease, to.X, to.Y, SurfaceMainTouchscreen); err != nil {
-			golog.Warn("failed to lift the contact after a drag, the device may still consider the screen touched",
+		if err := s.hid.SendTouchscreen(TouchRelease, last.X, last.Y, SurfaceMainTouchscreen); err != nil {
+			golog.Warn("failed to lift the contact after a gesture, the device may still consider the screen touched",
 				"module", logModule, "error", err)
 		}
 	}()
 
 	var interval time.Duration
-	if duration > 0 {
-		interval = duration / time.Duration(steps)
+	if duration > 0 && len(points) > 1 {
+		interval = duration / time.Duration(len(points)-1)
 	}
-	// steps is the number of moves, so steps+1 samples are sent: the touch-down
-	// at from, which is what UIKit hit-tests, then one per step up to to.
-	for i := 0; i <= steps; i++ {
-		x := interpolate(from.X, to.X, i, steps)
-		y := interpolate(from.Y, to.Y, i, steps)
-		if err := s.hid.SendTouchscreen(TouchContact, x, y, SurfaceMainTouchscreen); err != nil {
-			return fmt.Errorf("Drag: contact sample %d/%d: %w", i, steps, err)
+	for i, p := range points {
+		if err := s.hid.SendTouchscreen(TouchContact, p.X, p.Y, SurfaceMainTouchscreen); err != nil {
+			return fmt.Errorf("contact sample %d/%d: %w", i+1, len(points), err)
 		}
 		contactDown = true
 		if err := sleepCtx(ctx, interval); err != nil {
-			return fmt.Errorf("Drag: %w", err)
+			return err
 		}
 	}
 	return nil

--- a/ios/hid/session_test.go
+++ b/ios/hid/session_test.go
@@ -72,6 +72,7 @@ func TestClosedSessionRejectsEverything(t *testing.T) {
 	assert.Error(t, s.TouchDown(ctx, Point{}))
 	assert.Error(t, s.TouchMove(ctx, Point{}))
 	assert.Error(t, s.TouchUp(ctx, Point{}))
+	assert.Error(t, s.EnsureStream(ctx))
 	_, err := s.ListServices()
 	assert.Error(t, err)
 }
@@ -99,7 +100,9 @@ func TestUserspaceTunnelIsRejectedForStreams(t *testing.T) {
 		hid:    &UniversalConnection{},
 	}
 
-	err := s.ensureStream(context.Background())
+	// Through the exported entry point, so callers warming the stream up front
+	// see the same refusal a gesture would hit.
+	err := s.EnsureStream(context.Background())
 	assert.ErrorIs(t, err, display.ErrUserspaceTunnelUnsupported)
 	assert.False(t, s.StreamActive(), "a rejected stream must leave no state behind")
 }

--- a/ios/hid/session_test.go
+++ b/ios/hid/session_test.go
@@ -134,6 +134,33 @@ func TestUserspaceTunnelIsRejectedForStreams(t *testing.T) {
 	assert.False(t, s.StreamActive(), "a rejected stream must leave no state behind")
 }
 
+// TestTouchUpWithoutDownIsNoop covers the stray-release case an input stream can
+// produce: it must not error and must not touch the device.
+func TestTouchUpWithoutDownIsNoop(t *testing.T) {
+	s := &Session{hid: &UniversalConnection{}}
+
+	require.NoError(t, s.TouchUp(context.Background(), Point{X: 1, Y: 2}))
+	assert.False(t, s.contactDown)
+}
+
+// TestClosedSessionRejectsStreamingTouches keeps the streaming methods behind
+// the same closed-session guard as the gesture methods.
+func TestClosedSessionRejectsStreamingTouches(t *testing.T) {
+	s := &Session{closed: true}
+	ctx := context.Background()
+
+	assert.Error(t, s.TouchDown(ctx, Point{}))
+	assert.Error(t, s.TouchMove(ctx, Point{}))
+	assert.Error(t, s.TouchUp(ctx, Point{}))
+}
+
+// TestCloseWithoutHeldContactDoesNotPanic guards the Close path that lifts a
+// held contact: with nothing down it must not dereference the connection.
+func TestCloseWithoutHeldContactDoesNotPanic(t *testing.T) {
+	s := &Session{}
+	require.NoError(t, s.Close())
+}
+
 func TestSessionOptions(t *testing.T) {
 	s := &Session{displayID: display.DefaultDisplayID, typingInterval: defaultTypingInterval}
 

--- a/ios/hid/session_test.go
+++ b/ios/hid/session_test.go
@@ -38,10 +38,34 @@ func TestInterpolate(t *testing.T) {
 	}
 }
 
+// TestInterpolateCoversTheWholeGesture pins the sampling contract Drag relies
+// on: step 0 is the touch-down at the start point, which is what UIKit
+// hit-tests, and the last step lands exactly on the target.
+func TestInterpolateCoversTheWholeGesture(t *testing.T) {
+	from, to := uint16(1000), uint16(5000)
+	steps := 4
+
+	assert.Equal(t, from, interpolate(from, to, 0, steps), "step 0 must be the start point")
+	assert.Equal(t, to, interpolate(from, to, steps, steps), "the last step must be the target")
+
+	previous := interpolate(from, to, 0, steps)
+	for i := 1; i <= steps; i++ {
+		current := interpolate(from, to, i, steps)
+		assert.Greater(t, current, previous, "samples must advance monotonically")
+		previous = current
+	}
+}
+
 func TestSleepCtxReturnsAfterDuration(t *testing.T) {
 	start := time.Now()
 	require.NoError(t, sleepCtx(context.Background(), 10*time.Millisecond))
 	assert.GreaterOrEqual(t, time.Since(start), 10*time.Millisecond)
+}
+
+func TestSleepCtxDoesNotSleepForNonPositiveDurations(t *testing.T) {
+	// A zero interval means "no pacing", not "report the context".
+	assert.NoError(t, sleepCtx(context.Background(), 0))
+	assert.NoError(t, sleepCtx(context.Background(), -time.Second))
 }
 
 func TestSleepCtxHonoursCancellation(t *testing.T) {
@@ -60,7 +84,7 @@ func TestClosedSessionRejectsGestures(t *testing.T) {
 	ctx := context.Background()
 	assert.Error(t, s.Tap(ctx, Point{X: 1, Y: 1}))
 	assert.Error(t, s.Drag(ctx, Point{}, Point{X: 1, Y: 1}, 2, 0))
-	assert.Error(t, s.Move(ctx, 1, 1))
+	assert.Error(t, s.MoveDigitizer(ctx, 1, 1))
 	assert.Error(t, s.Type(ctx, "hello"))
 	assert.Error(t, s.PressButton(ctx, 12, 64))
 	_, err := s.ListServices()

--- a/ios/hid/session_test.go
+++ b/ios/hid/session_test.go
@@ -1,0 +1,121 @@
+package hid
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/display"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests cover the session logic that does not need a device: coordinate
+// interpolation, context handling and the closed-session guards. The stream
+// negotiation itself is covered by ios/display's encoder tests and by the
+// on-device checks documented in the package.
+
+func TestInterpolate(t *testing.T) {
+	tests := []struct {
+		name        string
+		from, to    uint16
+		step, steps int
+		want        uint16
+	}{
+		{name: "single step lands on target", from: 0, to: 1000, step: 1, steps: 1, want: 1000},
+		{name: "midpoint", from: 0, to: 1000, step: 1, steps: 2, want: 500},
+		{name: "last step lands on target", from: 0, to: 1000, step: 4, steps: 4, want: 1000},
+		{name: "descending", from: 1000, to: 0, step: 1, steps: 2, want: 500},
+		{name: "no movement", from: 700, to: 700, step: 1, steps: 3, want: 700},
+		{name: "full range does not overflow", from: 0, to: 65535, step: 8, steps: 8, want: 65535},
+		{name: "full range midpoint", from: 0, to: 65535, step: 4, steps: 8, want: 32767},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, interpolate(tt.from, tt.to, tt.step, tt.steps))
+		})
+	}
+}
+
+func TestSleepCtxReturnsAfterDuration(t *testing.T) {
+	start := time.Now()
+	require.NoError(t, sleepCtx(context.Background(), 10*time.Millisecond))
+	assert.GreaterOrEqual(t, time.Since(start), 10*time.Millisecond)
+}
+
+func TestSleepCtxHonoursCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sleepCtx(ctx, time.Hour)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestClosedSessionRejectsGestures makes sure a closed session fails fast
+// instead of dereferencing its released connections.
+func TestClosedSessionRejectsGestures(t *testing.T) {
+	s := &Session{closed: true}
+
+	ctx := context.Background()
+	assert.Error(t, s.Tap(ctx, Point{X: 1, Y: 1}))
+	assert.Error(t, s.Drag(ctx, Point{}, Point{X: 1, Y: 1}, 2, 0))
+	assert.Error(t, s.Move(ctx, 1, 1))
+	assert.Error(t, s.Type(ctx, "hello"))
+	assert.Error(t, s.PressButton(ctx, 12, 64))
+	_, err := s.ListServices()
+	assert.Error(t, err)
+}
+
+// TestCloseIsIdempotent covers the common teardown path: Close after a failed
+// open, and Close twice, must not panic or error.
+func TestCloseIsIdempotent(t *testing.T) {
+	s := &Session{}
+
+	require.NoError(t, s.Close())
+	require.NoError(t, s.Close())
+	assert.False(t, s.StreamActive())
+}
+
+// TestTeardownStreamOnFreshSessionIsNoop guards the partially-initialised paths
+// ensureStream unwinds through when opening a stream fails.
+func TestTeardownStreamOnFreshSessionIsNoop(t *testing.T) {
+	s := &Session{}
+
+	s.mutex.Lock()
+	s.teardownStream()
+	s.mutex.Unlock()
+
+	assert.False(t, s.StreamActive())
+}
+
+// TestNewSessionRejectsDeviceWithoutTunnel documents that a session needs a
+// tunnelled device: without RSD ports there is nothing to connect to.
+func TestNewSessionRejectsDeviceWithoutTunnel(t *testing.T) {
+	_, err := NewSession(ios.DeviceEntry{})
+	assert.Error(t, err)
+}
+
+// TestUserspaceTunnelIsRejectedForStreams pins the documented behaviour: touch
+// input cannot work over the userspace tunnel because the device cannot reach a
+// host UDP socket.
+func TestUserspaceTunnelIsRejectedForStreams(t *testing.T) {
+	s := &Session{
+		device: ios.DeviceEntry{UserspaceTUN: true, Address: "fd00::1"},
+		hid:    &UniversalConnection{},
+	}
+
+	err := s.ensureStream(context.Background())
+	assert.ErrorIs(t, err, display.ErrUserspaceTunnelUnsupported)
+	assert.False(t, s.StreamActive(), "a rejected stream must leave no state behind")
+}
+
+func TestSessionOptions(t *testing.T) {
+	s := &Session{displayID: display.DefaultDisplayID, typingInterval: defaultTypingInterval}
+
+	WithDisplayID(7)(s)
+	WithTypingInterval(5 * time.Millisecond)(s)
+
+	assert.Equal(t, 7, s.displayID)
+	assert.Equal(t, 5*time.Millisecond, s.typingInterval)
+}

--- a/ios/hid/session_test.go
+++ b/ios/hid/session_test.go
@@ -11,10 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These tests cover the session logic that does not need a device: coordinate
-// interpolation, context handling and the closed-session guards. The stream
-// negotiation itself is covered by ios/display's encoder tests and by the
-// on-device checks documented in the package.
+// These cover the session logic that needs no device. Stream negotiation is
+// covered by ios/display's encoder tests.
 
 func TestInterpolate(t *testing.T) {
 	tests := []struct {
@@ -23,6 +21,7 @@ func TestInterpolate(t *testing.T) {
 		step, steps int
 		want        uint16
 	}{
+		{name: "step 0 is the start point, which UIKit hit-tests", from: 1000, to: 5000, step: 0, steps: 4, want: 1000},
 		{name: "single step lands on target", from: 0, to: 1000, step: 1, steps: 1, want: 1000},
 		{name: "midpoint", from: 0, to: 1000, step: 1, steps: 2, want: 500},
 		{name: "last step lands on target", from: 0, to: 1000, step: 4, steps: 4, want: 1000},
@@ -36,21 +35,10 @@ func TestInterpolate(t *testing.T) {
 			assert.Equal(t, tt.want, interpolate(tt.from, tt.to, tt.step, tt.steps))
 		})
 	}
-}
 
-// TestInterpolateCoversTheWholeGesture pins the sampling contract Drag relies
-// on: step 0 is the touch-down at the start point, which is what UIKit
-// hit-tests, and the last step lands exactly on the target.
-func TestInterpolateCoversTheWholeGesture(t *testing.T) {
-	from, to := uint16(1000), uint16(5000)
-	steps := 4
-
-	assert.Equal(t, from, interpolate(from, to, 0, steps), "step 0 must be the start point")
-	assert.Equal(t, to, interpolate(from, to, steps, steps), "the last step must be the target")
-
-	previous := interpolate(from, to, 0, steps)
-	for i := 1; i <= steps; i++ {
-		current := interpolate(from, to, i, steps)
+	previous := interpolate(0, 5000, 0, 4)
+	for i := 1; i <= 4; i++ {
+		current := interpolate(0, 5000, i, 4)
 		assert.Greater(t, current, previous, "samples must advance monotonically")
 		previous = current
 	}
@@ -70,24 +58,27 @@ func TestSleepCtx(t *testing.T) {
 	assert.ErrorIs(t, sleepCtx(ctx, time.Hour), context.Canceled)
 }
 
-// TestClosedSessionRejectsGestures makes sure a closed session fails fast
-// instead of dereferencing its released connections.
-func TestClosedSessionRejectsGestures(t *testing.T) {
+// A closed session must fail fast rather than dereference its released
+// connections.
+func TestClosedSessionRejectsEverything(t *testing.T) {
 	s := &Session{closed: true}
-
 	ctx := context.Background()
+
 	assert.Error(t, s.Tap(ctx, Point{X: 1, Y: 1}))
 	assert.Error(t, s.Drag(ctx, Point{}, Point{X: 1, Y: 1}, 2, 0))
 	assert.Error(t, s.MoveDigitizer(ctx, 1, 1))
 	assert.Error(t, s.Type(ctx, "hello"))
 	assert.Error(t, s.PressButton(ctx, 12, 64))
+	assert.Error(t, s.TouchDown(ctx, Point{}))
+	assert.Error(t, s.TouchMove(ctx, Point{}))
+	assert.Error(t, s.TouchUp(ctx, Point{}))
 	_, err := s.ListServices()
 	assert.Error(t, err)
 }
 
-// TestCloseIsIdempotent covers the common teardown path: Close after a failed
-// open, and Close twice, must not panic or error.
-func TestCloseIsIdempotent(t *testing.T) {
+// Close runs on the teardown path of a failed open, so it must tolerate a
+// session that never opened anything, and must be idempotent.
+func TestCloseOnUnopenedSessionIsSafe(t *testing.T) {
 	s := &Session{}
 
 	require.NoError(t, s.Close())
@@ -95,27 +86,12 @@ func TestCloseIsIdempotent(t *testing.T) {
 	assert.False(t, s.StreamActive())
 }
 
-// TestTeardownStreamOnFreshSessionIsNoop guards the partially-initialised paths
-// ensureStream unwinds through when opening a stream fails.
-func TestTeardownStreamOnFreshSessionIsNoop(t *testing.T) {
-	s := &Session{}
-
-	s.mutex.Lock()
-	s.teardownStream()
-	s.mutex.Unlock()
-
-	assert.False(t, s.StreamActive())
-}
-
-// TestNewSessionRejectsDeviceWithoutTunnel documents that a session needs a
-// tunnelled device: without RSD ports there is nothing to connect to.
 func TestNewSessionRejectsDeviceWithoutTunnel(t *testing.T) {
 	_, err := NewSession(ios.DeviceEntry{})
 	assert.Error(t, err)
 }
 
-// TestUserspaceTunnelIsRejectedForStreams pins the documented behaviour: touch
-// input cannot work over the userspace tunnel because the device cannot reach a
+// Touch input cannot work over a userspace tunnel: the device has no route to a
 // host UDP socket.
 func TestUserspaceTunnelIsRejectedForStreams(t *testing.T) {
 	s := &Session{
@@ -128,29 +104,11 @@ func TestUserspaceTunnelIsRejectedForStreams(t *testing.T) {
 	assert.False(t, s.StreamActive(), "a rejected stream must leave no state behind")
 }
 
-// TestTouchUpWithoutDownIsNoop covers the stray-release case an input stream can
-// produce: it must not error and must not touch the device.
+// A stray release, which an input stream can produce, must not error or reach
+// the device.
 func TestTouchUpWithoutDownIsNoop(t *testing.T) {
 	s := &Session{hid: &UniversalConnection{}}
 
 	require.NoError(t, s.TouchUp(context.Background(), Point{X: 1, Y: 2}))
 	assert.False(t, s.contactDown)
-}
-
-// TestClosedSessionRejectsStreamingTouches keeps the streaming methods behind
-// the same closed-session guard as the gesture methods.
-func TestClosedSessionRejectsStreamingTouches(t *testing.T) {
-	s := &Session{closed: true}
-	ctx := context.Background()
-
-	assert.Error(t, s.TouchDown(ctx, Point{}))
-	assert.Error(t, s.TouchMove(ctx, Point{}))
-	assert.Error(t, s.TouchUp(ctx, Point{}))
-}
-
-// TestCloseWithoutHeldContactDoesNotPanic guards the Close path that lifts a
-// held contact: with nothing down it must not dereference the connection.
-func TestCloseWithoutHeldContactDoesNotPanic(t *testing.T) {
-	s := &Session{}
-	require.NoError(t, s.Close())
 }

--- a/ios/hid/session_test.go
+++ b/ios/hid/session_test.go
@@ -56,24 +56,18 @@ func TestInterpolateCoversTheWholeGesture(t *testing.T) {
 	}
 }
 
-func TestSleepCtxReturnsAfterDuration(t *testing.T) {
+func TestSleepCtx(t *testing.T) {
 	start := time.Now()
 	require.NoError(t, sleepCtx(context.Background(), 10*time.Millisecond))
 	assert.GreaterOrEqual(t, time.Since(start), 10*time.Millisecond)
-}
 
-func TestSleepCtxDoesNotSleepForNonPositiveDurations(t *testing.T) {
-	// A zero interval means "no pacing", not "report the context".
+	// A zero or negative interval means "no pacing", not "report the context".
 	assert.NoError(t, sleepCtx(context.Background(), 0))
 	assert.NoError(t, sleepCtx(context.Background(), -time.Second))
-}
 
-func TestSleepCtxHonoursCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-
-	err := sleepCtx(ctx, time.Hour)
-	assert.ErrorIs(t, err, context.Canceled)
+	assert.ErrorIs(t, sleepCtx(ctx, time.Hour), context.Canceled)
 }
 
 // TestClosedSessionRejectsGestures makes sure a closed session fails fast
@@ -159,14 +153,4 @@ func TestClosedSessionRejectsStreamingTouches(t *testing.T) {
 func TestCloseWithoutHeldContactDoesNotPanic(t *testing.T) {
 	s := &Session{}
 	require.NoError(t, s.Close())
-}
-
-func TestSessionOptions(t *testing.T) {
-	s := &Session{displayID: display.DefaultDisplayID, typingInterval: defaultTypingInterval}
-
-	WithDisplayID(7)(s)
-	WithTypingInterval(5 * time.Millisecond)(s)
-
-	assert.Equal(t, 7, s.displayID)
-	assert.Equal(t, 5*time.Millisecond, s.typingInterval)
 }

--- a/main.go
+++ b/main.go
@@ -95,6 +95,12 @@ Usage:
   ios forward [options] [<hostPort> <targetPort>] [--port=<mapping>]...
   ios fsync [--app=bundleId] [options] (pull | push) --srcPath=<srcPath> --dstPath=<dstPath>
   ios fsync [--app=bundleId] [options] (rm [--r] | tree | mkdir) --path=<targetPath>
+  ios hid services [options]
+  ios hid tap <x> <y> [options]
+  ios hid drag <x> <y> <tox> <toy> [--steps=<steps>] [--duration=<seconds>] [options]
+  ios hid button <usagepage> <usagecode> [options]
+  ios hid type <text> [options]
+  ios hid session [--script=<file>] [options]
   ios httpproxy <host> <port> [<user>] [<pass>] --p12file=<orgid> --password=<p12password> [options]
   ios httpproxy remove [options]
   ios image auto [--basedir=<where_dev_images_are_stored>] [options]
@@ -304,6 +310,24 @@ The commands work as following:
     ios fsync [--app=bundleId] [options] (rm [--r] | tree | mkdir) --path=<targetPath>
                                                                   Remove | treeview | mkdir in target path.
                                                                   --r used alongside rm will recursively remove all files and directories from target path.
+
+    ios hid services [options]                                    List the HID surfaces registered on the device as JSON, with their _ServiceID.
+    ios hid tap <x> <y> [options]                                 Tap the touchscreen. Coordinates are normalised across the display:
+                                                                  0 is the left/top edge, 65535 the right/bottom. iOS 17+ and a kernel tunnel.
+    ios hid drag <x> <y> <tox> <toy> [--steps=<steps>] [--duration=<seconds>] [options]
+                                                                  Drag from one point to another with the contact held down. --steps sets how
+                                                                  many samples are sent and --duration how long the drag takes, which together
+                                                                  decide whether the device reads a flick or a slow drag. Defaults: 8 steps
+                                                                  over 0.1s, which reads as a flick.
+    ios hid button <usagepage> <usagecode> [options]              Press and release a hardware button, e.g. usage page 12 (Consumer) for the
+                                                                  media keys. Buttons need no media stream.
+    ios hid type <text> [options]                                 Register a virtual keyboard and type text through it.
+    ios hid session [--script=<file>] [options]                   Run a batch of gestures through ONE media stream, read from --script or
+                                                                  stdin. One gesture per line: 'tap X Y', 'drag X Y TOX TOY [STEPS [SECONDS]]',
+                                                                  'move X Y', 'type TEXT', 'button PAGE CODE', 'sleep SECONDS'. Prefer this
+                                                                  over repeating single-gesture commands: touch input requires a media stream,
+                                                                  each command negotiates its own, and rapid re-negotiation can wedge the
+                                                                  device's mediastream daemon until it is rebooted.
 
     ios httpproxy <host> <port> [<user>] [<pass>] --p12file=<orgid> [--password=<p12password>]
                                                                   Set global http proxy on supervised device.

--- a/testdata/help/global.golden
+++ b/testdata/help/global.golden
@@ -47,6 +47,7 @@ Commands:
   file push                       Push file to device.
   forward                         Forward host port to device.
   fsync                           App container file sync operations.
+  hid                             Inject touch, hardware button and keyboard input (iOS 17+, kernel tunnel).
   httpproxy                       Install global HTTP proxy profile.
   httpproxy remove                Remove go-ios HTTP proxy profile.
   image auto                      Auto-download and mount developer image.

--- a/testdata/help/global.golden
+++ b/testdata/help/global.golden
@@ -47,7 +47,7 @@ Commands:
   file push                       Push file to device.
   forward                         Forward host port to device.
   fsync                           App container file sync operations.
-  hid                             Inject touch, hardware button and keyboard input (iOS 17+, kernel tunnel).
+  hid                             Inject touch, hardware button and keyboard input (iOS 27+, kernel tunnel).
   httpproxy                       Install global HTTP proxy profile.
   httpproxy remove                Remove go-ios HTTP proxy profile.
   image auto                      Auto-download and mount developer image.


### PR DESCRIPTION
> **Review #845 first.** `ios/display` has been split out into #845 so it can be reviewed on its own. This branch still contains it, because `Session` imports it and the branch has to build — but those 846 lines are the same commit and need no second review. Once #845 merges, this diff shrinks to the HID work on its own (`ios/hid`, `Session`, the CLI) with no rebase needed here.

Adds touch, hardware button and virtual keyboard input over the CoreDevice HID services, so `go-ios` can drive a device without WebDriverAgent.

```
ios hid services
ios hid tap 32767 32767
ios hid drag 45000 40000 20000 40000 --steps 8 --duration 0.1
ios hid button 12 233
ios hid type "hello"
ios hid session --script gestures.txt
```

## The part that is not obvious

Touch reports are gated on a running media stream. Without one, `dtuhidd` publishes the digitizer surfaces as `eventSource: externalAccessory` and `backboardd` drops every event with *"ignoring digitizer event for display &lt;main&gt; from unsupported service"*. The reports are still **accepted without error**, so a caller sees success while nothing happens on screen. Starting a video stream flips the surfaces to authenticated and the same reports arrive as real `UIEventTypeTouches`.

The stream's RTP payload is irrelevant, it only has to exist, so `ios/display` implements stream negotiation and nothing about decoding video: the socket is bound and drained purely so the device keeps sending. The gate is per client: a stream Xcode started does not authenticate our reports.

pymobiledevice3 arrived at the same design independently, which is worth reading if this seems like an odd amount of machinery for a tap: [`hid_service.py`](https://github.com/doronz88/pymobiledevice3/blob/master/pymobiledevice3/remote/core_device/hid_service.py) documents the gate in its "Authentication gate" comment (`authenticated: NO; builtIn: NO; eventSource: externalAccessory`), and its `touch_session` helper starts a stream, drains the RTP in a background task and notes "we just need a session to exist for the duration of the gestures". It uses the same 1MB receive buffer and the same post-start settle delay, for the same reasons.

`Session` owns this. It opens one connection, starts a stream lazily on the first gesture that needs one, and holds it for the session's lifetime. Negotiating per gesture costs seconds and has been seen to wedge the device's mediastream daemon until reboot. Hardware buttons never start a stream, since that surface is already authenticated.

## Constraints

- **iOS 27 or later.** The services connect from iOS 17, but earlier versions will not start a stream: 26.3 reports no supported media features and fails with CoreDevice error 9021, "Remote control requires iOS 27.0 or later on this device".
- **Kernel tunnel only.** The device sends RTP to a host UDP socket, which a userspace tunnel cannot route. `NewSession` succeeds and the first gesture returns `display.ErrUserspaceTunnelUnsupported`.

## Layout

| package | role |
|---|---|
| `ios/hid` | HID report encoding, the two service wrappers, and `Session` |
| `ios/display` | `mediastreamstart` negotiation, and a UDP sink that discards frames |
| `cmd_device_hid.go` | the `ios hid` subcommands |

The negotiator offer was reverse engineered from `-[AVCMediaStreamNegotiator createOffer]`; the daemon rejects any deviation with an opaque "Invalid Parameter", so `offer_test.go` pins the encoder against a captured Xcode offer byte for byte. `offer.go` documents the blob layout.

Verified on device: gestures, typing and buttons on iOS 27.0, and the 9021 refusal on 26.3.


