### PR TITLE
feat(display): CoreDevice media stream negotiation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40
 	github.com/pierrec/lz4 v2.6.1+incompatible
-	github.com/pkg/errors v0.9.1
 	github.com/quic-go/quic-go v0.59.1
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/stretchr/testify v1.11.1
@@ -30,6 +29,8 @@ require (
 	howett.net/plist v1.0.1
 	software.sslmate.com/src/go-pkcs12 v0.7.2
 )
+
+require google.golang.org/protobuf v1.32.0
 
 require (
 	github.com/blacktop/go-dwarf v1.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
+google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
+google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/ios/coredevice/coredevice.go
+++ b/ios/coredevice/coredevice.go
@@ -18,3 +18,23 @@ func BuildRequest(deviceId, feature string, input map[string]interface{}) map[st
 		"CoreDevice.invocationIdentifier": u.String(),
 	}
 }
+
+// BuildRequestWithAction names the action some services require alongside the
+// feature identifier, and advertises the newer version pair displayservice needs.
+func BuildRequestWithAction(deviceId, feature, action string, input map[string]interface{}) map[string]interface{} {
+	u := uuid.New()
+	return map[string]interface{}{
+		"CoreDevice.CoreDeviceDDIProtocolVersion": int64(2),
+		"CoreDevice.action":                       map[string]interface{}{},
+		"CoreDevice.actionIdentifier":             action,
+		"CoreDevice.coreDeviceVersion": map[string]interface{}{
+			"components":              []interface{}{uint64(629), uint64(3)},
+			"originalComponentsCount": int64(2),
+			"stringValue":             "629.3",
+		},
+		"CoreDevice.deviceIdentifier":     deviceId,
+		"CoreDevice.featureIdentifier":    feature,
+		"CoreDevice.input":                input,
+		"CoreDevice.invocationIdentifier": u.String(),
+	}
+}

