### PR TITLE
fix(imagemounter): tolerate a device reporting an image already mounted

### DIFF
--- a/ios/imagemounter/imagemounter.go
+++ b/ios/imagemounter/imagemounter.go
@@ -242,7 +242,28 @@ func MountImage(device ios.DeviceEntry, path string) error {
 		golog.Warn("there is already a developer image mounted, reboot the device if you want to remove it. aborting.", "module", logModule, "udid", device.Properties.SerialNumber, "imagePath", path)
 		return nil
 	}
-	return conn.MountImage(path)
+
+	err = conn.MountImage(path)
+	if alreadyMounted(err) {
+		// A personalized DDI can auto-remount within about a second of boot (part of
+		// Developer Mode persisting across reboots) — faster than ListImages() above
+		// can catch, so the device can still refuse this as a duplicate right after
+		// it just reported nothing mounted. Treat it the same as the check above.
+		golog.Warn("device reports an image already mounted; treating as already in the desired state.", "module", logModule, "udid", device.Properties.SerialNumber, "imagePath", path)
+		return nil
+	}
+	return err
+}
+
+// alreadyMounted reports whether err is the device refusing MountImage because an image
+// is already mounted at the target path, as opposed to any other reason a mount can fail
+// (wrong signature, developer mode disabled, locked device, ...).
+func alreadyMounted(err error) bool {
+	var refused deviceRefusedError
+	if !errors.As(err, &refused) {
+		return false
+	}
+	return refused.deviceError == "ImageMountFailed" && strings.Contains(refused.detail, "already mounted at")
 }
 
 func UnmountImage(device ios.DeviceEntry) error {

--- a/ios/imagemounter/response_test.go
+++ b/ios/imagemounter/response_test.go
@@ -2,6 +2,7 @@ package imagemounter
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/danielpaulus/go-ios/ios"
@@ -25,6 +26,15 @@ var (
 		"Error": "InternalError",
 		"DetailedError": `Error Domain=com.apple.MobileStorage.ErrorDomain Code=-2 "Failed to unmount /Developer." ` +
 			`UserInfo={NSLocalizedDescription=There is no matching entry in the device map for /Developer.}`,
+	}
+	// iOS 26.6, mounting right after boot: the personalized DDI had already
+	// auto-remounted (Developer Mode persists it across reboots) faster than
+	// ListImages() could observe it.
+	alreadyMountedReply = map[string]interface{}{
+		"Error": "ImageMountFailed",
+		"DetailedError": `Error Domain=com.apple.MobileStorage.ErrorDomain Code=-2 "Failed to mount /private/.../ltFdWi.dmg." ` +
+			`UserInfo={NSUnderlyingError=Code=-2 "Invalid value for MountPath: Error Domain=com.apple.MobileStorage.ErrorDomain Code=-3 ` +
+			`\"A disk image of type Personalized/DeveloperDiskImage is already mounted at /System/Developer.\""}`,
 	}
 )
 
@@ -111,6 +121,17 @@ func TestReadImageMounterResponse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAlreadyMounted(t *testing.T) {
+	err := readImageMounterResponse(readerFor(t, alreadyMountedReply), "udid", "MountImage", "Complete")
+	require.Error(t, err)
+	assert.True(t, alreadyMounted(err))
+
+	assert.False(t, alreadyMounted(readImageMounterResponse(readerFor(t, developerModeDisabledReply), "udid", "MountImage", "Complete")))
+	assert.False(t, alreadyMounted(readImageMounterResponse(readerFor(t, deviceLockedReply), "udid", "MountImage", "Complete")))
+	assert.False(t, alreadyMounted(nil))
+	assert.False(t, alreadyMounted(errors.New("some other error")))
 }
 
 // Devices that predate 'UnmountImage' answer with UnknownCommand. Unmounting stays best-effort


### PR DESCRIPTION
## Problem

`MountImage()` checks `ListImages()` first and skips the mount if anything is already reported mounted — but on iOS 17+, a personalized DDI auto-remounts within about a second of boot (Developer Mode persists it across reboots, unlike the older mount-once-per-session model). That's fast enough to lose the race against `ListImages()`: it can observe nothing mounted, and the device still refuses the immediately-following mount attempt as a duplicate.

Reproduced directly against a real device (iOS 26.6), including right after a full reboot:

```
ListImages() -> none
MountImage() -> ImageMountFailed: ... "A disk image of type Personalized/DeveloperDiskImage is already mounted at /System/Developer."
```

An explicit `UnmountImage()` also fails in this state (`Failed to unload launchd jobs`), confirming something is genuinely mounted despite `ListImages()` saying otherwise — this isn't a false failure to swallow blindly, it's a real detection race between two different device queries.

## Fix

Treat that specific device response the same way the existing `ListImages()` pre-check already does: log a warning and return `nil` instead of failing the whole mount. Scoped narrowly via a new `alreadyMounted(err)` helper that only matches `ImageMountFailed` errors whose detail contains "already mounted at" — any other mount failure (developer mode disabled, locked device, wrong signature, ...) still fails normally.

## Testing

- `TestAlreadyMounted` (new): matches the real device-captured "already mounted" response, and confirms other error shapes (developer-mode-disabled, device-locked, nil, generic errors) are not matched.
- `go build ./...` and `go test ./ios/imagemounter/...` pass, aside from `TestUsesProxy`/`TestWorksWithoutProxy`, which are pre-existing failures unrelated to this change — they call the mounter's `MountImage` directly (bypassing the package-level `MountImage()` wrapper this PR touches) and are dependent on whatever real device happens to be attached to the machine running them.