--- a/ios/display/display.go
+++ b/ios/display/display.go
@@ -1,0 +1,190 @@
+// Package display starts RTP video streams over
+// com.apple.coredevice.displayservice. A stream also authenticates HID input.
+package display
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/coredevice"
+	"github.com/danielpaulus/go-ios/ios/xpc"
+	"github.com/google/uuid"
+)
+
+const logModule = "go-ios/display"
+
+const (
+	serviceName = "com.apple.coredevice.displayservice"
+
+	featureStartMediaStream = "com.apple.coredevice.feature.startmediastream"
+	featureStopMediaStream  = "com.apple.coredevice.feature.stopmediastream"
+
+	actionMediaStreamStart = "com.apple.coredevice.action.mediastreamstart"
+	actionMediaStreamStop  = "com.apple.coredevice.action.mediastreamstop"
+
+	// Host capabilities and link type. The values Xcode sends over a tunnel, with
+	// no documented meaning to derive them from.
+	clientSupportedFeatures = uint64(140)
+	accessNetworkType       = int64(1)
+	transportProtocolType   = int64(2)
+
+	// The deadline the device applies to its own side. Keep it under the caller's:
+	// the device giving up first answers with an error and keeps the connection.
+	negotiationTimeoutSeconds = uint64(10)
+
+	DefaultDisplayID = 1
+)
+
+// Service is a connection to the device's display service. One request runs at a
+// time: nothing in the XPC framing pairs a reply with its request (see invoke).
+type Service struct {
+	conn     xpcConn
+	deviceID string
+	mutex    sync.Mutex
+}
+
+// xpcConn is the subset of *xpc.Connection used here, so the request/reply logic
+// can be exercised with a fake.
+type xpcConn interface {
+	Send(data map[string]interface{}, flags ...uint32) error
+	ReceiveOnServerClientStream() (map[string]interface{}, error)
+	Close() error
+}
+
+// New connects to the display service. The Developer Disk Image must be
+// mounted, otherwise the service is not published and connecting fails.
+func New(device ios.DeviceEntry) (*Service, error) {
+	conn, err := ios.ConnectToXpcServiceTunnelIface(device, serviceName)
+	if err != nil {
+		return nil, fmt.Errorf("display.New: failed to connect to %s: %w", serviceName, err)
+	}
+	return &Service{conn: conn, deviceID: uuid.New().String()}, nil
+}
+
+// Close closes the connection to the display service. Stop any running stream
+// first, otherwise the device keeps sending RTP until it times out.
+func (s *Service) Close() error {
+	return s.conn.Close()
+}
+
+// VideoStreamRequest describes where the device should send a display's frames.
+// The receiver must already be bound: the device sends as soon as it answers.
+type VideoStreamRequest struct {
+	// ReceiverIP and ReceiverPort are the host's tunnel address and bound UDP
+	// port, as reported by a Receiver.
+	ReceiverIP   string
+	ReceiverPort int
+	// SenderIP is the device's address over the tunnel (ios.DeviceEntry.Address).
+	SenderIP string
+	// DisplayID selects the display; use DefaultDisplayID for the main one.
+	DisplayID int
+}
+
+// StreamAnswer is the device's response to a stream start.
+type StreamAnswer struct {
+	// ClientSessionID identifies the stream and is required to stop it.
+	ClientSessionID uuid.UUID
+	// Output is the raw CoreDevice output, kept so callers can inspect the
+	// negotiated configuration without this package modelling the whole answer.
+	Output map[string]interface{}
+}
+
+// StartVideoStream starts an RTP video stream of one display. iOS 27+, earlier
+// fails 9021. Pass a deadline: the daemon can stop answering, so close on timeout.
+func (s *Service) StartVideoStream(ctx context.Context, req VideoStreamRequest) (StreamAnswer, error) {
+	if req.ReceiverIP == "" || req.ReceiverPort == 0 {
+		return StreamAnswer{}, fmt.Errorf("StartVideoStream: receiver address is required, bind a Receiver first")
+	}
+	if req.SenderIP == "" {
+		return StreamAnswer{}, fmt.Errorf("StartVideoStream: sender address is required")
+	}
+	displayID := req.DisplayID
+	if displayID == 0 {
+		displayID = DefaultDisplayID
+	}
+
+	clientSessionID := uuid.New()
+	offer, err := buildVideoNegotiatorOffer(uuid.New(), rand.Uint32())
+	if err != nil {
+		return StreamAnswer{}, err
+	}
+
+	input := map[string]interface{}{
+		"clientSupportedFeatures": clientSupportedFeatures,
+		"direction":               "output",
+		"negotiatorOffer":         offer,
+		"options": map[string]interface{}{
+			"AVCMediaStreamNegotiatorAccessNetworkType":     map[string]interface{}{"int": accessNetworkType},
+			"AVCMediaStreamNegotiatorTransportProtocolType": map[string]interface{}{"int": transportProtocolType},
+			"CoreDeviceVideoDisplayMode":                    map[string]interface{}{"string": "DisplayByID"},
+			"VideoStreamForDisplayID":                       map[string]interface{}{"int": int64(displayID)},
+			"avcMediaStreamOptionClientSessionID":           map[string]interface{}{"uuid": clientSessionID},
+		},
+		"receiverIP":   req.ReceiverIP,
+		"receiverPort": uint64(req.ReceiverPort),
+		"senderIP":     req.SenderIP,
+		"timeout":      negotiationTimeoutSeconds,
+		"type":         "video",
+	}
+
+	output, err := s.invoke(ctx, featureStartMediaStream, actionMediaStreamStart, input)
+	if err != nil {
+		// The id comes back even on failure: the device may have started the
+		// stream anyway, and stopping it needs this id. A failure closes this
+		// Service's connection, so the stop has to go out on a new one.
+		return StreamAnswer{ClientSessionID: clientSessionID}, err
+	}
+	return StreamAnswer{ClientSessionID: clientSessionID, Output: output}, nil
+}
+
+// StopMediaStream stops this client's stream. stopAll is a key the payload is
+// expected to carry, and must be true, though a client only ever holds one
+// stream. The device often drops the channel mid-stop, which means it worked.
+func (s *Service) StopMediaStream(ctx context.Context, clientSessionID uuid.UUID) error {
+	input := map[string]interface{}{
+		"avcMediaStreamOptionClientSessionID": map[string]interface{}{"uuid": clientSessionID},
+		"stopAll":                             true,
+	}
+	_, err := s.invoke(ctx, featureStopMediaStream, actionMediaStreamStop, input)
+	return err
+}
+
+// invoke sends one CoreDevice request and waits for its response, honouring ctx.
+//
+// An interrupted exchange may have consumed part of a message, and nothing
+// reports whether it did, so the connection is closed rather than reused: there
+// is no way to resynchronise and no id to catch a reply meant for someone else.
+func (s *Service) invoke(ctx context.Context, feature, action string, input map[string]interface{}) (map[string]interface{}, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	// Neither a blocked read nor a blocked write can be cancelled, so closing the
+	// connection is what ends them. It is discarded either way, so nothing is lost
+	// by being blunt.
+	stop := context.AfterFunc(ctx, func() { _ = s.conn.Close() })
+	defer stop()
+
+	request := coredevice.BuildRequestWithAction(s.deviceID, feature, action, input)
+	if err := s.conn.Send(request, xpc.HeartbeatRequestFlag); err != nil {
+		_ = s.conn.Close()
+		return nil, fmt.Errorf("display: failed to send %s: %w", feature, err)
+	}
+
+	response, err := s.conn.ReceiveOnServerClientStream()
+	if err != nil {
+		_ = s.conn.Close()
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("display: %s did not complete: %w (the device's mediastream daemon may be wedged; rebooting the device clears it)", feature, ctxErr)
+		}
+		return nil, fmt.Errorf("display: failed to receive the response to %s: %w", feature, err)
+	}
+
+	output, ok := response["CoreDevice.output"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("display: unexpected response to %s: %+v", feature, response)
+	}
+	return output, nil
+}

--- a/ios/display/offer.go
+++ b/ios/display/offer.go
@@ -1,0 +1,251 @@
+package display
+
+import (
+	"bytes"
+	"compress/zlib"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/encoding/protowire"
+	"howett.net/plist"
+)
+
+// The daemon rejects any deviation with an opaque "Invalid Parameter" naming no
+// field, so offer_test.go pins this encoder against a captured offer.
+
+const (
+	// negotiatorModeVideo is the avcMediaStreamNegotiatorMode value for video.
+	// Audio is 6 and is not implemented.
+	negotiatorModeVideo = 5
+
+	// defaultDecoderName is Apple's decoder string. The device matches on it and
+	// rejects an unrecognised one.
+	defaultDecoderName = "Viceroy 1.7.0"
+
+	// resEntryCodecCapID is an AVConference codec-capability id, the same in every
+	// captured offer.
+	resEntryCodecCapID = 50115
+
+	// hevcFeatures and avcFeatures declare per-bank capability flags. "FLS;" is
+	// the AVConference framing marker.
+	hevcFeatures = "FLS;SW:1;"
+	avcFeatures  = "FLS;VRAE:0;SW:1;"
+
+	// RTP payload types for the two codec banks we advertise. The device picks
+	// one and reports it back as RxPayloadType; on iOS 27 it chooses AVC.
+	hevcPayloadType = 123
+	avcPayloadType  = 100
+
+	// capturedVideoTimestamp is a host clock value. The daemon does not appear to
+	// validate it, and keeping the captured one lets the test assert byte equality.
+	capturedVideoTimestamp = uint64(17137042128614416384)
+)
+
+// What the device is told the host is, and may pick encoder parameters from.
+// Hardcoded because the host is often not a Mac; these are Xcode's values.
+var hostIdentity = struct {
+	Model     string
+	OSVersion string
+	Build     string
+}{
+	Model:     "Mac15,9",
+	OSVersion: "2205.3.1",
+	Build:     "25F80",
+}
+
+// bitrateTier is one entry of the media blob's tier table. kind 0 carries a
+// bitrate cap; the others are markers we did not identify.
+type bitrateTier struct {
+	kind      uint64
+	bps       uint64
+	bufferCap uint64
+	hasBuffer bool
+}
+
+// defaultVideoBitrateTiers is Apple's tier table. The order is significant.
+var defaultVideoBitrateTiers = []bitrateTier{
+	{kind: 4074, bps: 0, bufferCap: 16384, hasBuffer: true},
+	{kind: 0, bps: 75_000_000, bufferCap: 524288, hasBuffer: true},
+	{kind: 0, bps: 40_000_000, bufferCap: 12288, hasBuffer: true},
+	{kind: 16, bps: 4100},
+	{kind: 0, bps: 20_000_000, bufferCap: 98304, hasBuffer: true},
+	{kind: 4, bps: 6500},
+	{kind: 0, bps: 6_000_000, bufferCap: 131072, hasBuffer: true},
+	{kind: 0, bps: 100_000_000, bufferCap: 1048576, hasBuffer: true},
+	{kind: 0, bps: 60_000_000, bufferCap: 262144, hasBuffer: true},
+	{kind: 1, bps: 299},
+}
+
+// videoBlobParams are the media blob's tunable flags. Only the defaults are sent:
+// long-term reference frames off (under UDP loss they leave the picture torn).
+type videoBlobParams struct {
+	sessionID     uint32
+	allowRTCPFB   bool
+	ltrpEnabled   bool
+	fecEnabled    bool
+	tilesPerFrame uint64
+	timestamp     uint64
+}
+
+func defaultVideoBlobParams(sessionID uint32) videoBlobParams {
+	return videoBlobParams{
+		sessionID:     sessionID,
+		fecEnabled:    true,
+		tilesPerFrame: 1,
+		timestamp:     capturedVideoTimestamp,
+	}
+}
+
+// The offer is a protobuf with no schema, so the field numbers below are Apple's.
+// protowire does the encoding; only varintPadded is not minimal-form protobuf.
+
+func fieldVarint(out []byte, field, value uint64) []byte {
+	out = protowire.AppendTag(out, protowire.Number(field), protowire.VarintType)
+	return protowire.AppendVarint(out, value)
+}
+
+func fieldBool(out []byte, field uint64, value bool) []byte {
+	if value {
+		return fieldVarint(out, field, 1)
+	}
+	return fieldVarint(out, field, 0)
+}
+
+func fieldBytes(out []byte, field uint64, value []byte) []byte {
+	out = protowire.AppendTag(out, protowire.Number(field), protowire.BytesType)
+	return protowire.AppendBytes(out, value)
+}
+
+func fieldString(out []byte, field uint64, value string) []byte {
+	out = protowire.AppendTag(out, protowire.Number(field), protowire.BytesType)
+	return protowire.AppendString(out, value)
+}
+
+// A varint padded to a fixed width with continuation bytes that add nothing, so
+// the session id can be rewritten in place. protowire only emits minimal form.
+func fieldVarintPadded(out []byte, field, value uint64, width int) []byte {
+	out = protowire.AppendTag(out, protowire.Number(field), protowire.VarintType)
+	return append(out, varintPadded(value, width)...)
+}
+
+// value must fit in 7*width bits.
+func varintPadded(value uint64, width int) []byte {
+	encoded := protowire.AppendVarint(nil, value)
+	for len(encoded) < width {
+		encoded[len(encoded)-1] |= 0x80
+		encoded = append(encoded, 0x00)
+	}
+	return encoded
+}
+
+// resEntry is one codec-capability tier inside a codec bank.
+func resEntry(pairIndex uint64) []byte {
+	entry := fieldVarint(nil, 1, 1)
+	entry = fieldVarint(entry, 2, pairIndex)
+	entry = fieldVarint(entry, 3, resEntryCodecCapID)
+	return fieldVarint(entry, 4, 0)
+}
+
+// codecBank describes one codec. resPairCount is 4 for HEVC and 2 for AVC; the
+// bank carries alternating pair indices 1, 2 repeated that many times.
+func codecBank(payloadType uint64, features string, trailer uint64, resPairCount int) []byte {
+	bank := fieldVarint(nil, 1, payloadType)
+	for i := 0; i < resPairCount; i++ {
+		bank = fieldBytes(bank, 2, resEntry(uint64(1+i%2)))
+	}
+	bank = fieldString(bank, 3, features)
+	return fieldVarint(bank, 4, trailer)
+}
+
+func videoSettings(params videoBlobParams) []byte {
+	settings := fieldVarintPadded(nil, 1, uint64(params.sessionID), 5)
+	settings = fieldBool(settings, 2, params.allowRTCPFB)
+	settings = fieldBytes(settings, 3, codecBank(hevcPayloadType, hevcFeatures, 1, 4))
+	settings = fieldBytes(settings, 3, codecBank(avcPayloadType, avcFeatures, 14, 2))
+	if params.tilesPerFrame != 1 {
+		settings = fieldVarint(settings, 6, params.tilesPerFrame)
+	}
+	settings = fieldBool(settings, 7, params.ltrpEnabled)
+	settings = fieldVarint(settings, 8, 63)
+	if params.fecEnabled {
+		settings = fieldVarint(settings, 10, 1)
+	}
+	return fieldVarint(settings, 12, 1)
+}
+
+// buildVideoMediaBlob assembles the media blob, before compression.
+func buildVideoMediaBlob(params videoBlobParams) []byte {
+	blob := fieldVarint(nil, 1, 1)
+	blob = fieldVarint(blob, 2, 1)
+	blob = fieldBytes(blob, 5, videoSettings(params))
+	blob = fieldString(blob, 6, defaultDecoderName)
+	blob = fieldVarint(blob, 8, 0)
+	for _, tier := range defaultVideoBitrateTiers {
+		entry := fieldVarint(nil, 1, tier.kind)
+		entry = fieldVarint(entry, 2, tier.bps)
+		if tier.hasBuffer {
+			entry = fieldVarint(entry, 3, tier.bufferCap)
+		}
+		blob = fieldBytes(blob, 9, entry)
+	}
+	blob = fieldVarint(blob, 13, params.timestamp)
+	blob = fieldVarint(blob, 14, 2)
+	blob = fieldVarint(blob, 16, 0)
+	return fieldVarint(blob, 18, 1)
+}
+
+// buildRemoteEndpointInfo describes the host in the
+// avcMediaStreamOptionRemoteEndpointInfo protobuf.
+func buildRemoteEndpointInfo() []byte {
+	info := fieldVarint(nil, 1, 0)
+	info = fieldVarint(info, 2, 1)
+	info = fieldString(info, 3, hostIdentity.Model)
+	info = fieldString(info, 4, hostIdentity.OSVersion)
+	return fieldString(info, 5, hostIdentity.Build)
+}
+
+// negotiatorOffer is the binary plist the device expects.
+type negotiatorOffer struct {
+	RemoteEndpointInfo []byte `plist:"avcMediaStreamOptionRemoteEndpointInfo"`
+	NegotiatorMode     int    `plist:"avcMediaStreamNegotiatorMode"`
+	MediaBlob          []byte `plist:"avcMediaStreamNegotiatorMediaBlob"`
+	CallID             string `plist:"avcMediaStreamOptionCallID"`
+}
+
+// buildVideoNegotiatorOffer encodes the offer plist. callID identifies the call
+// and sessionID the media session; both are generated per stream by the caller.
+func buildVideoNegotiatorOffer(callID uuid.UUID, sessionID uint32) ([]byte, error) {
+	blob, err := compressMediaBlob(buildVideoMediaBlob(defaultVideoBlobParams(sessionID)))
+	if err != nil {
+		return nil, err
+	}
+	offer := negotiatorOffer{
+		RemoteEndpointInfo: buildRemoteEndpointInfo(),
+		NegotiatorMode:     negotiatorModeVideo,
+		MediaBlob:          blob,
+		CallID:             strings.ToUpper(callID.String()),
+	}
+	data, err := plist.Marshal(offer, plist.BinaryFormat)
+	if err != nil {
+		return nil, fmt.Errorf("buildVideoNegotiatorOffer: failed to marshal offer plist: %w", err)
+	}
+	return data, nil
+}
+
+// compressMediaBlob zlib-compresses the blob. The level matters: the device
+// rejects anything but best compression.
+func compressMediaBlob(blob []byte) ([]byte, error) {
+	var compressed bytes.Buffer
+	writer, err := zlib.NewWriterLevel(&compressed, zlib.BestCompression)
+	if err != nil {
+		return nil, fmt.Errorf("compressMediaBlob: failed to create writer: %w", err)
+	}
+	if _, err := writer.Write(blob); err != nil {
+		return nil, fmt.Errorf("compressMediaBlob: failed to write blob: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("compressMediaBlob: failed to flush blob: %w", err)
+	}
+	return compressed.Bytes(), nil
+}

--- a/ios/display/offer_test.go
+++ b/ios/display/offer_test.go
@@ -1,0 +1,150 @@
+package display
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/hex"
+	"io"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+	"howett.net/plist"
+)
+
+// capturedVideoMediaBlob is the uncompressed media blob from an offer Xcode sent
+// to a device, with capturedVideoSessionID as the session id. dtuhidd rejects
+// malformed offers with an opaque "Invalid Parameter", so this fixture is the
+// only cheap way to catch encoder drift.
+//
+// The capture had LTRP enabled and FEC disabled; the default here is the inverse
+// (see videoBlobParams), so the test builds with the captured flags.
+const capturedVideoMediaBlobHex = "080110012a7f088182bae90810001a3f087b120a0801100118c387032000120a" +
+	"0801100218c387032000120a0801100118c387032000120a0801100218c38703" +
+	"20001a09464c533b53573a313b20011a2e0864120a0801100118c38703200012" +
+	"0a0801100218c3870320001a10464c533b565241453a303b53573a313b200e38" +
+	"01403f6001320d56696365726f7920312e372e3040004a0908ea1f1000188080" +
+	"014a0b080010c0d1e123188080204a0a08001080b489131880604a0508101084" +
+	"204a0b08001080dac409188080064a05080410e4324a0b080010809bee021880" +
+	"80084a0b08001080c2d72f188080404a0b080010808ece1c188080104a050801" +
+	"10ab026880c0dd87d2a0c0e9ed017002800100900101"
+
+const capturedVideoSessionID = uint32(2368635137)
+
+// TestBuildVideoMediaBlobMatchesCapture is the contract test for the whole
+// encoder: every protobuf field number, the 5-byte padded session id, the codec
+// banks, the bitrate tier table and its order.
+func TestBuildVideoMediaBlobMatchesCapture(t *testing.T) {
+	captured, err := hex.DecodeString(capturedVideoMediaBlobHex)
+	require.NoError(t, err)
+
+	params := defaultVideoBlobParams(capturedVideoSessionID)
+	params.ltrpEnabled = true // the capture had LTRP on
+	params.fecEnabled = false // ... and FEC off
+
+	built := buildVideoMediaBlob(params)
+
+	require.Equal(t, len(captured), len(built), "media blob length drifted from the captured offer")
+	assert.Equal(t, hex.EncodeToString(captured), hex.EncodeToString(built))
+}
+
+func TestVarintPadded(t *testing.T) {
+	tests := []struct {
+		name  string
+		value uint64
+		width int
+		want  string
+	}{
+		{name: "zero pads to width", value: 0, width: 5, want: "8080808000"},
+		{name: "small value pads", value: 1, width: 3, want: "818000"},
+		{name: "exact width unchanged", value: 300, width: 2, want: "ac02"},
+		{name: "captured session id", value: uint64(capturedVideoSessionID), width: 5, want: "8182bae908"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := varintPadded(tt.value, tt.width)
+			assert.Len(t, got, tt.width)
+			assert.Equal(t, tt.want, hex.EncodeToString(got))
+		})
+	}
+}
+
+// TestVarintPaddedIsValueStable verifies the padding does not change the decoded
+// value: redundant continuation bytes must be semantically invisible.
+func TestVarintPaddedIsValueStable(t *testing.T) {
+	for _, v := range []uint64{0, 1, 127, 128, 300, uint64(capturedVideoSessionID)} {
+		padded := varintPadded(v, 5)
+		decoded, n := decodeVarint(t, padded)
+		assert.Equal(t, v, decoded, "padded varint decoded to a different value")
+		assert.Equal(t, 5, n, "padded varint should consume exactly the padded width")
+	}
+}
+
+func decodeVarint(t *testing.T, b []byte) (uint64, int) {
+	t.Helper()
+	value, n := protowire.ConsumeVarint(b)
+	if n < 0 {
+		t.Fatalf("varint %x is truncated", b)
+	}
+	return value, n
+}
+
+// TestBuildVideoNegotiatorOfferEnvelope checks the plist envelope the daemon
+// parses: the four keys, the video negotiator mode, an upper-case call id, and a
+// media blob that is zlib data round-tripping to the uncompressed protobuf.
+func TestBuildVideoNegotiatorOfferEnvelope(t *testing.T) {
+	callID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+	data, err := buildVideoNegotiatorOffer(callID, capturedVideoSessionID)
+	require.NoError(t, err)
+
+	var decoded struct {
+		RemoteEndpointInfo []byte `plist:"avcMediaStreamOptionRemoteEndpointInfo"`
+		NegotiatorMode     int    `plist:"avcMediaStreamNegotiatorMode"`
+		MediaBlob          []byte `plist:"avcMediaStreamNegotiatorMediaBlob"`
+		CallID             string `plist:"avcMediaStreamOptionCallID"`
+	}
+	_, err = plist.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, negotiatorModeVideo, decoded.NegotiatorMode)
+	assert.Equal(t, "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE", decoded.CallID,
+		"the device expects an upper-case call id")
+	assert.NotEmpty(t, decoded.RemoteEndpointInfo)
+
+	r, err := zlib.NewReader(bytes.NewReader(decoded.MediaBlob))
+	require.NoError(t, err, "media blob must be zlib data")
+	inflated, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	assert.Equal(t, buildVideoMediaBlob(defaultVideoBlobParams(capturedVideoSessionID)), inflated)
+}
+
+// TestCompressMediaBlobUsesBestCompression pins the zlib level: the device
+// rejects offers compressed at any other level with "Invalid Parameter".
+func TestCompressMediaBlobUsesBestCompression(t *testing.T) {
+	blob := buildVideoMediaBlob(defaultVideoBlobParams(capturedVideoSessionID))
+
+	got, err := compressMediaBlob(blob)
+	require.NoError(t, err)
+
+	var want bytes.Buffer
+	w, err := zlib.NewWriterLevel(&want, zlib.BestCompression)
+	require.NoError(t, err)
+	_, err = w.Write(blob)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	assert.Equal(t, want.Bytes(), got)
+}
+
+func TestBuildRemoteEndpointInfoCarriesHostIdentity(t *testing.T) {
+	info := buildRemoteEndpointInfo()
+
+	assert.Contains(t, string(info), hostIdentity.Model)
+	assert.Contains(t, string(info), hostIdentity.OSVersion)
+	assert.Contains(t, string(info), hostIdentity.Build)
+}

--- a/ios/display/receiver.go
+++ b/ios/display/receiver.go
@@ -1,0 +1,112 @@
+package display
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/danielpaulus/go-ios/ios"
+	"github.com/danielpaulus/go-ios/ios/golog"
+)
+
+// The device sends RTP to a host address, which only a kernel tunnel gives a
+// real interface; the userspace stack registers TCP only.
+var ErrUserspaceTunnelUnsupported = errors.New("media streams require a kernel tunnel: start the tunnel without --userspace")
+
+// Sized to absorb a burst while the reader is between reads. Overflowing it
+// makes the device see packet loss and throttle its encoder.
+const receiverReadBuffer = 1024 * 1024
+
+// Receiver is the UDP socket the device streams RTP to. Its address and port go
+// to StartVideoStream; the caller then uses Read or Drain.
+type Receiver struct {
+	conn *net.UDPConn
+	ip   string
+	port int
+}
+
+// OpenReceiver binds a UDP socket on the host's tunnel address, ready to be
+// nominated as a stream's receiver. Close it when the stream is stopped.
+func OpenReceiver(device ios.DeviceEntry) (*Receiver, error) {
+	if device.UserspaceTUN {
+		return nil, ErrUserspaceTunnelUnsupported
+	}
+	hostIP, err := hostTunnelAddress(device)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.ListenUDP("udp6", &net.UDPAddr{IP: hostIP, Port: 0})
+	if err != nil {
+		return nil, fmt.Errorf("OpenReceiver: failed to bind a UDP socket on %s: %w", hostIP, err)
+	}
+	if err := conn.SetReadBuffer(receiverReadBuffer); err != nil {
+		// Not fatal, so the stream still starts, but at warn: the smaller buffer
+		// drops frames under a burst, and the device throttles when it sees that.
+		golog.Warn("could not enlarge the RTP receive buffer, keeping the default",
+			"module", logModule, "error", err)
+	}
+	local, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		conn.Close()
+		return nil, fmt.Errorf("OpenReceiver: unexpected local address type %T", conn.LocalAddr())
+	}
+	return &Receiver{conn: conn, ip: hostIP.String(), port: local.Port}, nil
+}
+
+// IP is the host address the device should send RTP to.
+func (r *Receiver) IP() string { return r.ip }
+
+// Port is the UDP port the device should send RTP to.
+func (r *Receiver) Port() int { return r.port }
+
+// Read receives one RTP packet and returns its length. Callers that want the
+// video read here; callers that only need the stream to exist use Drain.
+func (r *Receiver) Read(packet []byte) (int, error) {
+	n, _, err := r.conn.ReadFromUDP(packet)
+	if err != nil {
+		if errors.Is(err, net.ErrClosed) {
+			return 0, net.ErrClosed
+		}
+		return 0, fmt.Errorf("the RTP stream stopped being received: %w", err)
+	}
+	return n, nil
+}
+
+// Drain discards packets until the Receiver is closed, which is the only way to
+// stop it. Run it in a goroutine: unread, the socket fills and the device throttles.
+func (r *Receiver) Drain() error {
+	buf := make([]byte, 65535)
+	for {
+		if _, err := r.Read(buf); err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+// Close closes the socket, which also unblocks Drain.
+func (r *Receiver) Close() error {
+	return r.conn.Close()
+}
+
+// hostTunnelAddress returns the host's address on the tunnel. Dialing sends
+// nothing; it just makes the OS bind the local address the device can reach.
+func hostTunnelAddress(device ios.DeviceEntry) (net.IP, error) {
+	if device.Address == "" {
+		return nil, fmt.Errorf("hostTunnelAddress: device has no tunnel address, start a tunnel first")
+	}
+	// Port 9 is discard; nothing is ever sent to it.
+	conn, err := net.Dial("udp6", net.JoinHostPort(device.Address, "9"))
+	if err != nil {
+		return nil, fmt.Errorf("hostTunnelAddress: no route to device %s, is the tunnel up? %w", device.Address, err)
+	}
+	defer conn.Close()
+
+	local, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return nil, fmt.Errorf("hostTunnelAddress: unexpected local address type %T", conn.LocalAddr())
+	}
+	return local.IP, nil
+}

--- a/ios/display/service_test.go
+++ b/ios/display/service_test.go
@@ -1,0 +1,149 @@
+package display
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeConn stands in for the XPC connection so the request/reply logic can be
+// tested without a device.
+type fakeConn struct {
+	// invoke closes the connection from another goroutine to interrupt a read, so
+	// every field is guarded.
+	mutex     sync.Mutex
+	sent      []map[string]interface{}
+	sendErr   error
+	reply     map[string]interface{}
+	replyErr  error
+	replyWait time.Duration
+	closed    bool
+	closeCh   chan struct{}
+}
+
+func newFakeConn() *fakeConn {
+	return &fakeConn{closeCh: make(chan struct{})}
+}
+
+func (f *fakeConn) Send(data map[string]interface{}, flags ...uint32) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	if f.closed {
+		return errors.New("use of closed connection")
+	}
+	if f.sendErr != nil {
+		return f.sendErr
+	}
+	f.sent = append(f.sent, data)
+	return nil
+}
+
+func (f *fakeConn) ReceiveOnServerClientStream() (map[string]interface{}, error) {
+	f.mutex.Lock()
+	wait, reply, err := f.replyWait, f.reply, f.replyErr
+	f.mutex.Unlock()
+
+	if wait > 0 {
+		// Closing is what ends a blocked read on the real transport, so the fake
+		// waits on the same signal rather than on a deadline.
+		select {
+		case <-time.After(wait):
+		case <-f.closeCh:
+			return nil, errors.New("use of closed connection")
+		}
+	}
+	return reply, err
+}
+
+func (f *fakeConn) Close() error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	if !f.closed {
+		f.closed = true
+		close(f.closeCh)
+	}
+	return nil
+}
+
+func (f *fakeConn) isClosed() bool {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	return f.closed
+}
+
+func (f *fakeConn) requests() []map[string]interface{} {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	return slices.Clone(f.sent)
+}
+
+func newService(c xpcConn) *Service {
+	return &Service{conn: c, deviceID: uuid.New().String()}
+}
+
+func TestStopMediaStreamSendsStopAll(t *testing.T) {
+	// The device rejects the request without stopAll, and rejects it as invalid
+	// when false, so the request must carry it as true.
+	f := newFakeConn()
+	f.reply = map[string]interface{}{"CoreDevice.output": map[string]interface{}{}}
+	s := newService(f)
+
+	require.NoError(t, s.StopMediaStream(context.Background(), uuid.New()))
+	sent := f.requests()
+	require.Len(t, sent, 1)
+
+	input, ok := sent[0]["CoreDevice.input"].(map[string]interface{})
+	require.True(t, ok, "request carries an input dictionary")
+	assert.Equal(t, true, input["stopAll"])
+	assert.Contains(t, input, "avcMediaStreamOptionClientSessionID")
+	assert.Equal(t, actionMediaStreamStop, sent[0]["CoreDevice.actionIdentifier"])
+}
+
+func TestStartVideoStreamRequiresAReceiver(t *testing.T) {
+	s := newService(newFakeConn())
+
+	_, err := s.StartVideoStream(context.Background(), VideoStreamRequest{SenderIP: "fd00::1"})
+	assert.Error(t, err, "a stream with nowhere to send to must be refused")
+
+	_, err = s.StartVideoStream(context.Background(), VideoStreamRequest{
+		ReceiverIP: "fd00::2", ReceiverPort: 5000,
+	})
+	assert.Error(t, err, "a stream with no sender address must be refused")
+}
+
+func TestTimedOutRequestClosesTheConnection(t *testing.T) {
+	// The read may have consumed part of a message, and nothing says whether it
+	// did, so the connection cannot be reused.
+	f := newFakeConn()
+	f.replyWait = 500 * time.Millisecond
+	f.reply = map[string]interface{}{}
+	s := newService(f)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := s.invoke(ctx, featureStopMediaStream, actionMediaStreamStop, map[string]interface{}{})
+	require.Error(t, err)
+	assert.True(t, f.isClosed(), "an interrupted read leaves the stream position unknown, so the connection must go")
+
+	// Nothing is left running: invoke returned because the read itself was
+	// interrupted, so a later call simply fails on the closed connection.
+	_, err = s.invoke(context.Background(), featureStopMediaStream, actionMediaStreamStop, map[string]interface{}{})
+	assert.Error(t, err, "a later call must fail rather than decode the remains of the last one")
+}
+
+func TestInvokeReportsSendFailures(t *testing.T) {
+	f := newFakeConn()
+	f.sendErr = errors.New("channel gone")
+	s := newService(f)
+
+	_, err := s.invoke(context.Background(), featureStopMediaStream, actionMediaStreamStop, map[string]interface{}{})
+	assert.ErrorContains(t, err, "channel gone")
+	assert.True(t, f.isClosed(), "a failed write may be half a frame, so the connection must go")
+}


### PR DESCRIPTION
Adds `ios/display`, which drives `com.apple.coredevice.displayservice`. the service behind Xcode's device screen view. It negotiates and starts/stops an RTP video stream of a display. 

**Supported OS versions:** iOS27+

## Implementation
- We ported the implementation mostly from pymobiledevice3 which documents it in [`media_stream_offer.py`](https://github.com/doronz88/pymobiledevice3/blob/master/pymobiledevice3/remote/core_device/media_stream_offer.py).

- `Receiver` binds a UDP socket and drains it without decoding. The drain loop is not optional. Without a reader the socket buffer fills, the device sees packet loss and throttles its encoder, which shows up as stream stalls. pymobiledevice3 does the same thing for the same reason, with the same 1MB receive buffer: see the `touch_session` helper in [`hid_service.py`](https://github.com/doronz88/pymobiledevice3/blob/master/pymobiledevice3/remote/core_device/hid_service.py).

- Kernel tunnel only. The device sends RTP back to the host, and the userspace stack registers TCP only.

**Testing:** Verified on an iPhone running iOS 27.0: streams start, stop cleanly, and hold the HID auth gate open for the duration.